### PR TITLE
Fix watch bounds and async lifecycle issues

### DIFF
--- a/changelog.d/unreleased/3677.fixed.md
+++ b/changelog.d/unreleased/3677.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3677
+affected:
+  - src/CodeIndex/Cli/IndexWatchRunner.cs
+  - src/CodeIndex/Mcp/McpServer.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
+  - src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
+---
+
+## English
+
+- **Reduced sync-over-async in watch and documented required sync bridges (#3677)** — `index --watch` now uses an async delay loop for cancellation-friendly polling, while remaining MCP and worker sync wrappers document why they stay at compatibility or bounded subprocess protocol boundaries.
+
+## 日本語
+
+- **watch の sync-over-async を減らし、必要な同期 bridge を明文化しました (#3677)** — `index --watch` は cancellation しやすい async delay loop で polling し、残る MCP / worker の同期 wrapper は互換境界または bounded subprocess protocol 境界として残す理由を明記しました。

--- a/changelog.d/unreleased/3771.fixed.md
+++ b/changelog.d/unreleased/3771.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3771
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.UpdateTargets.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Unified JSON heartbeat shutdown without blocking waits (#3771)** — full-scan and update-target indexing now share a heartbeat stop helper that cancels heartbeat tasks without `Task.Wait` teardown.
+
+## 日本語
+
+- **JSON heartbeat shutdown を共通化し、blocking wait をなくしました (#3771)** — full-scan と update-target indexing は共通の heartbeat stop helper を使い、`Task.Wait` による停止処理を行わずに heartbeat task を cancel します。

--- a/changelog.d/unreleased/3803.fixed.md
+++ b/changelog.d/unreleased/3803.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3803
+affected:
+  - src/CodeIndex/Cli/IndexWatchRunner.cs
+  - tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
+---
+
+## English
+
+- **Bounded `index --watch` sub-run capture and large path batches (#3803)** — watch sub-runs now cap in-memory stdout capture, preserve JSON sub-run output through a spool stream, and split large `--files` updates before command-line argument limits are reached.
+
+## 日本語
+
+- **`index --watch` のサブ実行 capture と大量パス batch を制限しました (#3803)** — watch のサブ実行は stdout のメモリ capture を上限付きにし、JSON のサブ実行出力は spool stream で保持し、`--files` 更新はコマンドライン引数上限に達する前に分割します。

--- a/changelog.d/unreleased/3837.fixed.md
+++ b/changelog.d/unreleased/3837.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3837
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **Aligned CLI search cursor validation and pruned completed MCP request tasks (#3837)** — recipe search cursors now reject non-finite scores and negative chunk ids like the MCP parser, and the concurrent MCP frame loop prunes completed request tasks during long-lived sessions.
+
+## 日本語
+
+- **CLI search cursor validation を MCP と揃え、完了済み MCP request task を prune するようにしました (#3837)** — recipe search cursor は MCP parser と同じく非有限 score と負の chunk id を拒否し、並行 MCP frame loop は長時間 session 中に完了済み request task を prune します。

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -681,20 +681,7 @@ public static partial class IndexCommandRunner
     }
 
     private static void StopFullScanJsonPhaseHeartbeat((CancellationTokenSource Cts, Task Task)? heartbeat)
-    {
-        if (heartbeat == null)
-            return;
-
-        heartbeat.Value.Cts.Cancel();
-        try
-        {
-            heartbeat.Value.Task.Wait(TimeSpan.FromSeconds(1));
-        }
-        catch (AggregateException ex) when (ex.InnerExceptions.All(inner => inner is OperationCanceledException or TaskCanceledException))
-        {
-        }
-        heartbeat.Value.Cts.Dispose();
-    }
+        => StopObservedJsonPhaseHeartbeat(heartbeat);
 
     private static int RunFullScan(
         DbWriter writer,

--- a/src/CodeIndex/Cli/IndexCommandRunner.UpdateTargets.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.UpdateTargets.cs
@@ -184,18 +184,32 @@ public static partial class IndexCommandRunner
     }
 
     private static void StopIndexJsonPhaseHeartbeat((CancellationTokenSource Cts, Task Task)? heartbeat)
+        => StopObservedJsonPhaseHeartbeat(heartbeat);
+
+    internal static void StopObservedJsonPhaseHeartbeat((CancellationTokenSource Cts, Task Task)? heartbeat)
     {
         if (heartbeat == null)
             return;
 
-        heartbeat.Value.Cts.Cancel();
-        try
+        var cts = heartbeat.Value.Cts;
+        var task = heartbeat.Value.Task;
+        cts.Cancel();
+        if (task.IsCompleted)
         {
-            heartbeat.Value.Task.Wait(TimeSpan.FromSeconds(1));
+            cts.Dispose();
+            return;
         }
-        catch (AggregateException ex) when (ex.InnerExceptions.All(inner => inner is OperationCanceledException or TaskCanceledException))
-        {
-        }
-        heartbeat.Value.Cts.Dispose();
+
+        _ = task.ContinueWith(
+            static (completedTask, state) =>
+            {
+                if (completedTask.IsFaulted)
+                    _ = completedTask.Exception;
+                ((CancellationTokenSource)state!).Dispose();
+            },
+            cts,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 }

--- a/src/CodeIndex/Cli/IndexWatchRunner.cs
+++ b/src/CodeIndex/Cli/IndexWatchRunner.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.Text;
 using System.Text.Json;
 using CodeIndex.Indexer;
 
@@ -21,6 +22,7 @@ internal static class IndexWatchRunner
     internal const int MaxHumanSummarySubRunJsonChars = 64 * 1024;
     internal const int MaxHumanSummaryJsonDepth = 16;
     internal const int BatchPathSampleLimit = 20;
+    internal const int MaxSubRunArgumentChars = 64 * 1024;
     private const int InternalBufferSize = 64 * 1024;
     private const int PollIntervalMs = 50;
 
@@ -174,14 +176,66 @@ internal static class IndexWatchRunner
         IReadOnlyList<string> changedPaths,
         string resolvedDbPath)
     {
-        var stopwatch = Stopwatch.StartNew();
-        var args = BuildSubRunArgs(baseOptions, resolvedDbPath);
-        args.Add("--files");
-        foreach (var path in changedPaths)
-            args.Add(path);
+        var baseArgs = BuildSubRunArgs(baseOptions, resolvedDbPath);
+        var batches = BuildPartialUpdateBatches(baseArgs, changedPaths);
+        if (batches == null)
+            return RunFullRescan(baseOptions, jsonOptions, resolvedDbPath);
 
-        return InvokeSubRunAndEmit(baseOptions, jsonOptions, args, stopwatch, "updated", changedPaths.Count, "incremental", changedPaths);
+        var exitCode = CommandExitCodes.Success;
+        foreach (var batch in batches)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var args = new List<string>(baseArgs.Count + 1 + batch.Count);
+            args.AddRange(baseArgs);
+            args.Add("--files");
+            args.AddRange(batch);
+
+            var subRunExitCode = InvokeSubRunAndEmit(baseOptions, jsonOptions, args, stopwatch, "updated", batch.Count, "incremental", batch);
+            RecordSubRunExitCode(ref exitCode, subRunExitCode);
+        }
+
+        return exitCode;
     }
+
+    internal static List<List<string>>? BuildPartialUpdateBatches(IReadOnlyList<string> baseArgs, IReadOnlyList<string> changedPaths)
+    {
+        var baseArgumentChars = EstimateSubRunArgumentChars(baseArgs) + EstimateSubRunArgumentChars("--files");
+        var batches = new List<List<string>>();
+        var current = new List<string>();
+        var currentArgumentChars = baseArgumentChars;
+
+        foreach (var path in changedPaths)
+        {
+            var pathArgumentChars = EstimateSubRunArgumentChars(path);
+            if (baseArgumentChars + pathArgumentChars > MaxSubRunArgumentChars)
+                return null;
+
+            if (current.Count > 0 && currentArgumentChars + pathArgumentChars > MaxSubRunArgumentChars)
+            {
+                batches.Add(current);
+                current = new List<string>();
+                currentArgumentChars = baseArgumentChars;
+            }
+
+            current.Add(path);
+            currentArgumentChars += pathArgumentChars;
+        }
+
+        if (current.Count > 0)
+            batches.Add(current);
+        return batches;
+    }
+
+    private static int EstimateSubRunArgumentChars(IEnumerable<string> args)
+    {
+        var total = 0;
+        foreach (var arg in args)
+            total += EstimateSubRunArgumentChars(arg);
+        return total;
+    }
+
+    private static int EstimateSubRunArgumentChars(string arg)
+        => arg.Length + 1;
 
     private static int RunFullRescan(
         IndexCommandOptions baseOptions,
@@ -266,20 +320,41 @@ internal static class IndexWatchRunner
         IReadOnlyList<string>? batchPaths)
     {
         string capturedJson;
+        string? spoolPath = null;
         int subRunExitCode;
         var previousOut = Console.Out;
-        using var captureWriter = new StringWriter();
-        Console.SetOut(captureWriter);
+        WatchSubRunCaptureWriter? captureWriter = null;
         try
         {
-            subRunExitCode = IndexCommandRunner.Run(args.ToArray(), jsonOptions);
+            TextWriter? spoolWriter = null;
+            if (baseOptions.Json)
+            {
+                spoolPath = Path.Combine(Path.GetTempPath(), $"cdidx-watch-subrun-{Guid.NewGuid():N}.jsonl");
+                spoolWriter = new StreamWriter(
+                    new FileStream(spoolPath, FileMode.CreateNew, FileAccess.Write, FileShare.Read),
+                    new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            }
+
+            captureWriter = new WatchSubRunCaptureWriter(MaxHumanSummarySubRunJsonChars + 1, spoolWriter);
+            Console.SetOut(captureWriter);
+            try
+            {
+                subRunExitCode = IndexCommandRunner.Run(args.ToArray(), jsonOptions);
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+            }
+
+            captureWriter.Flush();
+            capturedJson = captureWriter.CapturedText;
         }
         finally
         {
             Console.SetOut(previousOut);
+            captureWriter?.Dispose();
         }
         stopwatch.Stop();
-        capturedJson = captureWriter.ToString();
         var eventStatus = subRunExitCode == CommandExitCodes.Success ? status : "failed";
         var failureReason = subRunExitCode == CommandExitCodes.Success
             ? null
@@ -310,9 +385,16 @@ internal static class IndexWatchRunner
                 Reason = failureReason,
             }, CliJsonSerializerContextFactory.Create(jsonOptions).IndexWatchEventJsonResult));
 
-            var trimmed = capturedJson.TrimEnd('\r', '\n');
-            if (!string.IsNullOrEmpty(trimmed))
-                Console.Out.WriteLine(trimmed);
+            if (!TryWriteSpooledSubRunOutput(spoolPath, out var endedWithLineBreak))
+            {
+                var trimmed = capturedJson.TrimEnd('\r', '\n');
+                if (!string.IsNullOrEmpty(trimmed))
+                    Console.Out.WriteLine(trimmed);
+            }
+            else if (!endedWithLineBreak)
+            {
+                Console.Out.WriteLine();
+            }
         }
         else
         {
@@ -320,8 +402,112 @@ internal static class IndexWatchRunner
             CommandErrorWriter.WriteStderr(human);
         }
 
+        DeleteSpoolFile(spoolPath);
         return subRunExitCode;
     }
+
+    private static bool TryWriteSpooledSubRunOutput(string? spoolPath, out bool endedWithLineBreak)
+    {
+        endedWithLineBreak = true;
+        if (string.IsNullOrWhiteSpace(spoolPath) || !File.Exists(spoolPath) || new FileInfo(spoolPath).Length == 0)
+            return false;
+
+        var buffer = new char[8192];
+        var wroteAny = false;
+        char lastChar = '\0';
+        using var reader = new StreamReader(spoolPath, Encoding.UTF8);
+        int read;
+        while ((read = reader.Read(buffer, 0, buffer.Length)) > 0)
+        {
+            Console.Out.Write(buffer, 0, read);
+            wroteAny = true;
+            lastChar = buffer[read - 1];
+        }
+
+        endedWithLineBreak = !wroteAny || lastChar is '\n' or '\r';
+        return wroteAny;
+    }
+
+    private static void DeleteSpoolFile(string? spoolPath)
+    {
+        if (string.IsNullOrWhiteSpace(spoolPath))
+            return;
+        try
+        {
+            File.Delete(spoolPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+        }
+    }
+
+    internal sealed class WatchSubRunCaptureWriter : TextWriter
+    {
+        private readonly int _maxCapturedChars;
+        private readonly TextWriter? _inner;
+        private readonly StringBuilder _captured = new();
+
+        internal WatchSubRunCaptureWriter(int maxCapturedChars, TextWriter? inner)
+        {
+            _maxCapturedChars = Math.Max(0, maxCapturedChars);
+            _inner = inner;
+        }
+
+        public override Encoding Encoding => _inner?.Encoding ?? Encoding.UTF8;
+
+        internal string CapturedText => _captured.ToString();
+
+        internal bool Truncated { get; private set; }
+
+        public override void Write(char value)
+        {
+            Capture(stackalloc char[] { value });
+            _inner?.Write(value);
+        }
+
+        public override void Write(string? value)
+        {
+            if (value != null)
+                Capture(value.AsSpan());
+            _inner?.Write(value);
+        }
+
+        public override void Write(char[] buffer, int index, int count)
+        {
+            Capture(buffer.AsSpan(index, count));
+            _inner?.Write(buffer, index, count);
+        }
+
+        public override void Flush()
+        {
+            _inner?.Flush();
+            base.Flush();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _inner?.Dispose();
+            base.Dispose(disposing);
+        }
+
+        private void Capture(ReadOnlySpan<char> value)
+        {
+            var remaining = _maxCapturedChars - _captured.Length;
+            if (remaining <= 0)
+            {
+                if (value.Length > 0)
+                    Truncated = true;
+                return;
+            }
+
+            var take = Math.Min(remaining, value.Length);
+            _captured.Append(value[..take]);
+            if (take < value.Length)
+                Truncated = true;
+        }
+    }
+
 
     private static string FormatHumanSummary(string status, int? batchSize, long elapsedMs, string subRunJson, int exitCode)
     {

--- a/src/CodeIndex/Cli/IndexWatchRunner.cs
+++ b/src/CodeIndex/Cli/IndexWatchRunner.cs
@@ -59,6 +59,18 @@ internal static class IndexWatchRunner
         string projectRoot,
         string resolvedDbPath,
         CancellationToken cancellationToken)
+        // Preserve the existing synchronous CLI/test entry point while the watch loop itself
+        // runs through RunCoreAsync so cancellation does not block on Task.Delay.
+        => RunCoreAsync(baseOptions, jsonOptions, projectRoot, resolvedDbPath, cancellationToken)
+            .GetAwaiter()
+            .GetResult();
+
+    internal static async Task<int> RunCoreAsync(
+        IndexCommandOptions baseOptions,
+        JsonSerializerOptions jsonOptions,
+        string projectRoot,
+        string resolvedDbPath,
+        CancellationToken cancellationToken)
     {
         var debounce = TimeSpan.FromMilliseconds(baseOptions.WatchDebounceMs ?? DefaultDebounceMs);
         var maxPendingPaths = baseOptions.WatchPendingPathLimit;
@@ -134,7 +146,7 @@ internal static class IndexWatchRunner
             {
                 try
                 {
-                    Task.Delay(PollIntervalMs, cancellationToken).GetAwaiter().GetResult();
+                    await Task.Delay(PollIntervalMs, cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -2397,16 +2397,22 @@ public static partial class QueryCommandRunner
     private static bool TryParseSearchCursor(string value, out SearchCursor cursor)
     {
         cursor = default;
-        var parts = value.Split(':');
-        if (parts.Length != 3)
+        var lastSeparator = value.LastIndexOf(':');
+        if (lastSeparator <= 0 || lastSeparator == value.Length - 1)
             return false;
-        if (!double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var score) ||
-            !long.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var chunkId) ||
-            !int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var offset) ||
-            offset < 0)
-        {
+
+        var firstSeparator = value.LastIndexOf(':', lastSeparator - 1);
+        if (firstSeparator <= 0 || firstSeparator == lastSeparator - 1)
             return false;
-        }
+
+        if (!double.TryParse(value.AsSpan(0, firstSeparator), NumberStyles.Float, CultureInfo.InvariantCulture, out var score)
+            || !double.IsFinite(score))
+            return false;
+        if (!long.TryParse(value.AsSpan(firstSeparator + 1, lastSeparator - firstSeparator - 1), NumberStyles.None, CultureInfo.InvariantCulture, out var chunkId)
+            || chunkId < 0)
+            return false;
+        if (!int.TryParse(value.AsSpan(lastSeparator + 1), NumberStyles.None, CultureInfo.InvariantCulture, out var offset) || offset < 0)
+            return false;
 
         cursor = new SearchCursor(score, chunkId, offset);
         return true;

--- a/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
+++ b/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
@@ -121,6 +121,8 @@ internal sealed class PostExtractionHookCallbackWorkerClient : IDisposable
             }
 
             stopwatch.Stop();
+            // WaitForTask already proved the async read completed within the callback budget;
+            // GetResult only observes that completed protocol response on this sync API.
             var responseJson = responseTask.GetAwaiter().GetResult();
             if (responseJson == null)
             {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
@@ -107,6 +107,8 @@ internal sealed class SymbolExtractionWorkerClient : IDisposable
             }
 
             stopwatch.Stop();
+            // WaitForTask already proved the async read completed within the worker budget;
+            // GetResult only observes that completed protocol response on this sync API.
             var responseJson = responseTask.GetAwaiter().GetResult();
             if (responseJson == null)
             {

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -598,6 +598,7 @@ public partial class McpServer : IDisposable
 
         while (_running)
         {
+            PruneCompletedRequestTasks(tasks);
             string? frame;
             try
             {
@@ -735,6 +736,38 @@ public partial class McpServer : IDisposable
 
         await DrainInFlightTasksAsync(tasks, DefaultEofDrainTimeout, DefaultEofPostCancelDrainTimeout, loopToken).ConfigureAwait(false);
         CommandErrorWriter.WriteStderr("[cdidx-mcp] Server stopped. Restart `cdidx mcp` when your client reconnects.");
+    }
+
+    internal static int PruneCompletedRequestTasks(List<Task> tasks)
+    {
+        var removed = 0;
+        for (var i = tasks.Count - 1; i >= 0; i--)
+        {
+            var task = tasks[i];
+            if (!task.IsCompleted)
+                continue;
+
+            ObserveCompletedRequestTask(task);
+            tasks.RemoveAt(i);
+            removed++;
+        }
+
+        return removed;
+    }
+
+    private static void ObserveCompletedRequestTask(Task task)
+    {
+        if (!task.IsFaulted)
+            return;
+
+        try
+        {
+            task.GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            CommandErrorWriter.WriteStderr($"[cdidx-mcp] In-flight request ended before EOF drain ({ex.GetType().Name}).");
+        }
     }
 
     internal async Task DrainInFlightTasksAsync(

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -971,6 +971,8 @@ public partial class McpServer : IDisposable
     /// <see cref="IMcpTransport"/> 実装が共有するトランスポート非依存の合流点 (issue #1558)。
     /// </summary>
     internal string? ProcessFrame(string line)
+        // Synchronous callers are compatibility entry points for tests and non-async hosts;
+        // transport loops use ProcessFrameAsync directly so request handling stays async.
         => ProcessFrameAsync(line).GetAwaiter().GetResult();
 
     internal async Task<string?> ProcessFrameAsync(string line)
@@ -1345,6 +1347,8 @@ public partial class McpServer : IDisposable
     /// JSON-RPCメッセージを適切なハンドラにルーティング。
     /// </summary>
     internal JsonNode? HandleMessage(JsonNode request)
+        // Keep this sync wrapper for existing in-process callers; async transports call
+        // HandleMessageAsync so server loops do not need a sync-over-async bridge.
         => HandleMessageAsync(request, isolateRequestDb: false).GetAwaiter().GetResult();
 
     internal Task<JsonNode?> HandleMessageAsync(JsonNode request)

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -84,6 +84,21 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void StopObservedJsonPhaseHeartbeat_CancelsPendingTaskWithoutBlocking_Issue3771()
+    {
+        var cts = new CancellationTokenSource();
+        var pending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stopwatch = Stopwatch.StartNew();
+
+        IndexCommandRunner.StopObservedJsonPhaseHeartbeat((cts, pending.Task));
+
+        stopwatch.Stop();
+        Assert.True(cts.IsCancellationRequested);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1));
+        pending.SetResult();
+    }
+
+    [Fact]
     public void ParseArgs_HelpFlagSetsShowHelp()
     {
         var options = IndexCommandRunner.ParseArgs(["--help"]);

--- a/tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
@@ -203,6 +203,47 @@ public class IndexWatchRunnerTests
     }
 
     [Fact]
+    public void BuildPartialUpdateBatches_SplitsBeforeArgumentLimit_Issue3803()
+    {
+        var baseArgs = new List<string> { "/repo", "--json", "--quiet" };
+        var longPath = "/" + new string('a', IndexWatchRunner.MaxSubRunArgumentChars / 2);
+
+        var batches = IndexWatchRunner.BuildPartialUpdateBatches(
+            baseArgs,
+            [longPath + "1", longPath + "2", longPath + "3"]);
+
+        Assert.NotNull(batches);
+        Assert.Equal(3, batches.Count);
+        Assert.All(batches, batch => Assert.Single(batch));
+    }
+
+    [Fact]
+    public void BuildPartialUpdateBatches_OversizedSinglePathRequestsFullRescan_Issue3803()
+    {
+        var baseArgs = new List<string> { "/repo", "--json", "--quiet" };
+        var oversizedPath = "/" + new string('p', IndexWatchRunner.MaxSubRunArgumentChars);
+
+        var batches = IndexWatchRunner.BuildPartialUpdateBatches(baseArgs, [oversizedPath]);
+
+        Assert.Null(batches);
+    }
+
+    [Fact]
+    public void WatchSubRunCaptureWriter_CapsCaptureAndPreservesSpooledOutput_Issue3803()
+    {
+        using var spool = new StringWriter();
+        using var writer = new IndexWatchRunner.WatchSubRunCaptureWriter(10, spool);
+        var payload = new string('x', 32);
+
+        writer.Write(payload);
+        writer.Flush();
+
+        Assert.Equal(new string('x', 10), writer.CapturedText);
+        Assert.True(writer.Truncated);
+        Assert.Equal(payload, spool.ToString());
+    }
+
+    [Fact]
     public void InvokeSubRunAndEmit_JsonSubRunFailure_EmitsFailedStatusAndExitCode()
     {
         var projectRoot = CreateTempProject();

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -110,6 +110,50 @@ public class McpServerTests : IDisposable
         Assert.False(MethodCallsType(method!, typeof(SpinWait)));
     }
 
+    [Fact]
+    public void PruneCompletedRequestTasks_RemovesCompletedTasks_Issue3837()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var pending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tasks = new List<Task>
+        {
+            Task.CompletedTask,
+            pending.Task,
+            Task.FromCanceled(cts.Token),
+        };
+
+        var removed = McpServer.PruneCompletedRequestTasks(tasks);
+
+        Assert.Equal(2, removed);
+        Assert.Same(pending.Task, Assert.Single(tasks));
+    }
+
+    [Fact]
+    public void PruneCompletedRequestTasks_ObservesFaultedTasks_Issue3837()
+    {
+        var pending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var faulted = Task.FromException(new InvalidOperationException("boom"));
+        var tasks = new List<Task> { pending.Task, faulted };
+        var originalError = Console.Error;
+        using var stderr = new StringWriter();
+        Console.SetError(stderr);
+
+        int removed;
+        try
+        {
+            removed = McpServer.PruneCompletedRequestTasks(tasks);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+
+        Assert.Equal(1, removed);
+        Assert.Same(pending.Task, Assert.Single(tasks));
+        Assert.Contains("In-flight request ended before EOF drain (InvalidOperationException)", stderr.ToString(), StringComparison.Ordinal);
+    }
+
     private static bool MethodCallsType(MethodInfo method, Type declaringType)
     {
         var body = method.GetMethodBody()?.GetILAsByteArray();

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -1457,6 +1457,22 @@ public partial class QueryCommandRunnerTests
         Assert.Contains("--json=array is not supported with --list-recipes", stderr);
     }
 
+    [Theory]
+    [InlineData("NaN:1:0")]
+    [InlineData("Infinity:1:0")]
+    [InlineData("1:-1:0")]
+    [InlineData("1:1:-1")]
+    public void RunSearch_RecipeInvalidCursorDomain_ReturnsUsageError_Issue3837(string cursor)
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+            ["--recipe", "risky-code/raw-diagnostic-echo", "--cursor", cursor],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("--cursor", stderr, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void RunSearch_RecipeJsonRunsBuiltInQueries_Issue3144()
     {


### PR DESCRIPTION
## Summary
- Bound watch partial-update batching and sub-run output capture/spooling.
- Harden CLI cursor validation and MCP completed request-task pruning, including fault observation.
- Share nonblocking index heartbeat shutdown and reduce sync-over-async waits in watch/server worker paths.

## Validation
- `dotnet build src/CodeIndex/CodeIndex.csproj -p:UseSharedCompilation=false -m:1`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net8.0 --filter "FullyQualifiedName~IndexWatchRunnerTests|FullyQualifiedName~RunSearch_RecipeInvalidCursorDomain|FullyQualifiedName~PruneCompletedRequestTasks|FullyQualifiedName~StopObservedJsonPhaseHeartbeat" -p:UseSharedCompilation=false -m:1`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check origin/main..HEAD`
- Codex adversarial review: initial P2 on MCP faulted-task pruning was fixed; rerun found no blocking/correctness regression.

## Notes
- Local cdidx index rebuild/status could not be used for final code search validation in this environment; rebuild attempts ended with `E012_INTERRUPTED`.

Fixes #3837
Fixes #3803
Fixes #3771
Fixes #3677
