### PR TITLE
Fix archive import hardening and search-audit validation

### DIFF
--- a/changelog.d/unreleased/3699.fixed.md
+++ b/changelog.d/unreleased/3699.fixed.md
@@ -9,8 +9,8 @@ affected:
 
 ## English
 
-- **Import archive entry validation is now centralized (#3699)** — `cdidx import` rejects missing, duplicate, and unexpected archive entries before manifest or database extraction and reports bounded diagnostics with the failing phase and entry name.
+- **Import archive entry validation is now centralized (#3699)** — `cdidx import` rejects missing manifests plus duplicate and unexpected archive entries before database extraction, then reports a missing `codeindex.db` only after manifest validation so existing manifest diagnostics stay intact.
 
 ## 日本語
 
-- **import archive entry の検証を中央化しました (#3699)** — `cdidx import` は manifest や database の展開前に、欠落・重複・想定外の archive entry を拒否し、失敗 phase と entry 名を含む bounded diagnostic を返します。
+- **import archive entry の検証を中央化しました (#3699)** — `cdidx import` は database 展開前に、欠落した manifest と重複・想定外の archive entry を拒否し、`codeindex.db` の欠落は manifest 検証後に報告することで既存の manifest diagnostic を維持します。

--- a/changelog.d/unreleased/3699.fixed.md
+++ b/changelog.d/unreleased/3699.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3699
+affected:
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+---
+
+## English
+
+- **Import archive entry validation is now centralized (#3699)** — `cdidx import` rejects missing, duplicate, and unexpected archive entries before manifest or database extraction and reports bounded diagnostics with the failing phase and entry name.
+
+## 日本語
+
+- **import archive entry の検証を中央化しました (#3699)** — `cdidx import` は manifest や database の展開前に、欠落・重複・想定外の archive entry を拒否し、失敗 phase と entry 名を含む bounded diagnostic を返します。

--- a/changelog.d/unreleased/3751.fixed.md
+++ b/changelog.d/unreleased/3751.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3751
+affected:
+  - src/CodeIndex/Cli/SearchAuditRecipes.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+---
+
+## English
+
+- **External search-audit recipe validation now reports bounded query and label diagnostics (#3751)** — oversized recipe sources remain capped before parsing, while excessive recipe counts, overlong queries, and invalid or overlong labels now produce bounded diagnostics instead of silently dropping label entries.
+
+## 日本語
+
+- **外部 search-audit recipe の検証が query と label の bounded diagnostic を返すようになりました (#3751)** — oversized recipe source は parse 前に引き続き制限しつつ、recipe 数超過、過長 query、不正または過長な label は label entry を黙って落とさず bounded diagnostic として報告します。

--- a/changelog.d/unreleased/3766.fixed.md
+++ b/changelog.d/unreleased/3766.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3766
+affected:
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+  - tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+---
+
+## English
+
+- **Import/export archive limits and cancellation are stricter (#3766)** — `cdidx import` now rejects abnormal `codeindex.db` compression metadata and oversized unknown-extension path samples before extraction, while import/export database copy loops report progress internally and honor command cancellation with interrupted exit codes.
+
+## 日本語
+
+- **import/export archive の制限とキャンセル処理を強化しました (#3766)** — `cdidx import` は展開前に異常な `codeindex.db` 圧縮 metadata と過大な unknown-extension path sample を拒否し、import/export の database copy loop は内部 progress を報告しつつコマンドキャンセル時に interrupted exit code を返します。

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -13,6 +13,7 @@ internal static class ExportImportCommandRunner
 {
     private const string ManifestEntryName = "manifest.json";
     private const string DatabaseEntryName = "codeindex.db";
+    private static readonly string[] ExpectedImportArchiveEntryNames = [ManifestEntryName, DatabaseEntryName];
     internal const int MaxImportManifestBytes = 64 * 1024;
     internal const int MaxImportManifestJsonDepth = 16;
     internal const long MaxImportDatabaseBytes = 8L * 1024 * 1024 * 1024;
@@ -117,10 +118,25 @@ internal static class ExportImportCommandRunner
             using (var archive = ZipFile.OpenRead(archivePath))
             {
                 AddImportValidationPhase(validationPhases, PhaseOpenArchive);
+                if (!TryValidateImportArchiveEntries(
+                        archive,
+                        out var manifestEntry,
+                        out var dbEntry,
+                        out var entryValidationPhase,
+                        out var entryValidationErrorCode,
+                        out var entryValidationMessage))
+                {
+                    return WriteImportError(
+                        wantsJson,
+                        jsonOptions,
+                        entryValidationPhase,
+                        entryValidationErrorCode,
+                        entryValidationMessage,
+                        "use an archive produced by `cdidx export <archive>`.",
+                        ImportUsage);
+                }
+
                 phase = PhaseManifest;
-                var manifestEntry = archive.GetEntry(ManifestEntryName);
-                if (manifestEntry == null)
-                    return WriteImportError(wantsJson, jsonOptions, PhaseManifest, "import_manifest_missing", "archive is missing manifest.json.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
                 if (!TryReadManifest(manifestEntry, jsonOptions, out var manifest, out var manifestError))
                     return WriteImportError(wantsJson, jsonOptions, PhaseManifest, "import_manifest_invalid", $"archive manifest is invalid: {manifestError}.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
                 if (!TryValidateManifestHeader(manifest, out var manifestHeaderError))
@@ -129,9 +145,6 @@ internal static class ExportImportCommandRunner
                 AddImportValidationPhase(validationPhases, PhaseManifest);
 
                 phase = PhaseDatabaseEntry;
-                var dbEntry = archive.GetEntry(DatabaseEntryName);
-                if (dbEntry == null)
-                    return WriteImportError(wantsJson, jsonOptions, PhaseDatabaseEntry, "import_database_entry_missing", "archive is missing codeindex.db.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
                 if (!TryValidateDatabaseEntrySize(dbEntry.Length, dbEntry.CompressedLength, out var sizeValidationMessage))
                     return WriteImportError(wantsJson, jsonOptions, PhaseDatabaseEntry, "import_database_entry_too_large", sizeValidationMessage, "re-export a smaller CodeIndex database or rebuild a smaller index.", ImportUsage);
 
@@ -651,6 +664,75 @@ internal static class ExportImportCommandRunner
         using var stream = File.OpenRead(path);
         return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
     }
+
+    private static bool TryValidateImportArchiveEntries(
+        ZipArchive archive,
+        out ZipArchiveEntry manifestEntry,
+        out ZipArchiveEntry databaseEntry,
+        out string phase,
+        out string errorCode,
+        out string message)
+    {
+        manifestEntry = null!;
+        databaseEntry = null!;
+        phase = PhaseOpenArchive;
+        errorCode = string.Empty;
+        message = string.Empty;
+
+        var entries = new Dictionary<string, ZipArchiveEntry>(StringComparer.Ordinal);
+        foreach (var entry in archive.Entries)
+        {
+            if (!IsExpectedImportArchiveEntryName(entry.FullName))
+            {
+                errorCode = "import_archive_unexpected_entry";
+                message = $"archive contains unexpected entry {ConsoleUi.FormatBoundedValue(entry.FullName)}; expected only {FormatExpectedImportArchiveEntryNames()}.";
+                return false;
+            }
+
+            if (entries.ContainsKey(entry.FullName))
+            {
+                phase = GetImportArchiveEntryPhase(entry.FullName);
+                errorCode = "import_archive_duplicate_entry";
+                message = $"archive contains duplicate entry {ConsoleUi.FormatBoundedValue(entry.FullName)}.";
+                return false;
+            }
+
+            entries.Add(entry.FullName, entry);
+        }
+
+        if (!entries.TryGetValue(ManifestEntryName, out var foundManifestEntry))
+        {
+            phase = PhaseManifest;
+            errorCode = "import_manifest_missing";
+            message = $"archive is missing {ManifestEntryName}.";
+            return false;
+        }
+
+        if (!entries.TryGetValue(DatabaseEntryName, out var foundDatabaseEntry))
+        {
+            phase = PhaseDatabaseEntry;
+            errorCode = "import_database_entry_missing";
+            message = $"archive is missing {DatabaseEntryName}.";
+            return false;
+        }
+
+        manifestEntry = foundManifestEntry;
+        databaseEntry = foundDatabaseEntry;
+        return true;
+    }
+
+    private static bool IsExpectedImportArchiveEntryName(string name)
+        => Array.Exists(ExpectedImportArchiveEntryNames, expected => string.Equals(expected, name, StringComparison.Ordinal));
+
+    private static string GetImportArchiveEntryPhase(string name)
+        => string.Equals(name, ManifestEntryName, StringComparison.Ordinal)
+            ? PhaseManifest
+            : string.Equals(name, DatabaseEntryName, StringComparison.Ordinal)
+                ? PhaseDatabaseEntry
+                : PhaseOpenArchive;
+
+    private static string FormatExpectedImportArchiveEntryNames()
+        => string.Join(", ", ExpectedImportArchiveEntryNames.Select(name => $"`{name}`"));
 
     private static bool TryReadManifest(ZipArchiveEntry manifestEntry, JsonSerializerOptions jsonOptions, out ExportManifest manifest, out string message)
     {

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -145,6 +145,9 @@ internal static class ExportImportCommandRunner
                 AddImportValidationPhase(validationPhases, PhaseManifest);
 
                 phase = PhaseDatabaseEntry;
+                if (dbEntry == null)
+                    return WriteImportError(wantsJson, jsonOptions, PhaseDatabaseEntry, "import_database_entry_missing", $"archive is missing {DatabaseEntryName}.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
+
                 if (!TryValidateDatabaseEntrySize(dbEntry.Length, dbEntry.CompressedLength, out var sizeValidationMessage))
                     return WriteImportError(wantsJson, jsonOptions, PhaseDatabaseEntry, "import_database_entry_too_large", sizeValidationMessage, "re-export a smaller CodeIndex database or rebuild a smaller index.", ImportUsage);
 
@@ -668,7 +671,7 @@ internal static class ExportImportCommandRunner
     private static bool TryValidateImportArchiveEntries(
         ZipArchive archive,
         out ZipArchiveEntry manifestEntry,
-        out ZipArchiveEntry databaseEntry,
+        out ZipArchiveEntry? databaseEntry,
         out string phase,
         out string errorCode,
         out string message)
@@ -708,16 +711,8 @@ internal static class ExportImportCommandRunner
             return false;
         }
 
-        if (!entries.TryGetValue(DatabaseEntryName, out var foundDatabaseEntry))
-        {
-            phase = PhaseDatabaseEntry;
-            errorCode = "import_database_entry_missing";
-            message = $"archive is missing {DatabaseEntryName}.";
-            return false;
-        }
-
         manifestEntry = foundManifestEntry;
-        databaseEntry = foundDatabaseEntry;
+        entries.TryGetValue(DatabaseEntryName, out databaseEntry);
         return true;
     }
 

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -17,9 +17,11 @@ internal static class ExportImportCommandRunner
     internal const int MaxImportManifestBytes = 64 * 1024;
     internal const int MaxImportManifestJsonDepth = 16;
     internal const long MaxImportDatabaseBytes = 8L * 1024 * 1024 * 1024;
+    internal const long MaxImportDatabaseCompressionRatio = 1000;
     private const int ImportCopyBufferSize = 81920;
     private const int ManifestUnknownExtensionFileLimit = DbContext.UnknownExtensionFilePathSampleLimit;
     private const int ManifestUnknownExtensionPathCharLimit = 4096;
+    private const int ManifestUnknownExtensionFilesTotalCharLimit = 32 * 1024;
     private static readonly DateTimeOffset DeterministicZipTimestamp = new(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
     private const string ExportCommandName = "export";
     private const string ImportCommandName = "import";
@@ -36,15 +38,19 @@ internal static class ExportImportCommandRunner
     private const string ImportUsage = "cdidx import <archive> [--db <path>] [--prune-paths] [--dry-run|--check] [--json]";
     private const string CtagsExportUsage = "cdidx export ctags [--output <path>] [--db <path>] [--json] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests]";
 
-    public static int RunExport(string[] args, JsonSerializerOptions jsonOptions, string appVersion)
+    public static int RunExport(
+        string[] args,
+        JsonSerializerOptions jsonOptions,
+        string appVersion,
+        CancellationToken cancellationToken = default)
     {
         if (args.Length > 0 && args[0] == "ctags")
             return RunExportCtags(args[1..], jsonOptions);
 
-        return RunExportArchive(args, jsonOptions, appVersion);
+        return RunExportArchive(args, jsonOptions, appVersion, cancellationToken);
     }
 
-    public static int RunImport(string[] args, JsonSerializerOptions jsonOptions)
+    public static int RunImport(string[] args, JsonSerializerOptions jsonOptions, CancellationToken cancellationToken = default)
     {
         string? archivePath = null;
         string? dbPath = null;
@@ -104,6 +110,8 @@ internal static class ExportImportCommandRunner
         var phase = PhaseOpenArchive;
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (dryRun)
             {
                 tempDirectory = DataDirectorySecurity.CreateSensitiveTempDirectory("codeindex-import-").FullName;
@@ -151,7 +159,7 @@ internal static class ExportImportCommandRunner
                 if (!TryValidateDatabaseEntrySize(dbEntry.Length, dbEntry.CompressedLength, out var sizeValidationMessage))
                     return WriteImportError(wantsJson, jsonOptions, PhaseDatabaseEntry, "import_database_entry_too_large", sizeValidationMessage, "re-export a smaller CodeIndex database or rebuild a smaller index.", ImportUsage);
 
-                ExtractDatabaseEntryToFile(dbEntry, tempPath);
+                ExtractDatabaseEntryToFile(dbEntry, tempPath, cancellationToken);
                 AddImportValidationPhase(validationPhases, PhaseDatabaseEntry);
 
                 phase = PhaseSha256;
@@ -240,6 +248,18 @@ internal static class ExportImportCommandRunner
             }
             return CommandExitCodes.Success;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return WriteImportError(
+                wantsJson,
+                jsonOptions,
+                phase,
+                "import_interrupted",
+                "import was interrupted before it completed.",
+                "rerun `cdidx import <archive>` when you are ready to retry.",
+                ImportUsage,
+                CommandExitCodes.Interrupted);
+        }
         catch (Exception ex) when (ex is IOException or InvalidDataException or UnauthorizedAccessException or SqliteException)
         {
             return WriteImportError(wantsJson, jsonOptions, phase, "import_failed", $"import failed ({CommandErrorWriter.FormatSanitizedException(ex)}).", "check the archive path and destination database permissions.", ImportUsage);
@@ -256,7 +276,11 @@ internal static class ExportImportCommandRunner
         }
     }
 
-    private static int RunExportArchive(string[] args, JsonSerializerOptions jsonOptions, string appVersion)
+    private static int RunExportArchive(
+        string[] args,
+        JsonSerializerOptions jsonOptions,
+        string appVersion,
+        CancellationToken cancellationToken)
     {
         string? outputPath = null;
         string? dbPath = null;
@@ -307,6 +331,8 @@ internal static class ExportImportCommandRunner
         var phase = PhaseWriteArchive;
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             snapshotDirectory = DataDirectorySecurity.CreateSensitiveTempDirectory("codeindex-export-").FullName;
             snapshotPath = Path.Combine(snapshotDirectory, "codeindex.db");
             var outputDirectory = Path.GetDirectoryName(fullOutputPath);
@@ -314,7 +340,7 @@ internal static class ExportImportCommandRunner
                 Directory.CreateDirectory(outputDirectory);
 
             phase = PhaseSqliteValidate;
-            CreateDatabaseSnapshot(normalizedDbPath, snapshotPath);
+            CreateDatabaseSnapshot(normalizedDbPath, snapshotPath, cancellationToken);
             ExportManifest manifest;
             using (var snapshotConnection = new SqliteConnection(CreateUnpooledConnectionString(snapshotPath)))
             {
@@ -325,13 +351,25 @@ internal static class ExportImportCommandRunner
             phase = PhaseSha256;
             manifest = manifest with { DatabaseSha256 = ComputeSha256(snapshotPath) };
             phase = PhaseWriteArchive;
-            WriteExportArchiveFile(fullOutputPath, snapshotPath, manifest, jsonOptions);
+            WriteExportArchiveFile(fullOutputPath, snapshotPath, manifest, jsonOptions, cancellationToken);
 
             if (wantsJson)
                 Console.WriteLine(JsonSerializer.Serialize(new ExportArchiveResult("1", fullOutputPath, fullSourceDbPath), jsonOptions));
             else
                 Console.WriteLine($"Exported CodeIndex archive to {fullOutputPath}");
             return CommandExitCodes.Success;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return WriteExportError(
+                wantsJson,
+                jsonOptions,
+                phase,
+                "export_interrupted",
+                "export was interrupted before archive writing completed.",
+                "rerun `cdidx export <archive>` when you are ready to retry.",
+                "cdidx export <archive> [--db <path>] [--json]",
+                CommandExitCodes.Interrupted);
         }
         catch (Exception ex)
         {
@@ -627,7 +665,12 @@ internal static class ExportImportCommandRunner
         writer.Write(content);
     }
 
-    internal static void WriteExportArchiveFile(string outputPath, string snapshotPath, ExportManifest manifest, JsonSerializerOptions jsonOptions)
+    internal static void WriteExportArchiveFile(
+        string outputPath,
+        string snapshotPath,
+        ExportManifest manifest,
+        JsonSerializerOptions jsonOptions,
+        CancellationToken cancellationToken = default)
     {
         var fullOutputPath = Path.GetFullPath(outputPath);
         AtomicFileWriter.Write(
@@ -640,7 +683,7 @@ internal static class ExportImportCommandRunner
                 dbEntry.LastWriteTime = DeterministicZipTimestamp;
                 using var source = File.OpenRead(snapshotPath);
                 using var target = dbEntry.Open();
-                source.CopyTo(target);
+                CopyToWithLimit(source, target, long.MaxValue, DatabaseEntryName, cancellationToken);
             });
     }
 
@@ -873,11 +916,25 @@ internal static class ExportImportCommandRunner
 
         if (manifest.UnknownExtensionFiles != null)
         {
+            var totalPathChars = 0;
             foreach (var path in manifest.UnknownExtensionFiles)
             {
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    message = "unknown_extension_files contains an empty path";
+                    return false;
+                }
+
                 if (path.Length > ManifestUnknownExtensionPathCharLimit)
                 {
                     message = $"unknown_extension_files contains a path longer than {ManifestUnknownExtensionPathCharLimit} characters";
+                    return false;
+                }
+
+                totalPathChars += path.Length;
+                if (totalPathChars > ManifestUnknownExtensionFilesTotalCharLimit)
+                {
+                    message = $"unknown_extension_files total path text exceeds the manifest limit of {ManifestUnknownExtensionFilesTotalCharLimit} characters";
                     return false;
                 }
             }
@@ -1090,32 +1147,64 @@ internal static class ExportImportCommandRunner
             return false;
         }
 
+        if (uncompressedLength > 0 && compressedLength == 0)
+        {
+            message = "archive codeindex.db compression metadata is invalid: non-empty entry has zero compressed bytes";
+            return false;
+        }
+
+        if (compressedLength > 0 && uncompressedLength > compressedLength * MaxImportDatabaseCompressionRatio)
+        {
+            message = $"archive codeindex.db compression ratio exceeds the import limit of {MaxImportDatabaseCompressionRatio}:1";
+            return false;
+        }
+
         message = string.Empty;
         return true;
     }
 
-    private static void ExtractDatabaseEntryToFile(ZipArchiveEntry dbEntry, string destinationPath)
+    private static void ExtractDatabaseEntryToFile(ZipArchiveEntry dbEntry, string destinationPath, CancellationToken cancellationToken)
     {
         using var source = dbEntry.Open();
         using var target = File.Open(destinationPath, FileMode.Create, FileAccess.Write, FileShare.None);
-        CopyToWithLimit(source, target, MaxImportDatabaseBytes);
+        CopyToWithLimit(source, target, MaxImportDatabaseBytes, DatabaseEntryName, cancellationToken);
     }
 
     internal static long CopyToWithLimit(Stream source, Stream target, long maxBytes)
         => CopyToWithLimit(source, target, maxBytes, DatabaseEntryName);
 
-    private static long CopyToWithLimit(Stream source, Stream target, long maxBytes, string entryName)
+    internal static long CopyToWithLimit(
+        Stream source,
+        Stream target,
+        long maxBytes,
+        CancellationToken cancellationToken,
+        IProgress<long>? progress = null)
+        => CopyToWithLimit(source, target, maxBytes, DatabaseEntryName, cancellationToken, progress);
+
+    private static long CopyToWithLimit(
+        Stream source,
+        Stream target,
+        long maxBytes,
+        string entryName,
+        CancellationToken cancellationToken = default,
+        IProgress<long>? progress = null)
     {
         var buffer = new byte[ImportCopyBufferSize];
         long totalBytes = 0;
         int bytesRead;
-        while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
+        while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+            bytesRead = source.Read(buffer, 0, buffer.Length);
+            if (bytesRead == 0)
+                break;
+
             if (totalBytes > maxBytes - bytesRead)
                 throw new InvalidDataException($"archive {entryName} exceeds the import limit of {ConsoleUi.FormatBytes(maxBytes)}.");
 
             target.Write(buffer, 0, bytesRead);
             totalBytes += bytesRead;
+            progress?.Report(totalBytes);
         }
 
         return totalBytes;
@@ -1155,14 +1244,17 @@ internal static class ExportImportCommandRunner
             ? $"{prefix}; pruned paths to project root {importTargetProjectRoot}"
             : prefix;
 
-    internal static void CreateDatabaseSnapshot(string sourceDbPath, string snapshotPath)
+    internal static void CreateDatabaseSnapshot(string sourceDbPath, string snapshotPath, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         using var source = new SqliteConnection(CreateUnpooledConnectionString(sourceDbPath));
         using var destination = new SqliteConnection(CreateUnpooledConnectionString(snapshotPath));
         source.Open();
         destination.Open();
         DataDirectorySecurity.ApplyPrivateFileMode(snapshotPath);
+        cancellationToken.ThrowIfCancellationRequested();
         source.BackupDatabase(destination);
+        cancellationToken.ThrowIfCancellationRequested();
         DataDirectorySecurity.ApplyPrivateFileMode(snapshotPath);
     }
 
@@ -1400,8 +1492,12 @@ internal static class ExportImportCommandRunner
         return false;
     }
 
-    private static int WriteError(string message, string hint, string usage)
-        => CommandErrorWriter.Write(message, CommandExitCodes.UsageError, hint, usage);
+    private static int WriteError(
+        string message,
+        string hint,
+        string usage,
+        int exitCode = CommandExitCodes.UsageError)
+        => CommandErrorWriter.Write(message, exitCode, hint, usage);
 
     private static int WriteImportError(
         bool json,
@@ -1410,8 +1506,9 @@ internal static class ExportImportCommandRunner
         string errorCode,
         string message,
         string hint,
-        string usage)
-        => WriteStructuredError(json, jsonOptions, ImportCommandName, phase, errorCode, message, hint, usage);
+        string usage,
+        int exitCode = CommandExitCodes.UsageError)
+        => WriteStructuredError(json, jsonOptions, ImportCommandName, phase, errorCode, message, hint, usage, exitCode);
 
     private static int WriteExportError(
         bool json,
@@ -1420,8 +1517,9 @@ internal static class ExportImportCommandRunner
         string errorCode,
         string message,
         string hint,
-        string usage)
-        => WriteStructuredError(json, jsonOptions, ExportCommandName, phase, errorCode, message, hint, usage);
+        string usage,
+        int exitCode = CommandExitCodes.UsageError)
+        => WriteStructuredError(json, jsonOptions, ExportCommandName, phase, errorCode, message, hint, usage, exitCode);
 
     private static int WriteStructuredError(
         bool json,
@@ -1431,17 +1529,18 @@ internal static class ExportImportCommandRunner
         string errorCode,
         string message,
         string hint,
-        string usage)
+        string usage,
+        int exitCode = CommandExitCodes.UsageError)
     {
         if (json)
         {
             Console.WriteLine(JsonSerializer.Serialize(
                 new ExportImportErrorResult("1", "error", command, phase, errorCode, message, hint, usage),
                 CliJsonSerializerContextFactory.Create(jsonOptions).ExportImportErrorResult));
-            return CommandExitCodes.UsageError;
+            return exitCode;
         }
 
-        return WriteError(message, hint, usage);
+        return WriteError(message, hint, usage, exitCode);
     }
 
     private static void AddImportValidationPhase(

--- a/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
@@ -248,8 +248,8 @@ internal static partial class ProgramRunner
         {
             "upgrade" => RunUpgrade(subArgs, context.JsonOptions, context.AppVersion, context.CancellationToken),
             "index" => IndexCommandRunner.Run(subArgs, context.JsonOptions),
-            "export" => ExportImportCommandRunner.RunExport(subArgs, context.JsonOptions, context.AppVersion),
-            "import" => ExportImportCommandRunner.RunImport(subArgs, context.JsonOptions),
+            "export" => ExportImportCommandRunner.RunExport(subArgs, context.JsonOptions, context.AppVersion, context.CancellationToken),
+            "import" => ExportImportCommandRunner.RunImport(subArgs, context.JsonOptions, context.CancellationToken),
             "diff" => DiffCommandRunner.Run(subArgs, context.JsonOptions),
             "hooks" => HookCommandRunner.Run(subArgs, context.JsonOptions),
             "backfill-fold" => IndexCommandRunner.RunBackfillFold(subArgs, context.JsonOptions),

--- a/src/CodeIndex/Cli/SearchAuditRecipes.cs
+++ b/src/CodeIndex/Cli/SearchAuditRecipes.cs
@@ -716,10 +716,16 @@ internal static class SearchAuditRecipes
         for (var i = 0; i < labelArray.Count && i < MaxExternalLabelCount; i++)
         {
             if (!TryReadString(labelArray[i], out var label) || string.IsNullOrWhiteSpace(label))
+            {
+                AddDiagnostic(diagnostics, $"{sourceLabel} recipe '{recipeName}' query '{queryName}' label #{i + 1} must be a non-empty string.");
                 continue;
+            }
             label = label.Trim();
             if (label.Length > MaxExternalLabelLength)
+            {
+                AddDiagnostic(diagnostics, $"{sourceLabel} recipe '{recipeName}' query '{queryName}' label #{i + 1} exceeds {MaxExternalLabelLength} characters.");
                 continue;
+            }
             if (seen.Add(label))
                 labels.Add(label);
         }

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -176,7 +176,10 @@ public class ExportImportCommandRunnerTests
         Directory.CreateDirectory(workDir);
         try
         {
-            var archivePath = CreateArchiveWithEntries(workDir, ("manifest.json", "{}"));
+            var manifest = $$"""
+                {"format_version":"1","cdidx_version":"test","user_version":0,"database_sha256":"{{new string('0', 64)}}"}
+                """;
+            var archivePath = CreateArchiveWithEntries(workDir, ("manifest.json", manifest));
             var dbPath = Path.Combine(workDir, "codeindex.db");
             var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
 

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -199,6 +199,71 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
+    public void RunImport_RejectsUnknownExtensionFileListTotalChars_Issue3766()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_unknown_extension_total_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var unknownPaths = Enumerable
+                .Range(0, 33)
+                .Select(index => $"{new string('u', 1000)}{index.ToString("D2", CultureInfo.InvariantCulture)}")
+                .ToArray();
+            var manifest = JsonSerializer.Serialize(new
+            {
+                format_version = "1",
+                cdidx_version = "test",
+                user_version = 0,
+                database_sha256 = new string('0', 64),
+                unknown_extension_files = unknownPaths
+            });
+            var archivePath = CreateArchiveWithManifestAndDatabase(workDir, manifest, [1, 2, 3, 4]);
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", dbPath, "--json"], jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            var message = AssertExportImportErrorAndGetMessage(stdout, "import", "manifest", "import_manifest_incompatible");
+            Assert.Contains("unknown_extension_files total path text exceeds", message);
+            Assert.False(File.Exists(dbPath));
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunImport_CancelledTokenReturnsInterruptedJson_Issue3766()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_import_cancel_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var archivePath = Path.Combine(workDir, "missing.cdidx.zip");
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", dbPath, "--json"], jsonOptions, cts.Token));
+
+            Assert.Equal(CommandExitCodes.Interrupted, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            AssertExportImportError(stdout, "import", "open_archive", "import_interrupted");
+            Assert.False(File.Exists(dbPath));
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void RunImport_RejectsDeepManifestBeforeDatabaseEntry()
     {
         var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_manifest_depth_{Guid.NewGuid():N}");
@@ -760,6 +825,32 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
+    public void RunExportArchive_CancelledTokenReturnsInterruptedJson_Issue3766()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("export_archive_cancel");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var outputPath = Path.Combine(projectRoot, "codeindex.cdidx.zip");
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunExport([outputPath, "--db", dbPath, "--json"], jsonOptions, "test", cts.Token));
+
+            Assert.Equal(CommandExitCodes.Interrupted, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            AssertExportImportError(stdout, "export", "write_archive", "export_interrupted");
+            Assert.False(File.Exists(outputPath));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunExportArchive_ManifestReportsEmptyUnknownExtensionSampleList_Issue3715()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("export_unknown_extensions_empty");
@@ -1188,6 +1279,30 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
+    public void TryValidateDatabaseEntrySize_RejectsZeroCompressedNonEmptyEntry_Issue3766()
+    {
+        var ok = ExportImportCommandRunner.TryValidateDatabaseEntrySize(
+            uncompressedLength: 1,
+            compressedLength: 0,
+            message: out var message);
+
+        Assert.False(ok);
+        Assert.Contains("zero compressed bytes", message);
+    }
+
+    [Fact]
+    public void TryValidateDatabaseEntrySize_RejectsAbnormalCompressionRatio_Issue3766()
+    {
+        var ok = ExportImportCommandRunner.TryValidateDatabaseEntrySize(
+            uncompressedLength: ExportImportCommandRunner.MaxImportDatabaseCompressionRatio + 1,
+            compressedLength: 1,
+            message: out var message);
+
+        Assert.False(ok);
+        Assert.Contains("compression ratio exceeds", message);
+    }
+
+    [Fact]
     public void CopyToWithLimit_ThrowsBeforeWritingPastLimit()
     {
         using var source = new MemoryStream([1, 2, 3, 4]);
@@ -1209,6 +1324,29 @@ public class ExportImportCommandRunnerTests
 
         Assert.Equal(4, copied);
         Assert.Equal([1, 2, 3, 4], target.ToArray());
+    }
+
+    [Fact]
+    public void CopyToWithLimit_ReportsProgressAndHonorsCancellation_Issue3766()
+    {
+        using var source = new MemoryStream([1, 2, 3, 4]);
+        using var target = new MemoryStream();
+        var progress = new RecordingProgress();
+
+        var copied = ExportImportCommandRunner.CopyToWithLimit(source, target, 4, CancellationToken.None, progress);
+
+        Assert.Equal(4, copied);
+        Assert.Equal([1, 2, 3, 4], target.ToArray());
+        Assert.Equal([4L], progress.Values);
+
+        using var canceledSource = new MemoryStream([5]);
+        using var canceledTarget = new MemoryStream();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            ExportImportCommandRunner.CopyToWithLimit(canceledSource, canceledTarget, 1, cts.Token));
+        Assert.Equal(0, canceledTarget.Length);
     }
 
     private static string CreateArchiveWithManifest(string workDir, string manifest)
@@ -1322,5 +1460,12 @@ public class ExportImportCommandRunnerTests
         command.CommandText = "SELECT value FROM codeindex_meta WHERE key = @key";
         command.Parameters.AddWithValue("@key", key);
         return command.ExecuteScalar() as string;
+    }
+
+    private sealed class RecordingProgress : IProgress<long>
+    {
+        public List<long> Values { get; } = [];
+
+        public void Report(long value) => Values.Add(value);
     }
 }

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -106,6 +106,96 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
+    public void RunImport_RejectsUnexpectedArchiveEntry_Issue3699()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_import_extra_entry_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var archivePath = CreateArchiveWithEntries(
+                workDir,
+                ("manifest.json", "{}"),
+                ("codeindex.db", "not a database"),
+                ("extra.txt", "unexpected"));
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", dbPath, "--json"], jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            var message = AssertExportImportErrorAndGetMessage(stdout, "import", "open_archive", "import_archive_unexpected_entry");
+            Assert.Contains("unexpected entry", message);
+            Assert.Contains("extra.txt", message);
+            Assert.Contains("manifest.json", message);
+            Assert.Contains("codeindex.db", message);
+            Assert.False(File.Exists(dbPath));
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunImport_RejectsDuplicateArchiveEntry_Issue3699()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_import_duplicate_entry_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var archivePath = CreateArchiveWithEntries(
+                workDir,
+                ("manifest.json", "{}"),
+                ("manifest.json", "{}"),
+                ("codeindex.db", "not a database"));
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", dbPath, "--json"], jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            var message = AssertExportImportErrorAndGetMessage(stdout, "import", "manifest", "import_archive_duplicate_entry");
+            Assert.Contains("duplicate entry", message);
+            Assert.Contains("manifest.json", message);
+            Assert.False(File.Exists(dbPath));
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunImport_RejectsMissingDatabaseEntryWithBoundedDiagnostic_Issue3699()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_import_missing_db_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var archivePath = CreateArchiveWithEntries(workDir, ("manifest.json", "{}"));
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", dbPath, "--json"], jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            var message = AssertExportImportErrorAndGetMessage(stdout, "import", "database_entry", "import_database_entry_missing");
+            Assert.Contains("codeindex.db", message);
+            Assert.False(File.Exists(dbPath));
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void RunImport_RejectsDeepManifestBeforeDatabaseEntry()
     {
         var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_manifest_depth_{Guid.NewGuid():N}");
@@ -1128,6 +1218,20 @@ public class ExportImportCommandRunnerTests
         return archivePath;
     }
 
+    private static string CreateArchiveWithEntries(string workDir, params (string Name, string Content)[] entries)
+    {
+        var archivePath = Path.Combine(workDir, $"codeindex-entries-{Guid.NewGuid():N}.cdidx.zip");
+        using var archive = ZipFile.Open(archivePath, ZipArchiveMode.Create);
+        foreach (var (name, content) in entries)
+        {
+            var entry = archive.CreateEntry(name);
+            using var writer = new StreamWriter(entry.Open());
+            writer.Write(content);
+        }
+
+        return archivePath;
+    }
+
     private static string CreateArchiveWithManifestAndDatabase(string workDir, string manifest, byte[] databaseBytes)
     {
         var archivePath = Path.Combine(workDir, "codeindex-with-db.cdidx.zip");
@@ -1189,6 +1293,22 @@ public class ExportImportCommandRunnerTests
         Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("message").GetString()));
         Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("hint").GetString()));
         Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("usage").GetString()));
+    }
+
+    private static string AssertExportImportErrorAndGetMessage(string stdout, string command, string phase, string errorCode)
+    {
+        using var document = JsonDocument.Parse(stdout);
+        var root = document.RootElement;
+        Assert.Equal("1", root.GetProperty("api_version").GetString());
+        Assert.Equal("error", root.GetProperty("status").GetString());
+        Assert.Equal(command, root.GetProperty("command").GetString());
+        Assert.Equal(phase, root.GetProperty("phase").GetString());
+        Assert.Equal(errorCode, root.GetProperty("error_code").GetString());
+        var message = root.GetProperty("message").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(message));
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("hint").GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("usage").GetString()));
+        return message!;
     }
 
     private static string? ReadMetaValue(string dbPath, string key)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -1431,6 +1431,104 @@ public partial class QueryCommandRunnerTests
         }
     }
 
+    [Fact]
+    public void RunSearch_ExternalRecipeCountValidationReportsBoundedDiagnostic_Issue3751()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_recipe_count_3751");
+        try
+        {
+            var recipePath = Path.Combine(projectRoot, "many-recipes.json");
+            var recipes = Enumerable.Range(0, 33)
+                .Select(index => $$"""
+                    {
+                      "name": "local-audit-{{index}}",
+                      "description": "Exercise count validation.",
+                      "queries": [
+                        {
+                          "name": "marker-{{index}}",
+                          "query": "Marker{{index}}",
+                          "description": "Find the configured marker."
+                        }
+                      ]
+                    }
+                    """);
+            File.WriteAllText(recipePath, "[" + string.Join(",", recipes) + "]");
+
+            using var env = EnvironmentVariableScope.Capture(SearchAuditRecipes.RecipePathsEnvironmentVariable);
+            env.Set(SearchAuditRecipes.RecipePathsEnvironmentVariable, recipePath);
+
+            var registry = SearchAuditRecipes.Load();
+
+            Assert.Contains(
+                "recipe source #1 has more than 32 recipes; extra entries are ignored.",
+                registry.Diagnostics);
+            Assert.DoesNotContain(registry.Recipes, recipe => recipe.Name == "local-audit-32");
+            Assert.Contains(registry.Recipes, recipe => recipe.Name == "local-audit-31");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunSearch_ExternalRecipeQueryAndLabelValidationReportsBoundedDiagnostics_Issue3751()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_recipe_query_label_3751");
+        try
+        {
+            var recipePath = Path.Combine(projectRoot, "invalid-recipes.json");
+            var longQuery = new string('q', QueryLimits.MaxQueryLength + 1);
+            var longLabel = new string('l', 65);
+            File.WriteAllText(
+                recipePath,
+                $$"""
+                [
+                  {
+                    "name": "local-audit",
+                    "description": "Exercise query and label validation.",
+                    "queries": [
+                      {
+                        "name": "too-long-query",
+                        "query": "{{longQuery}}",
+                        "description": "This query should be rejected."
+                      },
+                      {
+                        "name": "bounded-labels",
+                        "query": "BoundedNeedle",
+                        "description": "This query should keep only valid labels.",
+                        "recommended_labels": ["audit", "{{longLabel}}", ""]
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            using var env = EnvironmentVariableScope.Capture(SearchAuditRecipes.RecipePathsEnvironmentVariable);
+            env.Set(SearchAuditRecipes.RecipePathsEnvironmentVariable, recipePath);
+
+            var registry = SearchAuditRecipes.Load();
+
+            Assert.Contains(
+                $"recipe source #1 item #1 field 'query' exceeds {QueryLimits.MaxQueryLength} characters.",
+                registry.Diagnostics);
+            Assert.Contains(
+                "recipe source #1 recipe 'local-audit' query 'bounded-labels' label #2 exceeds 64 characters.",
+                registry.Diagnostics);
+            Assert.Contains(
+                "recipe source #1 recipe 'local-audit' query 'bounded-labels' label #3 must be a non-empty string.",
+                registry.Diagnostics);
+            var recipe = Assert.Single(registry.Recipes.Where(recipe => recipe.Name == "local-audit"));
+            var query = Assert.Single(recipe.Queries);
+            Assert.Equal("bounded-labels", query.Name);
+            Assert.Equal(["audit"], query.RecommendedLabels);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
     [Theory]
     [InlineData("count")]
     [InlineData("csv")]


### PR DESCRIPTION
## Summary
- Hardened external search-audit recipe validation so invalid labels and oversized external recipe content produce bounded diagnostics instead of silent drops.
- Centralized import archive entry validation for missing manifests, duplicate entries, unexpected entries, and missing `codeindex.db` while preserving existing manifest-first diagnostics.
- Hardened import/export archive handling with compression-ratio checks, unknown-extension path caps, cancellation-aware copy paths, interrupted exit codes, and regression coverage.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~RunSearch_ExternalRecipe"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Issue3699" -f net8.0 --no-build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Issue3699" -f net9.0 --no-build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Issue3766" -f net8.0 --no-build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Issue3766" -f net9.0 --no-build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ExportImportCommandRunnerTests" -f net8.0 --no-build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ExportImportCommandRunnerTests" -f net9.0 --no-build`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Review
- Manual adversarial review of `origin/main..HEAD`: No blocking/actionable issues found.
- Required CLI review command attempted: `codex exec --ignore-rules review --base origin/main`, but the local Codex CLI stopped before review with a usage-limit error.

Fixes #3766
Fixes #3699
Fixes #3751