### PR TITLE
Fix MCP response budgeting and HTTP transport bounds

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1265,6 +1265,7 @@ Process exit codes are coarse (`0` success including valid zero-row queries, `1`
 - **MCP rate limiter bucket eviction** — `RateLimiter` keeps `(tool, caller)` token buckets only while they are active. `CDIDX_MCP_RATE_LIMIT_BUCKET_IDLE_SECONDS` defaults to 900 seconds; stale buckets are pruned on later acquisitions so shared or HTTP MCP deployments do not retain historical caller identities for the process lifetime (#2824).
 - **MCP envelope response cap** — `CDIDX_MCP_RESPONSE_MAX_BYTES` defaults to 10 MiB and clamps at 64 MiB. Invalid values fall back to the default; values above the cap are clamped with a stderr warning so operators cannot accidentally disable the JSON-RPC response guard.
 - **MCP `batch_query` response cap** — `batch_query` estimates the UTF-8 JSON size of aggregate slot results and stops appending once the response would exceed `CDIDX_MCP_BATCH_RESPONSE_MAX_BYTES` (default: 1 MiB / 1,048,576 bytes; maximum: 10 MiB). Truncated responses include `truncated: true`, `truncated_queries`, and byte-limit metadata so clients can split the batch or lower per-slot limits without parsing prose (#1416). Invalid values fall back to the default, values above the maximum are clamped with a stderr warning, and MCP `status` exposes the effective value under `mcp.limits.batch_response_bytes`.
+- **HTTP MCP response and stream caps** — `HttpMcpTransport` caps ordinary JSON response bodies with `CDIDX_MCP_HTTP_MAX_RESPONSE_BYTES` (default: 1,000,000 bytes; maximum: 16,777,216 bytes). Oversized JSON-RPC responses return HTTP 500 with a bounded text diagnostic instead of streaming the payload, while request-loop diagnostics record `request_body_length_unknown` for unknown-length request bodies and `request_body_limit_exceeded` for bodies that cross the request cap. SSE stream writes keep the existing bounded queue and apply write timeouts so disconnected or slow clients do not pin writer work indefinitely.
 - **MCP pagination offset cap** — `references`, `callers`, and `callees` clamp `offset` to 10,000 before executing SQL queries. `tools/list` advertises the maximum in each offset schema, and MCP `status` mirrors it under `mcp.limits.max_pagination_offset`.
 - **MCP array argument bounds** — MCP string-array filters such as `path`, `project`, `excludePaths`, and mixed `names` arrays reject invalid entries instead of silently dropping them. Arrays are capped at 100 entries and each entry is capped at 4096 characters; `batch_query` reports these validation failures per slot with `request_index` and `ok: false`.
 - **MCP schema lock-down** — Every tool `inputSchema` includes `additionalProperties: false`, and `tools/call` mirrors that contract by rejecting unknown argument names with `-32602` / `invalid_argument` instead of silently defaulting misspelled fields.
@@ -2774,6 +2775,16 @@ MCP JSON-RPC `ping` method は `status`、`uptime_s`、`last_request_at`、`db_o
 HTTP MCP `/events` stream は opt-in の server-initiated `notifications/keep_alive` JSON-RPC notification を出せる。`CDIDX_MCP_KEEP_ALIVE_INTERVAL_S` に `1` から `300` 秒の finite value を設定すると有効化される。未設定、non-finite、範囲外の値は既定の off behavior を維持し、warning を出す。stdio session は parent process が transport の liveness を所有するため、既定では keep-alive notification を出さない。
 
 各 keep-alive notification は `params` に `server_time` と `uptime_s` を含める。notification は best-effort であり、切断済み SSE client は stream registry から削除され、keep-alive write failure が MCP server を終了させてはならない。
+
+### MCP HTTP トランスポートの上限
+
+`HttpMcpTransport` は通常の JSON response body を `CDIDX_MCP_HTTP_MAX_RESPONSE_BYTES`
+で制限します。既定値は 1,000,000 bytes、最大値は 16,777,216 bytes です。上限を超える
+JSON-RPC response は payload を stream せず、bounded な text diagnostic を持つ HTTP 500
+として返します。request-loop diagnostics は、長さ不明の request body を
+`request_body_length_unknown`、request body 上限超過を `request_body_limit_exceeded`
+として記録します。SSE stream write は既存の bounded queue を維持し、write timeout も適用して、
+切断済みまたは低速な client が writer work を無期限に保持しないようにします。
 
 ## データベーススキーマ
 

--- a/changelog.d/unreleased/3722.fixed.md
+++ b/changelog.d/unreleased/3722.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3722
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP isolated request timeouts now enforce cleanup around background work (#3722)** — timed-out isolated actions report draining state, keep bounded cleanup alive after the timeout, and remove active request state once the background task exits.
+
+## 日本語
+
+- **MCP isolated request timeout が background work 周辺の cleanup を確実にするようになりました (#3722)** — timeout した isolated action は draining 状態を報告し、timeout 後も bounded cleanup を継続して、background task 終了後に active request state を削除します。

--- a/changelog.d/unreleased/3755.fixed.md
+++ b/changelog.d/unreleased/3755.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3755
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Mcp/HttpMcpTransport.cs
+  - tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **HTTP MCP now caps response bodies and records bounded request diagnostics (#3755)** — oversized JSON responses return a bounded HTTP 500 diagnostic, SSE writes use timeouts, and request logs distinguish unknown-length and over-limit request bodies.
+
+## 日本語
+
+- **HTTP MCP が response body 上限と bounded な request diagnostic を持つようになりました (#3755)** — 過大な JSON response は bounded な HTTP 500 diagnostic を返し、SSE write に timeout を適用し、request log で長さ不明と上限超過の request body を区別します。

--- a/changelog.d/unreleased/3770.fixed.md
+++ b/changelog.d/unreleased/3770.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3770
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP frame callers can avoid sync-over-async entrypoints (#3770)** — async frame and message entrypoints are covered by regression tests, while the sync wrappers remain documented as compatibility-only paths for legacy in-process callers.
+
+## 日本語
+
+- **MCP frame caller が sync-over-async entrypoint を避けられるようになりました (#3770)** — async frame/message entrypoint を regression test で覆い、sync wrapper は legacy in-process caller 向けの互換 path としてのみ残すことを明記しました。

--- a/changelog.d/unreleased/3774.fixed.md
+++ b/changelog.d/unreleased/3774.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3774
+affected:
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP request dispatch keeps shutdown thread-pool exposure bounded (#3774)** — request-loop dispatch documents the concurrency gate and keeps late cleanup observers uncancelled so shutdown can drain bounded work without leaking slots.
+
+## 日本語
+
+- **MCP request dispatch が shutdown 時の thread-pool 使用を bounded に保つようになりました (#3774)** — request-loop dispatch は concurrency gate の契約を明示し、shutdown 中も late cleanup observer を cancel しないことで bounded work を drain しつつ slot leak を防ぎます。

--- a/changelog.d/unreleased/3792.fixed.md
+++ b/changelog.d/unreleased/3792.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3792
+affected:
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **`batch_query` now avoids per-slot deep cloning near response limits (#3792)** — response budgeting estimates each candidate slot incrementally while preserving deterministic truncation metadata for clients that need to split large batches.
+
+## 日本語
+
+- **`batch_query` が response 上限付近で slot ごとの deep clone を避けるようになりました (#3792)** — 大きな batch を分割する client 向けの決定的な truncation metadata を保ちながら、候補 slot ごとの response budget を増分推定するようにしました。

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -2434,7 +2434,12 @@ internal static partial class ProgramRunner
         HttpMcpTransport transport;
         try
         {
-            transport = new HttpMcpTransport(resolved.Prefix, resolved.Host, resolved.Port, bearerToken, LogHttpMcpRequest);
+            transport = new HttpMcpTransport(
+                resolved.Prefix,
+                resolved.Host,
+                resolved.Port,
+                bearerToken,
+                requestLogger: LogHttpMcpRequest);
         }
         catch (FormatException ex)
         {
@@ -2515,7 +2520,8 @@ internal static partial class ProgramRunner
             + $" status={record.StatusCode.ToString(CultureInfo.InvariantCulture)}"
             + $" duration_ms={record.DurationMs.ToString("0.###", CultureInfo.InvariantCulture)}"
             + $" auth={FormatLogValue(record.AuthOutcome)}"
-            + $" rejection={FormatLogValue(record.RejectionReason)}");
+            + $" rejection={FormatLogValue(record.RejectionReason)}"
+            + $" diagnostic={FormatLogValue(record.Diagnostic)}");
     }
 
     private static string FormatLogValue(string? value)
@@ -2536,7 +2542,7 @@ internal static partial class ProgramRunner
     {
         CommandErrorWriter.WriteStderr("Usage: cdidx mcp [--db <path>] [--transport stdio|http] [--http-listen <host:port>] [--audit-log <path>] [--audit-log-include-values] [--audit-log-max-bytes <n>] [--suggestion-dedup-threshold <0..1>]");
         CommandErrorWriter.WriteStderr("Note: --json is not supported; MCP requests and responses are JSON-RPC over the selected transport.");
-        CommandErrorWriter.WriteStderr($"HTTP limits: {HttpMcpTransport.MaxRequestBodyBytesEnvVar}=<bytes> (1..{HttpMcpTransport.MaxConfiguredRequestBodyBytes.ToString(CultureInfo.InvariantCulture)}, default {HttpMcpTransport.DefaultMaxRequestBodyBytes.ToString(CultureInfo.InvariantCulture)}), {HttpMcpTransport.MaxQueueDepthEnvVar}=<n> (1..{HttpMcpTransport.MaxConfiguredQueuedRequests.ToString(CultureInfo.InvariantCulture)}, default {HttpMcpTransport.DefaultMaxQueuedRequests.ToString(CultureInfo.InvariantCulture)}), {HttpMcpTransport.MaxConcurrentHandlersEnvVar}=<n> (1..{HttpMcpTransport.MaxConfiguredConcurrentHandlers.ToString(CultureInfo.InvariantCulture)}, default {HttpMcpTransport.DefaultMaxConcurrentHandlers.ToString(CultureInfo.InvariantCulture)}), {HttpMcpTransport.MaxEventStreamsEnvVar}=<n> (1..{HttpMcpTransport.MaxConfiguredEventStreams.ToString(CultureInfo.InvariantCulture)}, default {HttpMcpTransport.DefaultMaxEventStreams.ToString(CultureInfo.InvariantCulture)}).");
+        CommandErrorWriter.WriteStderr($"HTTP limits: {HttpMcpTransport.MaxRequestBodyBytesEnvVar}=<bytes> (1..{HttpMcpTransport.MaxConfiguredRequestBodyBytes.ToString(CultureInfo.InvariantCulture)}, default {HttpMcpTransport.DefaultMaxRequestBodyBytes.ToString(CultureInfo.InvariantCulture)}), {HttpMcpTransport.MaxResponseBodyBytesEnvVar}=<bytes> (1..{HttpMcpTransport.MaxConfiguredResponseBodyBytes.ToString(CultureInfo.InvariantCulture)}, default {HttpMcpTransport.DefaultMaxResponseBodyBytes.ToString(CultureInfo.InvariantCulture)}), {HttpMcpTransport.MaxQueueDepthEnvVar}=<n> (1..{HttpMcpTransport.MaxConfiguredQueuedRequests.ToString(CultureInfo.InvariantCulture)}, default {HttpMcpTransport.DefaultMaxQueuedRequests.ToString(CultureInfo.InvariantCulture)}), {HttpMcpTransport.MaxConcurrentHandlersEnvVar}=<n> (1..{HttpMcpTransport.MaxConfiguredConcurrentHandlers.ToString(CultureInfo.InvariantCulture)}, default {HttpMcpTransport.DefaultMaxConcurrentHandlers.ToString(CultureInfo.InvariantCulture)}), {HttpMcpTransport.MaxEventStreamsEnvVar}=<n> (1..{HttpMcpTransport.MaxConfiguredEventStreams.ToString(CultureInfo.InvariantCulture)}, default {HttpMcpTransport.DefaultMaxEventStreams.ToString(CultureInfo.InvariantCulture)}).");
     }
 
     internal static bool TryConsumeSuggestionDedupThresholdFlag(ref string[] args, out string? thresholdValue, out string error)

--- a/src/CodeIndex/Mcp/HttpMcpTransport.cs
+++ b/src/CodeIndex/Mcp/HttpMcpTransport.cs
@@ -29,7 +29,9 @@ namespace CodeIndex.Mcp;
 internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
 {
     internal const int DefaultMaxRequestBodyBytes = 1_000_000;
+    internal const int DefaultMaxResponseBodyBytes = 1_000_000;
     internal const int MaxConfiguredRequestBodyBytes = 16 * 1024 * 1024;
+    internal const int MaxConfiguredResponseBodyBytes = 16 * 1024 * 1024;
     internal const int DefaultMaxQueuedRequests = 64;
     internal const int MaxConfiguredQueuedRequests = 1024;
     internal const int DefaultMaxConcurrentHandlers = 64;
@@ -41,6 +43,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     internal const int MaxSseEventFrameBytes = 64 * 1024;
     internal const string RequestLogTruncationMarker = "...<truncated>";
     internal const string MaxRequestBodyBytesEnvVar = "CDIDX_MCP_HTTP_MAX_REQUEST_BYTES";
+    internal const string MaxResponseBodyBytesEnvVar = "CDIDX_MCP_HTTP_MAX_RESPONSE_BYTES";
     internal const string MaxQueueDepthEnvVar = "CDIDX_MCP_HTTP_MAX_QUEUE_DEPTH";
     internal const string MaxConcurrentHandlersEnvVar = "CDIDX_MCP_HTTP_MAX_CONCURRENT_HANDLERS";
     internal const string MaxEventStreamsEnvVar = "CDIDX_MCP_HTTP_MAX_EVENT_STREAMS";
@@ -54,6 +57,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     private const string InvalidHealthJson = """{"status":"degraded","db_open":false,"error":"health_provider_invalid"}""";
     private static readonly TimeSpan EventStreamDisconnectProbeInterval = TimeSpan.FromSeconds(1);
     private static readonly TimeSpan EventStreamWriteTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan ResponseWriteTimeout = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan DisposeAcceptLoopTimeout = TimeSpan.FromSeconds(5);
 
     private readonly HttpListener _listener;
@@ -66,6 +70,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     private readonly SemaphoreSlim _queueSlots;
     private readonly SemaphoreSlim _handlerSemaphore;
     private readonly int _maxRequestBodyBytes;
+    private readonly int _maxResponseBodyBytes;
     private readonly int _maxQueuedRequests;
     private readonly int _maxConcurrentHandlers;
     private readonly int _maxEventStreams;
@@ -105,6 +110,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
         string? bearerToken,
         Action<HttpRequestLogRecord>? requestLogger = null,
         int? maxRequestBodyBytes = null,
+        int? maxResponseBodyBytes = null,
         int? maxQueuedRequests = null,
         int? maxConcurrentHandlers = null,
         int? maxEventStreams = null)
@@ -116,6 +122,13 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
             DefaultMaxRequestBodyBytes,
             MaxConfiguredRequestBodyBytes,
             "HTTP MCP request body byte limit");
+        _maxResponseBodyBytes = ResolvePositiveIntOption(
+            maxResponseBodyBytes,
+            nameof(maxResponseBodyBytes),
+            MaxResponseBodyBytesEnvVar,
+            DefaultMaxResponseBodyBytes,
+            MaxConfiguredResponseBodyBytes,
+            "HTTP MCP response body byte limit");
         _maxQueuedRequests = ResolvePositiveIntOption(
             maxQueuedRequests,
             nameof(maxQueuedRequests),
@@ -191,6 +204,8 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     internal bool HasEventStreams => EventStreamCount > 0;
 
     internal int MaxRequestBodyBytes => _maxRequestBodyBytes;
+
+    internal int MaxResponseBodyBytes => _maxResponseBodyBytes;
 
     internal int MaxQueuedRequests => _maxQueuedRequests;
 
@@ -526,10 +541,13 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
         var context = request.Context;
         if (context.Request.ContentLength64 > _maxRequestBodyBytes)
         {
+            request.Diagnostic = "request_body_limit_exceeded";
             await RespondAsync(context, (int)HttpStatusCode.RequestEntityTooLarge, $"MCP HTTP request body exceeds the configured {_maxRequestBodyBytes.ToString(CultureInfo.InvariantCulture)} byte limit.\n").ConfigureAwait(false);
             LogRequest(request, (int)HttpStatusCode.RequestEntityTooLarge);
             return null;
         }
+        if (context.Request.ContentLength64 < 0)
+            request.Diagnostic = "request_body_length_unknown";
 
         using var buffer = new MemoryStream();
         var scratch = new byte[Math.Min(8192, _maxRequestBodyBytes)];
@@ -541,6 +559,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
 
             if (buffer.Length + read > _maxRequestBodyBytes)
             {
+                request.Diagnostic = "request_body_limit_exceeded";
                 await RespondAsync(context, (int)HttpStatusCode.RequestEntityTooLarge, $"MCP HTTP request body exceeds the configured {_maxRequestBodyBytes.ToString(CultureInfo.InvariantCulture)} byte limit.\n").ConfigureAwait(false);
                 LogRequest(request, (int)HttpStatusCode.RequestEntityTooLarge);
                 return null;
@@ -584,10 +603,12 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
             }
 
             var payload = Encoding.UTF8.GetBytes(frame);
+            if (!await TryRejectOversizedResponseAsync(request, payload.LongLength).ConfigureAwait(false))
+                return true;
             context.Response.StatusCode = (int)HttpStatusCode.OK;
             context.Response.ContentType = "application/json; charset=utf-8";
             context.Response.ContentLength64 = payload.LongLength;
-            await context.Response.OutputStream.WriteAsync(payload.AsMemory(), cancellationToken).ConfigureAwait(false);
+            await WriteResponseBytesAsync(context.Response.OutputStream, payload, cancellationToken).ConfigureAwait(false);
             CloseOutputStreamOrThrow(context.Response.OutputStream, "out-of-band response body");
             LogRequest(request, (int)HttpStatusCode.OK);
             return true;
@@ -648,10 +669,12 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
             }
 
             var payload = Encoding.UTF8.GetBytes(frame);
+            if (!await TryRejectOversizedResponseAsync(request, payload.LongLength).ConfigureAwait(false))
+                return;
             context.Response.StatusCode = (int)HttpStatusCode.OK;
             context.Response.ContentType = "application/json; charset=utf-8";
             context.Response.ContentLength64 = payload.LongLength;
-            await context.Response.OutputStream.WriteAsync(payload.AsMemory(), cancellationToken).ConfigureAwait(false);
+            await WriteResponseBytesAsync(context.Response.OutputStream, payload, cancellationToken).ConfigureAwait(false);
             CloseOutputStreamOrThrow(context.Response.OutputStream, "request response body");
             LogRequest(request, (int)HttpStatusCode.OK);
         }
@@ -662,6 +685,27 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
             AbortResponseBestEffort(context.Response, "request response failure");
             throw;
         }
+    }
+
+    private async Task<bool> TryRejectOversizedResponseAsync(PendingRequest request, long payloadBytes)
+    {
+        if (payloadBytes <= _maxResponseBodyBytes)
+            return true;
+
+        request.Diagnostic = "response_body_limit_exceeded";
+        await RespondAsync(
+            request.Context,
+            (int)HttpStatusCode.InternalServerError,
+            $"MCP HTTP response body exceeds the configured {_maxResponseBodyBytes.ToString(CultureInfo.InvariantCulture)} byte limit.\n").ConfigureAwait(false);
+        LogRequest(request, (int)HttpStatusCode.InternalServerError);
+        return false;
+    }
+
+    private static async Task WriteResponseBytesAsync(Stream stream, byte[] bytes, CancellationToken cancellationToken)
+    {
+        using var writeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        writeCts.CancelAfter(ResponseWriteTimeout);
+        await stream.WriteAsync(bytes.AsMemory(), writeCts.Token).ConfigureAwait(false);
     }
 
     public async Task WriteOutOfBandFrameAsync(string frame, CancellationToken cancellationToken)
@@ -778,7 +822,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
             context.Response.ContentType = "text/plain; charset=utf-8";
             var bytes = Encoding.UTF8.GetBytes(body);
             context.Response.ContentLength64 = bytes.LongLength;
-            await context.Response.OutputStream.WriteAsync(bytes).ConfigureAwait(false);
+            await WriteResponseBytesAsync(context.Response.OutputStream, bytes, CancellationToken.None).ConfigureAwait(false);
             CloseOutputStreamOrThrow(context.Response.OutputStream, "plain-text response body");
         }
         catch
@@ -795,7 +839,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
             context.Response.ContentType = "application/json; charset=utf-8";
             var bytes = Encoding.UTF8.GetBytes(body);
             context.Response.ContentLength64 = bytes.LongLength;
-            await context.Response.OutputStream.WriteAsync(bytes).ConfigureAwait(false);
+            await WriteResponseBytesAsync(context.Response.OutputStream, bytes, CancellationToken.None).ConfigureAwait(false);
             CloseOutputStreamOrThrow(context.Response.OutputStream, "json response body");
         }
         catch
@@ -864,7 +908,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
             _eventStreams[streamId] = stream;
 
             var prelude = Encoding.UTF8.GetBytes(": cdidx mcp event stream ready\n\n");
-            await context.Response.OutputStream.WriteAsync(prelude.AsMemory(), cancellationToken).ConfigureAwait(false);
+            await WriteResponseBytesAsync(context.Response.OutputStream, prelude, cancellationToken).ConfigureAwait(false);
             await context.Response.OutputStream.FlushAsync(cancellationToken).ConfigureAwait(false);
 
             await RunKeepAliveLoopAsync(stream, cancellationToken).ConfigureAwait(false);
@@ -961,11 +1005,13 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
 
         private async Task WriteSseBytesAsync(byte[] bytes, CancellationToken cancellationToken)
         {
-            await _writeGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            using var writeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            writeCts.CancelAfter(EventStreamWriteTimeout);
+            await _writeGate.WaitAsync(writeCts.Token).ConfigureAwait(false);
             try
             {
-                await Response.OutputStream.WriteAsync(bytes.AsMemory(), cancellationToken).ConfigureAwait(false);
-                await Response.OutputStream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                await Response.OutputStream.WriteAsync(bytes.AsMemory(), writeCts.Token).ConfigureAwait(false);
+                await Response.OutputStream.FlushAsync(writeCts.Token).ConfigureAwait(false);
             }
             finally
             {
@@ -1127,7 +1173,8 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
         int StatusCode,
         double DurationMs,
         string AuthOutcome,
-        string? RejectionReason);
+        string? RejectionReason,
+        string? Diagnostic);
 
     private PendingRequest BeginRequest(HttpListenerContext context)
     {
@@ -1168,7 +1215,8 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
                     statusCode,
                     request.Elapsed.TotalMilliseconds,
                     request.AuthOutcome,
-                    request.RejectionReason);
+                    request.RejectionReason,
+                    request.Diagnostic);
             lock (_requestLoggerGate)
             {
                 _requestLogger(record);
@@ -1232,6 +1280,8 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
         internal string AuthOutcome { get; set; } = "none";
 
         internal string? RejectionReason { get; set; }
+
+        internal string? Diagnostic { get; set; }
 
         internal bool Logged { get; set; }
 

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -932,10 +932,13 @@ public partial class McpServer : IDisposable
 
     /// <summary>
     /// Process one MCP JSON-RPC frame and return the wire-ready response string (or null when
-    /// the request was a notification or otherwise yields no response). This is the
-    /// transport-neutral seam used by <see cref="IMcpTransport"/> implementations (issue #1558).
+    /// the request was a notification or otherwise yields no response). This synchronous wrapper
+    /// is retained for compatibility tests and legacy in-process callers only; transports and
+    /// request loops should call <see cref="ProcessFrameAsync"/> so cancellation and shutdown can
+    /// flow without sync-over-async blocking (#3770).
     /// 1 フレーム分の MCP JSON-RPC を処理し、ワイヤー応答文字列を返す（通知などで応答なしの場合は null）。
-    /// <see cref="IMcpTransport"/> 実装が共有するトランスポート非依存の合流点 (issue #1558)。
+    /// この同期ラッパは互換テストと legacy in-process 呼び出し専用に残す。transport と request loop は
+    /// sync-over-async blocking を避けるため <see cref="ProcessFrameAsync"/> を await する (#3770)。
     /// </summary>
     internal string? ProcessFrame(string line)
         => ProcessFrameAsync(line).GetAwaiter().GetResult();
@@ -1308,8 +1311,12 @@ public partial class McpServer : IDisposable
     }
 
     /// <summary>
-    /// Route a JSON-RPC message to the appropriate handler.
-    /// JSON-RPCメッセージを適切なハンドラにルーティング。
+    /// Route a JSON-RPC message to the appropriate handler. This synchronous wrapper is retained
+    /// for compatibility tests and legacy in-process callers only; transports should prefer
+    /// <see cref="HandleMessageAsync(JsonNode)"/> to avoid sync-over-async dispatch (#3770).
+    /// JSON-RPCメッセージを適切なハンドラにルーティング。この同期ラッパは互換テストと legacy
+    /// in-process 呼び出し専用に残し、transport は sync-over-async dispatch を避けるため
+    /// <see cref="HandleMessageAsync(JsonNode)"/> を優先する (#3770)。
     /// </summary>
     internal JsonNode? HandleMessage(JsonNode request)
         => HandleMessageAsync(request, isolateRequestDb: false).GetAwaiter().GetResult();

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -347,6 +347,7 @@ public partial class McpServer : IDisposable
 
     internal Action<JsonNode?>? RequestRegisteredForTests { get; set; }
     internal Func<CancellationToken, Task>? RequestDelayForTests { get; set; }
+    internal bool ShutdownRequestedForTests => _shutdownCts.IsCancellationRequested;
 
     /// <summary>
     /// Cap configured for concurrent in-flight tool calls (#1567). Surfaced for tests so
@@ -678,6 +679,15 @@ public partial class McpServer : IDisposable
 
             await _concurrencyGate.WaitAsync(loopToken).ConfigureAwait(false);
             var requestTaskStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            // Intentional bounded dispatch (#3774): normal request work can await SQLite,
+            // sampling, or transport callbacks while the read loop still needs to accept
+            // cancellation / response frames. `_concurrencyGate` caps thread-pool exposure;
+            // the scheduling token stays uncancelled because the gate slot is already owned
+            // and the task's finally block must release it even during shutdown.
+            // 意図的な bounded dispatch (#3774)。通常 request は SQLite / sampling /
+            // transport callback を await し得る一方、read loop は cancellation / response
+            // frame を受け続ける必要がある。`_concurrencyGate` で thread-pool 使用量を上限化し、
+            // gate slot 解放の finally を必ず走らせるため scheduling token は未キャンセルにする。
             var requestTask = Task.Run(async () =>
             {
                 try
@@ -779,6 +789,10 @@ public partial class McpServer : IDisposable
         if (postCancelDelay.IsCanceled)
             return;
 
+        // The shutdown token is already canceled in this path. Use an uncancelled observer so
+        // late task faults are still observed after the client-visible drain window (#3774).
+        // この経路では shutdown token はキャンセル済み。client-visible な drain window 後でも
+        // late fault を観測できるよう、未キャンセルの observer を使う (#3774)。
         _ = allTasks.ContinueWith(task =>
         {
             _ = task.Exception;

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -1673,6 +1673,11 @@ public partial class McpServer : IDisposable
                 var elapsed = stopwatch.Elapsed;
                 RecordTimedOutIsolatedActionDraining(requestKey, elapsed);
                 cleanupNow = false;
+                // This cleanup must run even after request timeout/shutdown cancellation;
+                // otherwise `_activeRequests` and the linked CTS would leak when an isolated
+                // action eventually observes cancellation and exits (#3722).
+                // request timeout / shutdown cancellation 後でも cleanup は必ず実行する。
+                // isolated action が後で終了した時に `_activeRequests` と linked CTS を漏らさないため (#3722)。
                 _ = actionTask.ContinueWith(task =>
                 {
                     _ = task.Exception;

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -23,6 +23,7 @@ public partial class McpServer
     private const int DefaultBatchQueryResponseByteLimit = MaxLineByteLength;
     internal const int MaxBatchQueryResponseByteLimit = 10 * 1024 * 1024;
     internal const int MaxBatchQuerySize = 10;
+    private const int BatchQueryIncrementalEstimatePaddingBytes = 512;
     private const int DefaultExcerptOutputByteLimit = MaxLineByteLength;
     private const string BatchQueryResponseByteLimitEnvVar = "CDIDX_MCP_BATCH_RESPONSE_MAX_BYTES";
     internal const int MaxMcpArrayFilterCount = QueryCommandRunner.MaxQueryPathFilterCount;
@@ -3945,17 +3946,15 @@ public partial class McpServer
 
         bool TryAppendResult(JsonObject entry, string? toolName, JsonNode? toolArgs, int requestIndex, string? slotId, bool successfulSlot = false, bool failedSlot = false)
         {
-            var candidateResults = CloneJsonArray(resultsArray);
-            candidateResults.Add(entry.DeepClone());
             var candidateSuccessCount = successCount + (successfulSlot ? 1 : 0);
             var candidateFailureCount = failureCount + (failedSlot ? 1 : 0);
             var candidateExecutedCount = candidateSuccessCount + candidateFailureCount;
-            var candidateSummary = candidateFailureCount == 0
-                ? $"Executed {candidateExecutedCount} of {queries.Count} queries in 0 ms (all succeeded)."
-                : $"Executed {candidateExecutedCount} of {queries.Count} queries in 0 ms ({candidateSuccessCount} succeeded, {candidateFailureCount} failed).";
-            var candidateBytes = EstimateBatchResponseBytes(id, candidateSummary, queries.Count, candidateSuccessCount, candidateFailureCount,
-                GetBatchFailureScope(queries.Count, candidateSuccessCount, candidateFailureCount, cascadeStartedAtIndex), cascadeStartedAtIndex,
-                responseByteLimit, candidateResults, truncated: false, truncatedQueries, adjustments);
+            var candidateBytes = EstimateBatchAppendBytes(
+                estimatedResponseBytes,
+                entry,
+                candidateExecutedCount,
+                candidateSuccessCount,
+                candidateFailureCount);
             if (candidateBytes > responseByteLimit)
             {
                 truncated = true;
@@ -4605,19 +4604,45 @@ public partial class McpServer
         return EstimateJsonUtf8Bytes(CreateToolResult(id, summary, payload), responseByteLimit);
     }
 
+    private int EstimateBatchAppendBytes(int currentEstimateBytes, JsonObject entry, int executedCount, int successCount, int failureCount)
+    {
+        var entryBytes = EstimateJsonUtf8Bytes(entry);
+        var digitGrowth = CountDecimalDigits(executedCount) + CountDecimalDigits(successCount) + CountDecimalDigits(failureCount);
+        return SaturatingAdd(
+            currentEstimateBytes,
+            entryBytes,
+            BatchQueryIncrementalEstimatePaddingBytes,
+            digitGrowth);
+    }
+
+    private static int CountDecimalDigits(int value)
+    {
+        var digits = 1;
+        while (value >= 10)
+        {
+            value /= 10;
+            digits++;
+        }
+        return digits;
+    }
+
+    private static int SaturatingAdd(params int[] values)
+    {
+        var total = 0L;
+        foreach (var value in values)
+        {
+            total += value;
+            if (total >= int.MaxValue)
+                return int.MaxValue;
+        }
+        return (int)total;
+    }
+
     private static string GetBatchFailureScope(int submittedCount, int successCount, int failureCount, int? cascadeStartedAtIndex)
     {
         if (cascadeStartedAtIndex.HasValue && cascadeStartedAtIndex.Value < submittedCount)
             return "cascading";
         return failureCount == 0 ? "none" : "isolated";
-    }
-
-    private static JsonArray CloneJsonArray(JsonArray source)
-    {
-        var clone = new JsonArray();
-        foreach (var item in source)
-            clone.Add(item?.DeepClone());
-        return clone;
     }
 
     /// <summary>

--- a/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+++ b/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
@@ -497,19 +497,63 @@ public class HttpMcpTransportTests : IDisposable
     [Fact]
     public async Task HttpTransport_RequestBodyOverLimit_Returns413AndDoesNotKillServer()
     {
-        await using var harness = await McpHttpHarness.StartAsync(_dbPath, maxRequestBodyBytes: 64);
+        var records = new ConcurrentQueue<HttpMcpTransport.HttpRequestLogRecord>();
+        await using var harness = await McpHttpHarness.StartAsync(_dbPath, requestLogger: records.Enqueue, maxRequestBodyBytes: 64);
 
         using var oversized = await harness.PostJsonAsync(new string('x', 65));
 
         Assert.Equal(HttpStatusCode.RequestEntityTooLarge, oversized.StatusCode);
         var rejectedBody = await oversized.Content.ReadAsStringAsync();
         Assert.Contains("64 byte limit", rejectedBody, StringComparison.Ordinal);
+        var rejectedRecord = Assert.Single(await WaitForRequestLogRecordsAsync(records, 1));
+        Assert.Equal("request_body_limit_exceeded", rejectedRecord.Diagnostic);
 
         using var follow = await harness.PostJsonAsync("""{"jsonrpc":"2.0","id":7,"method":"ping"}""");
         Assert.Equal(HttpStatusCode.OK, follow.StatusCode);
         var body = await follow.Content.ReadAsStringAsync();
         using var doc = JsonDocument.Parse(body);
         Assert.Equal(7, doc.RootElement.GetProperty("id").GetInt32());
+    }
+
+    [Fact]
+    public async Task HttpTransport_UnknownLengthRequestBody_LogsBoundedDiagnostic_Issue3755()
+    {
+        var records = new ConcurrentQueue<HttpMcpTransport.HttpRequestLogRecord>();
+        await using var harness = await McpHttpHarness.StartAsync(_dbPath, requestLogger: records.Enqueue);
+
+        using var client = new HttpClient();
+        using var request = new HttpRequestMessage(HttpMethod.Post, harness.Endpoint)
+        {
+            Content = new UnknownLengthStringContent("""{"jsonrpc":"2.0","id":3755,"method":"ping"}"""),
+        };
+        using var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var record = Assert.Single(await WaitForRequestLogRecordsAsync(records, 1));
+        Assert.Equal("request_body_length_unknown", record.Diagnostic);
+        Assert.Equal("3755", record.RequestId);
+    }
+
+    [Fact]
+    public async Task HttpTransport_ResponseBodyOverLimit_Returns500AndLogsDiagnostic_Issue3755()
+    {
+        var records = new ConcurrentQueue<HttpMcpTransport.HttpRequestLogRecord>();
+        await using var harness = await McpHttpHarness.StartAsync(_dbPath, requestLogger: records.Enqueue, maxResponseBodyBytes: 1024);
+
+        using var oversized = await harness.PostJsonAsync("""{"jsonrpc":"2.0","id":1,"method":"tools/list"}""");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, oversized.StatusCode);
+        var rejectedBody = await oversized.Content.ReadAsStringAsync();
+        Assert.Contains("response body exceeds", rejectedBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"tools\"", rejectedBody, StringComparison.Ordinal);
+        var rejectedRecord = Assert.Single(await WaitForRequestLogRecordsAsync(records, 1));
+        Assert.Equal("response_body_limit_exceeded", rejectedRecord.Diagnostic);
+
+        using var follow = await harness.PostJsonAsync("""{"jsonrpc":"2.0","id":2,"method":"ping"}""");
+        Assert.Equal(HttpStatusCode.OK, follow.StatusCode);
+        var body = await follow.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(2, doc.RootElement.GetProperty("id").GetInt32());
     }
 
     [Fact]
@@ -523,10 +567,12 @@ public class HttpMcpTransportTests : IDisposable
             bearerToken: null);
 
         Assert.Equal(HttpMcpTransport.DefaultMaxRequestBodyBytes, transport.MaxRequestBodyBytes);
+        Assert.Equal(HttpMcpTransport.DefaultMaxResponseBodyBytes, transport.MaxResponseBodyBytes);
         Assert.Equal(HttpMcpTransport.DefaultMaxQueuedRequests, transport.MaxQueuedRequests);
         Assert.Equal(HttpMcpTransport.DefaultMaxConcurrentHandlers, transport.MaxConcurrentHandlers);
         Assert.Equal(HttpMcpTransport.DefaultMaxEventStreams, transport.MaxEventStreams);
         Assert.InRange(transport.MaxRequestBodyBytes, 1, HttpMcpTransport.MaxConfiguredRequestBodyBytes);
+        Assert.InRange(transport.MaxResponseBodyBytes, 1, HttpMcpTransport.MaxConfiguredResponseBodyBytes);
         Assert.InRange(transport.MaxQueuedRequests, 1, HttpMcpTransport.MaxConfiguredQueuedRequests);
         Assert.InRange(transport.MaxConcurrentHandlers, 1, HttpMcpTransport.MaxConfiguredConcurrentHandlers);
         Assert.InRange(transport.MaxEventStreams, 1, HttpMcpTransport.MaxConfiguredEventStreams);
@@ -553,10 +599,12 @@ public class HttpMcpTransportTests : IDisposable
     {
         using var env = EnvironmentVariableScope.Capture(
             HttpMcpTransport.MaxRequestBodyBytesEnvVar,
+            HttpMcpTransport.MaxResponseBodyBytesEnvVar,
             HttpMcpTransport.MaxQueueDepthEnvVar,
             HttpMcpTransport.MaxConcurrentHandlersEnvVar,
             HttpMcpTransport.MaxEventStreamsEnvVar);
         env.Set(HttpMcpTransport.MaxRequestBodyBytesEnvVar, (2 * 1024 * 1024).ToString(CultureInfo.InvariantCulture));
+        env.Set(HttpMcpTransport.MaxResponseBodyBytesEnvVar, (3 * 1024 * 1024).ToString(CultureInfo.InvariantCulture));
         env.Set(HttpMcpTransport.MaxQueueDepthEnvVar, "128");
         env.Set(HttpMcpTransport.MaxConcurrentHandlersEnvVar, "32");
         env.Set(HttpMcpTransport.MaxEventStreamsEnvVar, "8");
@@ -569,6 +617,7 @@ public class HttpMcpTransportTests : IDisposable
             bearerToken: null);
 
         Assert.Equal(2 * 1024 * 1024, transport.MaxRequestBodyBytes);
+        Assert.Equal(3 * 1024 * 1024, transport.MaxResponseBodyBytes);
         Assert.Equal(128, transport.MaxQueuedRequests);
         Assert.Equal(32, transport.MaxConcurrentHandlers);
         Assert.Equal(8, transport.MaxEventStreams);
@@ -1418,6 +1467,7 @@ public class HttpMcpTransportTests : IDisposable
             IMcpAuthenticator? authenticator = null,
             Action<HttpMcpTransport.HttpRequestLogRecord>? requestLogger = null,
             int? maxRequestBodyBytes = null,
+            int? maxResponseBodyBytes = null,
             int? maxQueuedRequests = null)
         {
             var listen = HttpMcpTransport.ResolveListenSpec("127.0.0.1:0");
@@ -1426,9 +1476,10 @@ public class HttpMcpTransportTests : IDisposable
                 listen.Host,
                 listen.Port,
                 bearerToken,
-                requestLogger,
-                maxRequestBodyBytes,
-                maxQueuedRequests);
+                requestLogger: requestLogger,
+                maxRequestBodyBytes: maxRequestBodyBytes,
+                maxResponseBodyBytes: maxResponseBodyBytes,
+                maxQueuedRequests: maxQueuedRequests);
             var server = authenticator is null
                 ? new McpServer(dbPath, ConsoleUi.LoadVersion())
                 : new McpServer(dbPath, ConsoleUi.LoadVersion(), dbPathExplicit: false, authenticator);
@@ -1470,6 +1521,29 @@ public class HttpMcpTransportTests : IDisposable
             catch { /* timeouts / cancellations expected when the listener stops mid-accept */ }
             _server.Dispose();
             _cts.Dispose();
+        }
+    }
+
+    private sealed class UnknownLengthStringContent : HttpContent
+    {
+        private readonly byte[] _bytes;
+
+        public UnknownLengthStringContent(string body)
+        {
+            _bytes = Encoding.UTF8.GetBytes(body);
+            Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue("application/json")
+            {
+                CharSet = "utf-8",
+            };
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+            => stream.WriteAsync(_bytes, 0, _bytes.Length);
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = 0;
+            return false;
         }
     }
 }

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -272,6 +272,22 @@ public class McpServerTests : IDisposable
         Assert.Equal("completed", drained["last"]!["state"]!.GetValue<string>());
     }
 
+    [Fact]
+    public async Task DrainInFlightTasksAsync_CancelsShutdownAfterBoundedDrainWindow_Issue3774()
+    {
+        var stuck = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tasks = new List<Task> { stuck.Task };
+
+        await _server.DrainInFlightTasksAsync(
+            tasks,
+            TimeSpan.FromMilliseconds(10),
+            TimeSpan.FromMilliseconds(10));
+
+        Assert.True(_server.ShutdownRequestedForTests);
+        stuck.SetResult();
+        await stuck.Task.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
     private static async Task WaitUntilAsync(Func<bool> condition, string description)
     {
         var deadline = DateTimeOffset.UtcNow.AddSeconds(5);

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -238,6 +238,54 @@ public class McpServerTests : IDisposable
             asyncDocument.RootElement.GetProperty("result").GetProperty("tools").GetArrayLength());
     }
 
+    [Fact]
+    public async Task ProcessFrameAsync_TimedOutIsolatedActionReportsAndCleansUpDrain_Issue3722()
+    {
+        using var server = new McpServer(_dbPath, ConsoleUi.LoadVersion())
+        {
+            RequestTimeout = TimeSpan.FromMilliseconds(20),
+        };
+        var blocker = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        server.RequestDelayForTests = _ => blocker.Task;
+
+        var response = await server.ProcessFrameAsync("""{"jsonrpc":"2.0","id":3722,"method":"ping"}""")
+            .WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.NotNull(response);
+        using (var document = JsonDocument.Parse(response))
+        {
+            var error = document.RootElement.GetProperty("error");
+            Assert.Equal("Request timed out", error.GetProperty("message").GetString());
+            Assert.True(error.GetProperty("data").GetProperty("isolated_action_draining").GetBoolean());
+        }
+        var draining = server.BuildRequestTimeoutDiagnosticsStatus();
+        Assert.Equal(1, draining["isolated_action_draining_count"]!.GetValue<long>());
+        Assert.Equal("draining", draining["last"]!["state"]!.GetValue<string>());
+
+        blocker.SetResult();
+
+        await WaitUntilAsync(
+            () => server.BuildRequestTimeoutDiagnosticsStatus()["isolated_action_draining_count"]!.GetValue<long>() == 0,
+            "timed-out isolated action to drain and unregister");
+        var drained = server.BuildRequestTimeoutDiagnosticsStatus();
+        Assert.Equal(1, drained["isolated_action_drained_count"]!.GetValue<long>());
+        Assert.Equal("completed", drained["last"]!["state"]!.GetValue<string>());
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, string description)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (condition())
+                return;
+
+            await Task.Delay(10);
+        }
+
+        Assert.Fail($"Timed out waiting for {description}.");
+    }
+
     private void InsertIndexedFile(string path, string lang, string content, bool generated = false)
     {
         var normalized = content.Replace("\r\n", "\n");

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -221,6 +221,23 @@ public class McpServerTests : IDisposable
         Assert.True(document.RootElement.TryGetProperty("result", out _));
     }
 
+    [Fact]
+    public async Task ProcessFrameAsync_MatchesSyncCompatibilityWrapper_Issue3770()
+    {
+        const string frame = """{"jsonrpc":"2.0","id":3770,"method":"tools/list"}""";
+
+        var syncResponse = _server.ProcessFrame(frame);
+        var asyncResponse = await _server.ProcessFrameAsync(frame);
+
+        Assert.NotNull(syncResponse);
+        Assert.NotNull(asyncResponse);
+        using var syncDocument = JsonDocument.Parse(syncResponse);
+        using var asyncDocument = JsonDocument.Parse(asyncResponse);
+        Assert.Equal(
+            syncDocument.RootElement.GetProperty("result").GetProperty("tools").GetArrayLength(),
+            asyncDocument.RootElement.GetProperty("result").GetProperty("tools").GetArrayLength());
+    }
+
     private void InsertIndexedFile(string path, string lang, string content, bool generated = false)
     {
         var normalized = content.Replace("\r\n", "\n");

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json.Nodes;
 using System.Text.Json;
 using System.Diagnostics;
+using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
@@ -390,6 +391,57 @@ public sealed class Caller
         Assert.True(structured["count"]!.GetValue<int>() > 0);
         Assert.NotNull(structured["result_stable_at"]);
         Assert.Empty(structured["results"]!.AsArray());
+    }
+
+    [Fact]
+    public void ToolsCall_BatchQueryNearResponseLimit_TruncatesDeterministically_Issue3792()
+    {
+        var queries = new JsonArray();
+        for (var i = 0; i < McpServer.MaxBatchQuerySize; i++)
+        {
+            queries.Add(new JsonObject
+            {
+                ["slotId"] = $"slot-{i.ToString(CultureInfo.InvariantCulture)}",
+                ["tool"] = "search",
+                ["arguments"] = new JsonObject
+                {
+                    ["query"] = "Run",
+                    ["limit"] = 1,
+                    ["format"] = "compact",
+                },
+            });
+        }
+        var request = new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = 3792,
+            ["method"] = "tools/call",
+            ["params"] = new JsonObject
+            {
+                ["name"] = "batch_query",
+                ["arguments"] = new JsonObject
+                {
+                    ["maxResponseBytes"] = 5000,
+                    ["queries"] = queries,
+                },
+            },
+        };
+
+        var stopwatch = Stopwatch.StartNew();
+        var response = _server.HandleMessage(request)!;
+        stopwatch.Stop();
+
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(5));
+        var structured = response["result"]!["structuredContent"]!;
+        Assert.True(structured["truncated"]!.GetValue<bool>());
+        Assert.True(structured["metadata"]!["estimated_response_bytes"]!.GetValue<int>() <= 5000);
+        Assert.True(structured["results"]!.AsArray().Count > 0);
+        var truncatedQueries = structured["truncated_queries"]!.AsArray();
+        Assert.NotEmpty(truncatedQueries);
+        var firstTruncatedIndex = truncatedQueries[0]!["request_index"]!.GetValue<int>();
+        Assert.Equal(firstTruncatedIndex, structured["cascade_started_at_index"]!.GetValue<int>());
+        Assert.True(firstTruncatedIndex > 0);
+        Assert.Equal("slot-" + firstTruncatedIndex.ToString(CultureInfo.InvariantCulture), truncatedQueries[0]!["slot_id"]!.GetValue<string>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Avoid per-slot deep cloning in `batch_query` response budgeting while preserving truncation metadata.
- Keep MCP async frame/message entrypoints covered and document the sync wrappers as compatibility-only paths.
- Tighten timeout cleanup for isolated MCP background work and shutdown drain observers.
- Add HTTP MCP response body limits, bounded request diagnostics, SSE write timeouts, and matching bilingual developer docs.

## Issues

Fixes #3792
Fixes #3774
Fixes #3770
Fixes #3722
Fixes #3755

Related #3869

## Validation

- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check origin/main..HEAD`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-restore -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-build --filter "FullyQualifiedName~Issue3792|FullyQualifiedName~Issue3755|FullyQualifiedName~Issue3770|FullyQualifiedName~Issue3722|FullyQualifiedName~Issue3774"`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net9.0 --no-restore -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net9.0 --no-build --filter "FullyQualifiedName~Issue3792|FullyQualifiedName~Issue3755|FullyQualifiedName~Issue3770|FullyQualifiedName~Issue3722|FullyQualifiedName~Issue3774"`

## Review Notes

- Attempted mandatory `codex exec` adversarial review, but the CLI returned a Codex usage-limit error before review could run. I performed a manual adversarial pass over `origin/main..HEAD` afterward and found no blocking issues.
- `AGENT.md`, `CLAUDE.md`, and `AGENT_GUIDE.md` were not modified.