### PR TITLE
Cap extraction fanout budgets

### DIFF
--- a/changelog.d/unreleased/3734.fixed.md
+++ b/changelog.d/unreleased/3734.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3734
+affected:
+  - src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
+  - tests/CodeIndex.Tests/PostExtractionHookTests.cs
+---
+
+## English
+
+- **Post-extraction hook budgets are now clamped (#3734)** — oversized callback, discovery result, and discovery byte budgets are reduced to bounded limits and reported as config diagnostics instead of allowing unbounded hook work.
+
+## 日本語
+
+- **post-extraction hook の予算を上限内に clamp するようになりました (#3734)** — 過大な callback、discovery result、discovery byte の予算は bounded な上限まで縮小され、無制限な hook 処理を許さず config diagnostic として報告します。

--- a/changelog.d/unreleased/3744.fixed.md
+++ b/changelog.d/unreleased/3744.fixed.md
@@ -1,0 +1,22 @@
+---
+category: fixed
+issues:
+  - 3744
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - src/CodeIndex/Indexer/Extensibility/ExtractionContext.cs
+  - src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
+  - src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/PostExtractionHookTests.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Plugin reference extraction and hook callbacks now materialize bounded payloads (#3744)** — reference plugins receive the active per-file reference budget, oversized plugin output is truncated with diagnostics, and hook callback input/output symbol and reference payloads are capped.
+
+## 日本語
+
+- **plugin reference extraction と hook callback の materialized payload に上限を追加しました (#3744)** — reference plugin は有効な per-file reference 予算を受け取り、過大な plugin 出力は diagnostic 付きで切り詰められ、hook callback の入出力 symbol/reference payload も上限管理されます。

--- a/changelog.d/unreleased/3764.fixed.md
+++ b/changelog.d/unreleased/3764.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3764
+affected:
+  - src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.TypeScriptPathAliases.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **TypeScript alias and language-map override fanout is now capped (#3764)** — TypeScript path alias resolution stops after a bounded expansion-candidate budget, and language-map override files now cap extension pattern counts in addition to bytes, lines, and loaded entries.
+
+## 日本語
+
+- **TypeScript alias と language-map override の fanout に上限を追加しました (#3764)** — TypeScript path alias 解決は bounded な expansion candidate 予算で停止し、language-map override file は byte、line、loaded entry に加えて extension pattern 数も上限管理します。

--- a/changelog.d/unreleased/3765.fixed.md
+++ b/changelog.d/unreleased/3765.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3765
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Dockerfile.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Structured-data and Dockerfile symbol extraction now caps fanout (#3765)** — JSON, YAML, XML/XAML, and Dockerfile JSON-form extraction stop at bounded traversal, symbol, body, and array budgets while emitting diagnostic symbols when output is truncated.
+
+## 日本語
+
+- **structured-data と Dockerfile の symbol extraction fanout に上限を追加しました (#3765)** — JSON、YAML、XML/XAML、Dockerfile JSON form の抽出は traversal、symbol、body、array の bounded な予算で停止し、出力を切り詰めた場合は diagnostic symbol を出します。

--- a/changelog.d/unreleased/3783.fixed.md
+++ b/changelog.d/unreleased/3783.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3783
+affected:
+  - src/CodeIndex/Indexer/References/ReferenceExtractionContext.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.Core.cs
+  - src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+  - tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+---
+
+## English
+
+- **Reference extractor lookup fanout is now bounded (#3783)** — high-cardinality symbol inputs cap definition, container, enclosing-type, and Swift property lookup materialization and report bounded diagnostics when lookup work is truncated.
+
+## 日本語
+
+- **reference extractor の lookup fanout に上限を追加しました (#3783)** — 高 cardinality の symbol 入力では definition、container、enclosing type、Swift property lookup の materialization を上限管理し、lookup 作業を切り詰めた場合は bounded な diagnostic を報告します。

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -56,6 +56,26 @@ public static partial class IndexCommandRunner
             Message = $"Reference extraction produced {referenceCount:N0} references, exceeding the --max-references-per-file limit of {maxReferencesPerFile:N0}; references were not indexed for this file. Exclude the generated/pathological file or raise --max-references-per-file if this is expected.",
         };
 
+    private static IReadOnlyList<FileIssue> AppendReferenceExtractionDiagnosticIssues(
+        IReadOnlyList<FileIssue> issues,
+        string path,
+        IReadOnlyList<ReferenceExtractionDiagnostic> diagnostics)
+    {
+        foreach (var diagnostic in diagnostics)
+        {
+            issues = AppendIssue(issues, new FileIssue
+            {
+                Path = path,
+                Kind = diagnostic.Kind,
+                Line = 0,
+                Message = diagnostic.Message,
+                Severity = FileIssue.SeverityWarning,
+            });
+        }
+
+        return issues;
+    }
+
     internal static FileIssue BuildNullByteIssue(FileIndexer.BinaryFileSkippedException ex) =>
         new()
         {
@@ -924,7 +944,10 @@ public static partial class IndexCommandRunner
         var activeJsonExtractionPhases = new ConcurrentDictionary<int, string>();
         CancellationTokenSource? jsonHeartbeatCts = null;
         Task? jsonHeartbeatTask = null;
-        using var postExtractionHooks = PostExtractionHookRunner.DiscoverDefault(options.MaxFileSizeBytes);
+        using var postExtractionHooks = PostExtractionHookRunner.DiscoverDefault(
+            options.MaxFileSizeBytes,
+            maxSymbolCount: options.MaxSymbolsPerFile + 1,
+            maxReferenceCount: options.MaxReferencesPerFile + 1);
         var extractionParallelism = Math.Max(1, options.Parallelism);
         var hasPostExtractionHooks = postExtractionHooks.Hooks.Count > 0;
         var existingFileCount = writer.GetCounts().files;
@@ -1185,6 +1208,7 @@ public static partial class IndexCommandRunner
                                 }
                                 SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(filePath, record.Lang));
                                 FileIssue? referenceRegexTimeoutIssue = null;
+                                ReferenceExtractionResult? referenceExtraction = null;
                                 if (options.SymbolsOnly)
                                 {
                                     references = [];
@@ -1193,7 +1217,7 @@ public static partial class IndexCommandRunner
                                 {
                                     activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(record.Path, "references");
                                     using var regexTimeouts = BoundedRegex.CaptureTimeouts(record.Lang, "reference_extraction");
-                                    references = ReferenceExtractor.Extract(
+                                    referenceExtraction = ReferenceExtractor.ExtractDetailed(
                                         0,
                                         record.Lang,
                                         content,
@@ -1202,6 +1226,7 @@ public static partial class IndexCommandRunner
                                         record.Lang == "csharp" ? csharpWorkspace.Symbols : null,
                                         extractionCancellationToken,
                                         maxReferenceCount: options.MaxReferencesPerFile + 1);
+                                    references = referenceExtraction.References;
                                     referenceRegexTimeoutIssue = BuildRegexTimeoutIssue(record.Path, regexTimeouts);
                                 }
                                 activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(record.Path, "validating");
@@ -1210,6 +1235,8 @@ public static partial class IndexCommandRunner
                                     issues = AppendIssue(issues, symbolRegexTimeoutIssue);
                                 if (referenceRegexTimeoutIssue != null)
                                     issues = AppendIssue(issues, referenceRegexTimeoutIssue);
+                                if (referenceExtraction != null)
+                                    issues = AppendReferenceExtractionDiagnosticIssues(issues, record.Path, referenceExtraction.Diagnostics);
                                 if (references.Count > options.MaxReferencesPerFile)
                                 {
                                     var issue = BuildReferenceCountExceededIssue(record.Path, references.Count, options.MaxReferencesPerFile);
@@ -1525,10 +1552,11 @@ public static partial class IndexCommandRunner
                     else
                     {
                         FileIssue? regexTimeoutIssue = null;
+                        ReferenceExtractionResult? referenceExtraction = null;
                         if (item.References == null)
                         {
                             using var regexTimeouts = BoundedRegex.CaptureTimeouts(record.Lang, "reference_extraction");
-                            references = ReferenceExtractor.Extract(
+                            referenceExtraction = ReferenceExtractor.ExtractDetailed(
                                 fileId,
                                 record.Lang,
                                 item.Content!,
@@ -1537,6 +1565,7 @@ public static partial class IndexCommandRunner
                                 record.Lang == "csharp" ? csharpWorkspace.Symbols : null,
                                 cancellationToken,
                                 maxReferenceCount: options.MaxReferencesPerFile + 1);
+                            references = referenceExtraction.References;
                             regexTimeoutIssue = BuildRegexTimeoutIssue(record.Path, regexTimeouts);
                         }
                         else
@@ -1548,6 +1577,14 @@ public static partial class IndexCommandRunner
                         {
                             var baseIssues = item.Issues ?? FileIndexer.ValidateContent(record.Path, item.RawBytes!, item.Content!, record.Lang);
                             item = item with { Issues = AppendIssue(baseIssues, regexTimeoutIssue) };
+                        }
+                        if (referenceExtraction != null)
+                        {
+                            var baseIssues = item.Issues ?? FileIndexer.ValidateContent(record.Path, item.RawBytes!, item.Content!, record.Lang);
+                            item = item with
+                            {
+                                Issues = AppendReferenceExtractionDiagnosticIssues(baseIssues, record.Path, referenceExtraction.Diagnostics),
+                            };
                         }
                         if (references.Count > options.MaxReferencesPerFile)
                         {

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -135,7 +135,10 @@ public static partial class IndexCommandRunner
         var ftsMutated = false;
         var purgedRefs = 0;
         var supportedGraphLanguages = ReferenceExtractor.GetSupportedLanguages();
-        using var postExtractionHooks = PostExtractionHookRunner.DiscoverDefault(options.MaxFileSizeBytes);
+        using var postExtractionHooks = PostExtractionHookRunner.DiscoverDefault(
+            options.MaxFileSizeBytes,
+            maxSymbolCount: options.MaxSymbolsPerFile + 1,
+            maxReferenceCount: options.MaxReferencesPerFile + 1);
         var currentFoldVersion = NameFold.Version.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var currentFoldFingerprint = NameFold.Fingerprint();
         var currentCSharpSymbolNameContractVersion = DbContext.CSharpSymbolNameContractVersion.ToString(System.Globalization.CultureInfo.InvariantCulture);
@@ -748,9 +751,10 @@ public static partial class IndexCommandRunner
                     currentUpdatePath = FormatIndexPhasePath(relPath, "references");
                     List<ReferenceRecord> references;
                     FileIssue? referenceRegexTimeoutIssue;
+                    ReferenceExtractionResult referenceExtraction;
                     using (var regexTimeouts = BoundedRegex.CaptureTimeouts(record.Lang, "reference_extraction"))
                     {
-                        references = ReferenceExtractor.Extract(
+                        referenceExtraction = ReferenceExtractor.ExtractDetailed(
                             fileId,
                             record.Lang,
                             content,
@@ -759,6 +763,7 @@ public static partial class IndexCommandRunner
                             record.Lang == "csharp" ? csharpWorkspace.Symbols : null,
                             cancellationToken,
                             maxReferenceCount: options.MaxReferencesPerFile + 1);
+                        references = referenceExtraction.References;
                         referenceRegexTimeoutIssue = BuildRegexTimeoutIssue(record.Path, regexTimeouts);
                     }
                     postExtractionHooks.OnReferencesExtracted(fileContext, references);
@@ -776,6 +781,7 @@ public static partial class IndexCommandRunner
                         issues = AppendIssue(issues, symbolRegexTimeoutIssue);
                     if (referenceRegexTimeoutIssue != null)
                         issues = AppendIssue(issues, referenceRegexTimeoutIssue);
+                    issues = AppendReferenceExtractionDiagnosticIssues(issues, record.Path, referenceExtraction.Diagnostics);
                     if (referenceCapIssue != null)
                         issues = AppendIssue(issues, referenceCapIssue);
                     writer.InsertIssues(fileId, issues);

--- a/src/CodeIndex/Indexer/Extensibility/ExtractionContext.cs
+++ b/src/CodeIndex/Indexer/Extensibility/ExtractionContext.cs
@@ -6,4 +6,5 @@ public sealed record ExtractionContext(
     string Language,
     string? FilePath,
     IReadOnlyList<SymbolRecord>? FileSymbols = null,
-    IReadOnlyList<SymbolRecord>? WorkspaceSymbols = null);
+    IReadOnlyList<SymbolRecord>? WorkspaceSymbols = null,
+    int? MaxReferenceCount = null);

--- a/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
+++ b/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
@@ -25,7 +25,9 @@ internal sealed record PostExtractionHookCallbackResult(
     string? CallbackError,
     long DurationMs,
     List<SymbolRecord>? Symbols,
-    List<ReferenceRecord>? References);
+    List<ReferenceRecord>? References,
+    bool SymbolsTruncated = false,
+    bool ReferencesTruncated = false);
 
 internal sealed class PostExtractionHookCallbackWorkerClient : IDisposable
 {
@@ -48,7 +50,9 @@ internal sealed class PostExtractionHookCallbackWorkerClient : IDisposable
         FileContext context,
         IReadOnlyList<SymbolRecord>? symbols,
         IReadOnlyList<ReferenceRecord>? references,
-        TimeSpan callbackBudget)
+        TimeSpan callbackBudget,
+        int? maxSymbols = null,
+        int? maxReferences = null)
     {
         lock (gate)
         {
@@ -64,7 +68,9 @@ internal sealed class PostExtractionHookCallbackWorkerClient : IDisposable
                 callback,
                 context,
                 symbols?.ToList(),
-                references?.ToList());
+                references?.ToList(),
+                maxSymbols,
+                maxReferences);
             var requestJson = JsonSerializer.Serialize(request, PostExtractionHookCallbackWorker.JsonOptions);
             var waitMilliseconds = GetRemainingWaitMilliseconds(stopwatch, callbackBudget);
             if (waitMilliseconds <= 0)
@@ -159,7 +165,9 @@ internal sealed class PostExtractionHookCallbackWorkerClient : IDisposable
                 CallbackError: response.CallbackError,
                 DurationMs: stopwatch.ElapsedMilliseconds,
                 Symbols: response.Symbols,
-                References: response.References);
+                References: response.References,
+                SymbolsTruncated: response.SymbolsTruncated,
+                ReferencesTruncated: response.ReferencesTruncated);
         }
     }
 
@@ -604,11 +612,24 @@ internal static class PostExtractionHookCallbackWorker
             Console.SetError(originalError);
         }
 
+        var symbolsTruncated = TrimToLimit(request.Symbols, request.MaxSymbols);
+        var referencesTruncated = TrimToLimit(request.References, request.MaxReferences);
         return new WorkerResponse(
             request.Symbols,
             request.References,
             callbackFailure is null ? null : SafeDiagnosticFormatter.FormatExceptionCategory("hook_callback_failed", callbackFailure),
-            null);
+            null,
+            symbolsTruncated,
+            referencesTruncated);
+    }
+
+    private static bool TrimToLimit<T>(List<T>? items, int? maxCount)
+    {
+        if (items == null || maxCount is not { } limit || limit <= 0 || items.Count <= limit)
+            return false;
+
+        items.RemoveRange(limit, items.Count - limit);
+        return true;
     }
 
     private static void AddProtocolLineLimitArguments(ProcessStartInfo startInfo, int maxProtocolLineBytes)
@@ -649,13 +670,17 @@ internal static class PostExtractionHookCallbackWorker
         string Callback,
         FileContext Context,
         List<SymbolRecord>? Symbols,
-        List<ReferenceRecord>? References);
+        List<ReferenceRecord>? References,
+        int? MaxSymbols = null,
+        int? MaxReferences = null);
 
     internal sealed record WorkerResponse(
         List<SymbolRecord>? Symbols,
         List<ReferenceRecord>? References,
         string? CallbackError,
-        string? WorkerError);
+        string? WorkerError,
+        bool SymbolsTruncated = false,
+        bool ReferencesTruncated = false);
 }
 
 [JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]

--- a/src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
+++ b/src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
@@ -44,26 +44,40 @@ public sealed class PostExtractionHookRunner : IDisposable
     public static readonly TimeSpan DefaultCallbackBudget = TimeSpan.FromSeconds(5);
     internal const int DefaultDiscoveryLimit = 128;
     internal const long DefaultDiscoveryMaxBytes = 64 * 1024 * 1024;
+    internal const int MaxCallbackBudgetMilliseconds = 60_000;
+    internal const int MaxDiscoveryLimit = 4096;
+    internal const long MaxDiscoveryMaxBytes = 512L * 1024 * 1024;
 
     private readonly List<LoadedPostExtractionHook> hooks;
     private readonly ConcurrentQueue<PostExtractionHookDiagnostic> diagnostics = new();
     private readonly ConcurrentDictionary<string, byte> disabledHooks = new(StringComparer.Ordinal);
     private readonly TimeSpan callbackBudget;
+    private readonly int? maxSymbolCount;
+    private readonly int? maxReferenceCount;
     private bool disposed;
     internal static Func<TimeSpan>? CallbackBudgetForTesting { get; set; }
     internal static Func<int>? DiscoveryLimitForTesting { get; set; }
     internal static Func<long>? DiscoveryMaxBytesForTesting { get; set; }
 
-    private PostExtractionHookRunner(List<LoadedPostExtractionHook> hooks, TimeSpan callbackBudget)
+    private PostExtractionHookRunner(
+        List<LoadedPostExtractionHook> hooks,
+        TimeSpan callbackBudget,
+        int? maxSymbolCount,
+        int? maxReferenceCount)
     {
         this.hooks = hooks;
         this.callbackBudget = callbackBudget;
+        this.maxSymbolCount = maxSymbolCount;
+        this.maxReferenceCount = maxReferenceCount;
     }
 
-    public static PostExtractionHookRunner DiscoverDefault(long? maxFileSizeBytes = null)
+    public static PostExtractionHookRunner DiscoverDefault(
+        long? maxFileSizeBytes = null,
+        int? maxSymbolCount = null,
+        int? maxReferenceCount = null)
     {
         var resolution = ResolveDefaultHooksDirectory(includeAcceptedOverrideDiagnostic: false);
-        return Discover(resolution.Directory, maxFileSizeBytes, resolution.Diagnostics);
+        return Discover(resolution.Directory, maxFileSizeBytes, resolution.Diagnostics, maxSymbolCount, maxReferenceCount);
     }
 
     public static PostExtractionHookDiscoverySnapshot DiscoverDefaultMetadata()
@@ -81,12 +95,16 @@ public sealed class PostExtractionHookRunner : IDisposable
         IReadOnlyList<ExtensionTrustOverride> initialTrustOverrides)
     {
         var loaded = new List<LoadedPostExtractionHook>();
-        var runner = new PostExtractionHookRunner(loaded, ResolveCallbackBudget());
+        var callbackBudget = ResolveCallbackBudget();
+        var runner = new PostExtractionHookRunner(loaded, callbackBudget.Value, null, null);
+        runner.EnqueueDiagnostic(callbackBudget.Diagnostic);
         runner.EnqueueDiagnostics(initialDiagnostics);
+        var discoveryLimit = ResolveDiscoveryLimit();
+        runner.EnqueueDiagnostic(discoveryLimit.Diagnostic);
         if (string.IsNullOrWhiteSpace(hooksDirectory) || !Directory.Exists(hooksDirectory))
             return new PostExtractionHookDiscoverySnapshot([], runner.Diagnostics, runner.CallbackBudget, initialTrustOverrides);
 
-        var hooks = EnumerateHookAssemblyPaths(hooksDirectory, runner, ResolveDiscoveryLimit())
+        var hooks = EnumerateHookAssemblyPaths(hooksDirectory, runner, discoveryLimit.Value)
             .Select(dllPath =>
             {
                 var fullPath = Path.GetFullPath(dllPath);
@@ -100,29 +118,44 @@ public sealed class PostExtractionHookRunner : IDisposable
         return new PostExtractionHookDiscoverySnapshot(hooks, runner.Diagnostics, runner.CallbackBudget, initialTrustOverrides);
     }
 
-    public static PostExtractionHookRunner Discover(string? hooksDirectory, long? maxFileSizeBytes = null)
-        => Discover(hooksDirectory, maxFileSizeBytes, []);
+    public static PostExtractionHookRunner Discover(
+        string? hooksDirectory,
+        long? maxFileSizeBytes = null,
+        int? maxSymbolCount = null,
+        int? maxReferenceCount = null)
+        => Discover(hooksDirectory, maxFileSizeBytes, [], maxSymbolCount, maxReferenceCount);
 
     private static PostExtractionHookRunner Discover(
         string? hooksDirectory,
         long? maxFileSizeBytes,
-        IReadOnlyList<PostExtractionHookDiagnostic> initialDiagnostics)
+        IReadOnlyList<PostExtractionHookDiagnostic> initialDiagnostics,
+        int? maxSymbolCount,
+        int? maxReferenceCount)
     {
         var loaded = new List<LoadedPostExtractionHook>();
-        var runner = new PostExtractionHookRunner(loaded, ResolveCallbackBudget());
+        var callbackBudget = ResolveCallbackBudget();
+        var runner = new PostExtractionHookRunner(
+            loaded,
+            callbackBudget.Value,
+            NormalizeHookMaterializationLimit(maxSymbolCount),
+            NormalizeHookMaterializationLimit(maxReferenceCount));
+        runner.EnqueueDiagnostic(callbackBudget.Diagnostic);
         runner.EnqueueDiagnostics(initialDiagnostics);
         var maxProtocolLineBytes = WorkerProtocolLineLimits.ResolveForSourceFileBytes(maxFileSizeBytes);
+        var discoveryLimit = ResolveDiscoveryLimit();
+        runner.EnqueueDiagnostic(discoveryLimit.Diagnostic);
 
         if (string.IsNullOrWhiteSpace(hooksDirectory) || !Directory.Exists(hooksDirectory))
             return runner;
 
         var maxAssemblyBytes = ResolveDiscoveryMaxBytes();
-        foreach (var dllPath in EnumerateHookAssemblyPaths(hooksDirectory, runner, ResolveDiscoveryLimit()))
+        runner.EnqueueDiagnostic(maxAssemblyBytes.Diagnostic);
+        foreach (var dllPath in EnumerateHookAssemblyPaths(hooksDirectory, runner, discoveryLimit.Value))
         {
             Assembly assembly;
             try
             {
-                if (!HookAssemblyCandidateIsWithinBudget(dllPath, runner, maxAssemblyBytes))
+                if (!HookAssemblyCandidateIsWithinBudget(dllPath, runner, maxAssemblyBytes.Value))
                     continue;
 
                 var loadContext = new ExtensionAssemblyLoadContext(
@@ -331,13 +364,24 @@ public sealed class PostExtractionHookRunner : IDisposable
 
         foreach (var hook in hooks)
         {
-            var workingSymbols = CloneSymbols(symbols);
+            var workingSymbols = CloneSymbols(symbols, maxSymbolCount, out var inputTruncated);
+            if (inputTruncated && maxSymbolCount is { } symbolLimit)
+            {
+                EnqueueHookMaterializationDiagnostic(
+                    hook,
+                    nameof(IPostExtractionHook.OnSymbolsExtracted),
+                    "symbol",
+                    symbolLimit,
+                    "input");
+            }
             if (InvokeHookWithBudget(
                     hook,
                     PostExtractionHookCallbackKind.Symbols,
                     nameof(IPostExtractionHook.OnSymbolsExtracted),
                     context,
                     workingSymbols,
+                    null,
+                    maxSymbolCount,
                     null))
             {
                 ReplaceList(symbols, workingSymbols);
@@ -351,14 +395,25 @@ public sealed class PostExtractionHookRunner : IDisposable
 
         foreach (var hook in hooks)
         {
-            var workingReferences = CloneReferences(references);
+            var workingReferences = CloneReferences(references, maxReferenceCount, out var inputTruncated);
+            if (inputTruncated && maxReferenceCount is { } referenceLimit)
+            {
+                EnqueueHookMaterializationDiagnostic(
+                    hook,
+                    nameof(IPostExtractionHook.OnReferencesExtracted),
+                    "reference",
+                    referenceLimit,
+                    "input");
+            }
             if (InvokeHookWithBudget(
                     hook,
                     PostExtractionHookCallbackKind.References,
                     nameof(IPostExtractionHook.OnReferencesExtracted),
                     context,
                     null,
-                    workingReferences))
+                    workingReferences,
+                    null,
+                    maxReferenceCount))
             {
                 ReplaceList(references, workingReferences);
             }
@@ -371,7 +426,9 @@ public sealed class PostExtractionHookRunner : IDisposable
         string callback,
         FileContext context,
         List<SymbolRecord>? symbols,
-        List<ReferenceRecord>? references)
+        List<ReferenceRecord>? references,
+        int? maxSymbols,
+        int? maxReferences)
     {
         if (disabledHooks.ContainsKey(hook.Info.TypeName))
             return false;
@@ -382,7 +439,9 @@ public sealed class PostExtractionHookRunner : IDisposable
             context,
             symbols,
             references,
-            callbackBudget);
+            callbackBudget,
+            maxSymbols,
+            maxReferences);
         if (result.TimedOut)
         {
             disabledHooks.TryAdd(hook.Info.TypeName, 0);
@@ -414,9 +473,31 @@ public sealed class PostExtractionHookRunner : IDisposable
         }
 
         if (result.Symbols != null && symbols != null)
+        {
+            if (result.SymbolsTruncated && maxSymbols is { } symbolLimit)
+            {
+                EnqueueHookMaterializationDiagnostic(
+                    hook,
+                    callback,
+                    "symbol",
+                    symbolLimit,
+                    "output");
+            }
             ReplaceList(symbols, result.Symbols);
+        }
         if (result.References != null && references != null)
+        {
+            if (result.ReferencesTruncated && maxReferences is { } referenceLimit)
+            {
+                EnqueueHookMaterializationDiagnostic(
+                    hook,
+                    callback,
+                    "reference",
+                    referenceLimit,
+                    "output");
+            }
             ReplaceList(references, result.References);
+        }
 
         if (result.CallbackError != null)
         {
@@ -469,13 +550,37 @@ public sealed class PostExtractionHookRunner : IDisposable
         diagnostics.Enqueue(CreateDiagnostic(assemblyPath, typeName, message, callback, durationMs, category));
     }
 
+    private void EnqueueDiagnostic(PostExtractionHookDiagnostic? diagnostic)
+    {
+        if (diagnostic != null)
+            diagnostics.Enqueue(diagnostic);
+    }
+
     private void EnqueueDiagnostics(IEnumerable<PostExtractionHookDiagnostic> items)
     {
         foreach (var item in items)
             diagnostics.Enqueue(item);
     }
 
-    private static TimeSpan ResolveCallbackBudget()
+    private void EnqueueHookMaterializationDiagnostic(
+        LoadedPostExtractionHook hook,
+        string callback,
+        string recordKind,
+        int maxCount,
+        string direction)
+    {
+        EnqueueDiagnostic(
+            hook.Info.AssemblyPath,
+            hook.Info.TypeName,
+            $"Post-extraction hook {callback} {direction} exceeded the {maxCount:N0} {recordKind} materialization budget; extra {recordKind} records were discarded.",
+            callback,
+            category: recordKind == "symbol" ? "hook_symbol_count_truncated" : "hook_reference_count_truncated");
+    }
+
+    private static int? NormalizeHookMaterializationLimit(int? value)
+        => value is > 0 ? value : null;
+
+    private static HookBudgetResolution<TimeSpan> ResolveCallbackBudget()
     {
         if (CallbackBudgetForTesting != null)
             return NormalizeCallbackBudget(CallbackBudgetForTesting());
@@ -483,10 +588,10 @@ public sealed class PostExtractionHookRunner : IDisposable
         var raw = Environment.GetEnvironmentVariable(CallbackBudgetEnvironmentVariable);
         return long.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var milliseconds)
             ? NormalizeCallbackBudgetMilliseconds(milliseconds)
-            : DefaultCallbackBudget;
+            : new HookBudgetResolution<TimeSpan>(DefaultCallbackBudget, null);
     }
 
-    private static int ResolveDiscoveryLimit()
+    private static HookBudgetResolution<int> ResolveDiscoveryLimit()
     {
         if (DiscoveryLimitForTesting != null)
             return NormalizeDiscoveryLimit(DiscoveryLimitForTesting());
@@ -494,13 +599,29 @@ public sealed class PostExtractionHookRunner : IDisposable
         var raw = Environment.GetEnvironmentVariable(DiscoveryLimitEnvironmentVariable);
         return int.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var value)
             ? NormalizeDiscoveryLimit(value)
-            : DefaultDiscoveryLimit;
+            : new HookBudgetResolution<int>(DefaultDiscoveryLimit, null);
     }
 
-    private static int NormalizeDiscoveryLimit(int value)
-        => value <= 0 ? DefaultDiscoveryLimit : value;
+    private static HookBudgetResolution<int> NormalizeDiscoveryLimit(int value)
+    {
+        if (value <= 0)
+            return new HookBudgetResolution<int>(DefaultDiscoveryLimit, null);
 
-    private static long ResolveDiscoveryMaxBytes()
+        if (value > MaxDiscoveryLimit)
+        {
+            return new HookBudgetResolution<int>(
+                MaxDiscoveryLimit,
+                CreateDiagnostic(
+                    "<configuration>",
+                    null,
+                    $"{DiscoveryLimitEnvironmentVariable} value {value} exceeded the maximum {MaxDiscoveryLimit}; clamped to {MaxDiscoveryLimit}.",
+                    category: "hook_discovery_limit_clamped"));
+        }
+
+        return new HookBudgetResolution<int>(value, null);
+    }
+
+    private static HookBudgetResolution<long> ResolveDiscoveryMaxBytes()
     {
         if (DiscoveryMaxBytesForTesting != null)
             return NormalizeDiscoveryMaxBytes(DiscoveryMaxBytesForTesting());
@@ -508,24 +629,86 @@ public sealed class PostExtractionHookRunner : IDisposable
         var raw = Environment.GetEnvironmentVariable(DiscoveryMaxBytesEnvironmentVariable);
         return long.TryParse(raw, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var value)
             ? NormalizeDiscoveryMaxBytes(value)
-            : DefaultDiscoveryMaxBytes;
+            : new HookBudgetResolution<long>(DefaultDiscoveryMaxBytes, null);
     }
 
-    private static long NormalizeDiscoveryMaxBytes(long value)
-        => value <= 0 ? DefaultDiscoveryMaxBytes : value;
+    private static HookBudgetResolution<long> NormalizeDiscoveryMaxBytes(long value)
+    {
+        if (value <= 0)
+            return new HookBudgetResolution<long>(DefaultDiscoveryMaxBytes, null);
 
-    private static TimeSpan NormalizeCallbackBudgetMilliseconds(long milliseconds)
-        => milliseconds <= 0
-            ? DefaultCallbackBudget
-            : TimeSpan.FromMilliseconds(Math.Min(milliseconds, int.MaxValue));
+        if (value > MaxDiscoveryMaxBytes)
+        {
+            return new HookBudgetResolution<long>(
+                MaxDiscoveryMaxBytes,
+                CreateDiagnostic(
+                    "<configuration>",
+                    null,
+                    $"{DiscoveryMaxBytesEnvironmentVariable} value {value} exceeded the maximum {MaxDiscoveryMaxBytes}; clamped to {MaxDiscoveryMaxBytes}.",
+                    category: "hook_discovery_bytes_clamped"));
+        }
 
-    private static TimeSpan NormalizeCallbackBudget(TimeSpan value)
-        => value <= TimeSpan.Zero
-            ? DefaultCallbackBudget
-            : TimeSpan.FromMilliseconds(Math.Min(value.TotalMilliseconds, int.MaxValue));
+        return new HookBudgetResolution<long>(value, null);
+    }
 
-    private static List<SymbolRecord> CloneSymbols(IEnumerable<SymbolRecord> symbols)
-        => symbols.Select(symbol => new SymbolRecord
+    private static HookBudgetResolution<TimeSpan> NormalizeCallbackBudgetMilliseconds(long milliseconds)
+    {
+        if (milliseconds <= 0)
+            return new HookBudgetResolution<TimeSpan>(DefaultCallbackBudget, null);
+
+        if (milliseconds > MaxCallbackBudgetMilliseconds)
+        {
+            return new HookBudgetResolution<TimeSpan>(
+                TimeSpan.FromMilliseconds(MaxCallbackBudgetMilliseconds),
+                CreateDiagnostic(
+                    "<configuration>",
+                    null,
+                    $"{CallbackBudgetEnvironmentVariable} value {milliseconds} exceeded the maximum {MaxCallbackBudgetMilliseconds}; clamped to {MaxCallbackBudgetMilliseconds}.",
+                    category: "hook_callback_budget_clamped"));
+        }
+
+        return new HookBudgetResolution<TimeSpan>(TimeSpan.FromMilliseconds(milliseconds), null);
+    }
+
+    private static HookBudgetResolution<TimeSpan> NormalizeCallbackBudget(TimeSpan value)
+    {
+        if (value <= TimeSpan.Zero)
+            return new HookBudgetResolution<TimeSpan>(DefaultCallbackBudget, null);
+
+        if (value.TotalMilliseconds > MaxCallbackBudgetMilliseconds)
+        {
+            return new HookBudgetResolution<TimeSpan>(
+                TimeSpan.FromMilliseconds(MaxCallbackBudgetMilliseconds),
+                CreateDiagnostic(
+                    "<configuration>",
+                    null,
+                    $"{CallbackBudgetEnvironmentVariable} value {value.TotalMilliseconds:0} exceeded the maximum {MaxCallbackBudgetMilliseconds}; clamped to {MaxCallbackBudgetMilliseconds}.",
+                    category: "hook_callback_budget_clamped"));
+        }
+
+        return new HookBudgetResolution<TimeSpan>(value, null);
+    }
+
+    private static List<SymbolRecord> CloneSymbols(IEnumerable<SymbolRecord> symbols, int? maxCount, out bool truncated)
+    {
+        var result = new List<SymbolRecord>();
+        truncated = false;
+        foreach (var symbol in symbols)
+        {
+            if (maxCount is { } limit && result.Count >= limit)
+            {
+                truncated = true;
+                break;
+            }
+
+            result.Add(CloneSymbol(symbol));
+        }
+
+        return result;
+    }
+
+    private static SymbolRecord CloneSymbol(SymbolRecord symbol)
+        => new()
         {
             Id = symbol.Id,
             FileId = symbol.FileId,
@@ -548,10 +731,28 @@ public sealed class PostExtractionHookRunner : IDisposable
             IsMetadataTarget = symbol.IsMetadataTarget,
             MetadataTargetSource = symbol.MetadataTargetSource,
             SameLineSignatureOccurrenceIndex = symbol.SameLineSignatureOccurrenceIndex,
-        }).ToList();
+        };
 
-    private static List<ReferenceRecord> CloneReferences(IEnumerable<ReferenceRecord> references)
-        => references.Select(reference => new ReferenceRecord
+    private static List<ReferenceRecord> CloneReferences(IEnumerable<ReferenceRecord> references, int? maxCount, out bool truncated)
+    {
+        var result = new List<ReferenceRecord>();
+        truncated = false;
+        foreach (var reference in references)
+        {
+            if (maxCount is { } limit && result.Count >= limit)
+            {
+                truncated = true;
+                break;
+            }
+
+            result.Add(CloneReference(reference));
+        }
+
+        return result;
+    }
+
+    private static ReferenceRecord CloneReference(ReferenceRecord reference)
+        => new()
         {
             Id = reference.Id,
             FileId = reference.FileId,
@@ -564,7 +765,7 @@ public sealed class PostExtractionHookRunner : IDisposable
             ContainerName = reference.ContainerName,
             IsSelfReference = reference.IsSelfReference,
             IsMutualRecursion = reference.IsMutualRecursion,
-        }).ToList();
+        };
 
     private static void ReplaceList<T>(IList<T> target, IReadOnlyList<T> replacement)
     {
@@ -737,4 +938,6 @@ public sealed class PostExtractionHookRunner : IDisposable
         string? Directory,
         IReadOnlyList<PostExtractionHookDiagnostic> Diagnostics,
         IReadOnlyList<ExtensionTrustOverride> TrustOverrides);
+
+    private sealed record HookBudgetResolution<T>(T Value, PostExtractionHookDiagnostic? Diagnostic);
 }

--- a/src/CodeIndex/Indexer/References/ReferenceExtractionContext.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractionContext.cs
@@ -15,4 +15,5 @@ public sealed record ReferenceExtractionContext(
     IReadOnlyList<SymbolRecord>? WorkspaceSymbols = null,
     string? RequestedLanguage = null,
     CancellationToken CancellationToken = default,
-    int? MaxReferenceCount = null);
+    int? MaxReferenceCount = null,
+    Action<ReferenceExtractionDiagnostic>? ReportDiagnostic = null);

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.Core.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.Core.cs
@@ -66,8 +66,8 @@ public static partial class ReferenceExtractor
         // no-arg attribute として誤分類されないよう、no-arg 属性用ゲートに使う。
         var csharpAttrTopLevelRanges = csharpAttrTables.Item2;
         var definitionNamesComparer = GetDefinitionNamesComparer(language);
-        var definitionNamesByLine = BuildDefinitionNamesByLine(language, symbols);
-        var allDefinitionNames = BuildAllDefinitionNames(language, symbols);
+        var definitionNamesByLine = BuildDefinitionNamesByLine(language, symbols, request.ReportDiagnostic);
+        var allDefinitionNames = BuildAllDefinitionNames(language, symbols, request.ReportDiagnostic);
         var fileDefinitionNames = isRazorFile
             ? new HashSet<string>(symbols.Select(symbol => symbol.Name), StringComparer.Ordinal)
             : null;
@@ -90,12 +90,12 @@ public static partial class ReferenceExtractor
         // enclosing class (see issue #233).
         // 式本体・ブロック本体のプロパティアクセサ内の呼び出しを、外側のクラスではなく
         // プロパティ自身に帰属させる (issue #233 参照)。
-        var containerCandidates = BuildReferenceContainerCandidates(symbols);
+        var containerCandidates = BuildReferenceContainerCandidates(symbols, request.ReportDiagnostic);
         var containerResolver = new InnermostContainerResolver(containerCandidates);
         if (language == "solidity")
             return ExtractSolidityReferences(fileId, lines, preparedLines, containerResolver);
 
-        var csharpXmlDocAttachmentScopeCandidates = BuildCSharpXmlDocAttachmentScopeCandidates(language, symbols);
+        var csharpXmlDocAttachmentScopeCandidates = BuildCSharpXmlDocAttachmentScopeCandidates(language, symbols, request.ReportDiagnostic);
         // Enclosing-type candidates for constructor-chain rewrites (class/struct/record; namespace excluded).
         // Ordered innermost-first via ascending body range. Java enums can declare constructors and
         // chain via `this(...)` so `enum` is included; C# enums cannot declare constructors, and
@@ -103,7 +103,7 @@ public static partial class ReferenceExtractor
         // コンストラクタ連鎖の呼び先解決で使う外側の型候補（class/struct/record/enum。namespace は含めない）。
         // 内側優先で昇順にソート。Java の enum は `this(...)` 連鎖を持てるため `enum` も含める。
         // C# の enum はコンストラクタ自体を持てず `CSharpCtorChainRegex` が一致しないので副作用は無い。
-        var enclosingTypeCandidates = BuildEnclosingTypeCandidates(symbols);
+        var enclosingTypeCandidates = BuildEnclosingTypeCandidates(symbols, request.ReportDiagnostic);
         var rustEnumCandidates = language == "rust"
             ? symbols
                 .Where(symbol => symbol.Kind == "enum" && symbol.BodyStartLine != null && symbol.BodyEndLine != null)
@@ -113,7 +113,7 @@ public static partial class ReferenceExtractor
         var pythonDefinitionContainersByLineAndKind = language == "python"
             ? BuildPythonDefinitionContainersByLineAndKind(symbols)
             : null;
-        var swiftPropertyDefinitionsByLine = BuildSwiftPropertyDefinitionsByLine(language, symbols);
+        var swiftPropertyDefinitionsByLine = BuildSwiftPropertyDefinitionsByLine(language, symbols, request.ReportDiagnostic);
 
         // Synthetic function-kind container for C# primary-ctor declarations with a base
         // primary-ctor call such as `record Child(int x) : Parent(x)` or C# 12 `class Child(int x) : Parent(x)`.

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -19,6 +19,11 @@ public sealed record ReferenceExtractionResult(
 public static partial class ReferenceExtractor
 {
     private static readonly TimeSpan ExtractionRegexTimeout = TimeSpan.FromSeconds(2);
+    internal const int MaxReferenceLookupSymbols = 50_000;
+    internal const int MaxReferenceLookupLines = 20_000;
+    internal const int MaxReferenceLookupNamesPerLine = 512;
+    internal const int MaxReferenceContainerCandidates = 20_000;
+    internal const int MaxSwiftPropertyDefinitionsPerLine = 256;
     // THREAD-SAFETY: Reference extraction is stateless per call. Shared Regex instances and
     // lookup tables are initialized once and then read concurrently; language-specific state
     // must be created per extraction call (for example via CreateState helpers) rather than
@@ -1021,37 +1026,85 @@ public static partial class ReferenceExtractor
 
     private static Dictionary<int, HashSet<string>> BuildDefinitionNamesByLine(
         string language,
-        IReadOnlyList<SymbolRecord> symbols)
+        IReadOnlyList<SymbolRecord> symbols,
+        Action<ReferenceExtractionDiagnostic>? reportDiagnostic)
     {
         var definitionNamesComparer = GetDefinitionNamesComparer(language);
+        var namesByLine = new Dictionary<int, HashSet<string>>();
+        var lineBudgetReported = false;
+        var lineNameBudgetReported = false;
+        for (var index = 0; index < symbols.Count; index++)
+        {
+            if (index >= MaxReferenceLookupSymbols)
+            {
+                ReportReferenceLookupBudgetHit(
+                    reportDiagnostic,
+                    "reference_definition_lookup_symbol_budget_exceeded",
+                    $"Reference definition-name lookup used the first {MaxReferenceLookupSymbols:N0} symbols and skipped additional symbols.");
+                break;
+            }
 
-        return symbols
-            .GroupBy(symbol => symbol.Line)
-            .ToDictionary(
-                group => group.Key,
-                group =>
+            var symbol = symbols[index];
+            if (!namesByLine.TryGetValue(symbol.Line, out var names))
+            {
+                if (namesByLine.Count >= MaxReferenceLookupLines)
                 {
-                    var names = new HashSet<string>(definitionNamesComparer);
-                    foreach (var symbol in group)
+                    if (!lineBudgetReported)
                     {
-                        names.Add(symbol.Name);
-                        if (language == "sql")
-                        {
-                            SqlReferenceExtractor.AddDefinitionNameAliases(names, symbol);
-                        }
+                        ReportReferenceLookupBudgetHit(
+                            reportDiagnostic,
+                            "reference_definition_lookup_line_budget_exceeded",
+                            $"Reference definition-name lookup used the first {MaxReferenceLookupLines:N0} definition lines and skipped additional lines.");
+                        lineBudgetReported = true;
                     }
 
-                    return names;
-                });
+                    continue;
+                }
+
+                names = new HashSet<string>(definitionNamesComparer);
+                namesByLine[symbol.Line] = names;
+            }
+
+            if (names.Count >= MaxReferenceLookupNamesPerLine && !names.Contains(symbol.Name))
+            {
+                if (!lineNameBudgetReported)
+                {
+                    ReportReferenceLookupBudgetHit(
+                        reportDiagnostic,
+                        "reference_definition_lookup_line_name_budget_exceeded",
+                        $"Reference definition-name lookup retained at most {MaxReferenceLookupNamesPerLine:N0} names per line and skipped additional names.");
+                    lineNameBudgetReported = true;
+                }
+
+                continue;
+            }
+
+            names.Add(symbol.Name);
+            if (language == "sql")
+                SqlReferenceExtractor.AddDefinitionNameAliases(names, symbol);
+        }
+
+        return namesByLine;
     }
 
     private static HashSet<string> BuildAllDefinitionNames(
         string language,
-        IReadOnlyList<SymbolRecord> symbols)
+        IReadOnlyList<SymbolRecord> symbols,
+        Action<ReferenceExtractionDiagnostic>? reportDiagnostic)
     {
         var names = new HashSet<string>(GetDefinitionNamesComparer(language));
-        foreach (var symbol in symbols)
+        for (var index = 0; index < symbols.Count; index++)
         {
+            if (index >= MaxReferenceLookupSymbols)
+            {
+                ReportReferenceLookupBudgetHit(
+                    reportDiagnostic,
+                    "reference_all_definition_lookup_symbol_budget_exceeded",
+                    $"Reference all-definition lookup used the first {MaxReferenceLookupSymbols:N0} symbols and skipped additional symbols.");
+                break;
+            }
+
+            var symbol = symbols[index];
             names.Add(symbol.Name);
             if (language == "sql")
                 SqlReferenceExtractor.AddDefinitionNameAliases(names, symbol);
@@ -1065,42 +1118,147 @@ public static partial class ReferenceExtractor
             ? StringComparer.OrdinalIgnoreCase
             : StringComparer.Ordinal;
 
-    private static List<SymbolRecord> BuildReferenceContainerCandidates(IReadOnlyList<SymbolRecord> symbols)
-        => symbols
-            .Where(symbol => symbol.BodyStartLine != null && symbol.BodyEndLine != null &&
-                              (IsFunctionLikeSymbolKind(symbol.Kind) || symbol.Kind == "hook" || symbol.Kind == "accessor" || symbol.Kind == "class"
-                               || symbol.Kind == "struct" || symbol.Kind == "namespace"
-                               || symbol.Kind == "object" || symbol.Kind == "property" || symbol.Kind == "heading" || symbol.Kind == "class_hook"))
-            .OrderBy(symbol => (symbol.BodyEndLine ?? symbol.EndLine) - (symbol.BodyStartLine ?? symbol.StartLine))
-            .ToList();
+    private static List<SymbolRecord> BuildReferenceContainerCandidates(
+        IReadOnlyList<SymbolRecord> symbols,
+        Action<ReferenceExtractionDiagnostic>? reportDiagnostic)
+        => BuildBoundedContainerCandidates(
+            symbols,
+            symbol => symbol.BodyStartLine != null && symbol.BodyEndLine != null &&
+                      (IsFunctionLikeSymbolKind(symbol.Kind) || symbol.Kind == "hook" || symbol.Kind == "accessor" || symbol.Kind == "class"
+                       || symbol.Kind == "struct" || symbol.Kind == "namespace"
+                       || symbol.Kind == "object" || symbol.Kind == "property" || symbol.Kind == "heading" || symbol.Kind == "class_hook"),
+            "reference_container_candidate_budget_exceeded",
+            "Reference container lookup retained the highest-priority bounded candidate set and skipped additional candidates.",
+            reportDiagnostic);
 
     private static List<SymbolRecord>? BuildCSharpXmlDocAttachmentScopeCandidates(
         string language,
-        IReadOnlyList<SymbolRecord> symbols)
+        IReadOnlyList<SymbolRecord> symbols,
+        Action<ReferenceExtractionDiagnostic>? reportDiagnostic)
         => language == "csharp"
-            ? symbols
-                .Where(symbol => symbol.BodyStartLine != null && symbol.BodyEndLine != null
-                                 && symbol.Kind is "class" or "struct" or "interface" or "enum" or "namespace")
-                .OrderBy(symbol => (symbol.BodyEndLine ?? symbol.EndLine) - (symbol.BodyStartLine ?? symbol.StartLine))
-                .ToList()
+            ? BuildBoundedContainerCandidates(
+                symbols,
+                symbol => symbol.BodyStartLine != null && symbol.BodyEndLine != null
+                          && symbol.Kind is "class" or "struct" or "interface" or "enum" or "namespace",
+                "reference_csharp_xml_doc_scope_candidate_budget_exceeded",
+                "C# XML documentation scope lookup retained the highest-priority bounded candidate set and skipped additional candidates.",
+                reportDiagnostic)
             : null;
 
-    private static List<SymbolRecord> BuildEnclosingTypeCandidates(IReadOnlyList<SymbolRecord> symbols)
-        => symbols
-            .Where(symbol => symbol.BodyStartLine != null && symbol.BodyEndLine != null &&
-                             (symbol.Kind == "class" || symbol.Kind == "struct" || symbol.Kind == "interface" || symbol.Kind == "enum"))
-            .OrderBy(symbol => (symbol.BodyEndLine ?? symbol.EndLine) - (symbol.BodyStartLine ?? symbol.StartLine))
-            .ToList();
+    private static List<SymbolRecord> BuildEnclosingTypeCandidates(
+        IReadOnlyList<SymbolRecord> symbols,
+        Action<ReferenceExtractionDiagnostic>? reportDiagnostic)
+        => BuildBoundedContainerCandidates(
+            symbols,
+            symbol => symbol.BodyStartLine != null && symbol.BodyEndLine != null &&
+                      (symbol.Kind == "class" || symbol.Kind == "struct" || symbol.Kind == "interface" || symbol.Kind == "enum"),
+            "reference_enclosing_type_candidate_budget_exceeded",
+            "Reference enclosing-type lookup retained the highest-priority bounded candidate set and skipped additional candidates.",
+            reportDiagnostic);
 
     private static Dictionary<int, SymbolRecord[]>? BuildSwiftPropertyDefinitionsByLine(
         string language,
-        IReadOnlyList<SymbolRecord> symbols)
-        => language == "swift"
-            ? symbols
-                .Where(symbol => symbol.Kind == "property")
-                .GroupBy(symbol => symbol.Line)
-                .ToDictionary(group => group.Key, group => group.OrderByDescending(symbol => symbol.StartColumn ?? 0).ToArray())
-            : null;
+        IReadOnlyList<SymbolRecord> symbols,
+        Action<ReferenceExtractionDiagnostic>? reportDiagnostic)
+    {
+        if (language != "swift")
+            return null;
+
+        var byLine = new Dictionary<int, List<SymbolRecord>>();
+        var lineBudgetReported = false;
+        var perLineBudgetReported = false;
+        for (var index = 0; index < symbols.Count && index < MaxReferenceLookupSymbols; index++)
+        {
+            var symbol = symbols[index];
+            if (symbol.Kind != "property")
+                continue;
+
+            if (!byLine.TryGetValue(symbol.Line, out var lineSymbols))
+            {
+                if (byLine.Count >= MaxReferenceLookupLines)
+                {
+                    if (!lineBudgetReported)
+                    {
+                        ReportReferenceLookupBudgetHit(
+                            reportDiagnostic,
+                            "reference_swift_property_line_budget_exceeded",
+                            $"Swift property lookup retained at most {MaxReferenceLookupLines:N0} definition lines and skipped additional lines.");
+                        lineBudgetReported = true;
+                    }
+
+                    continue;
+                }
+
+                lineSymbols = [];
+                byLine[symbol.Line] = lineSymbols;
+            }
+
+            if (lineSymbols.Count >= MaxSwiftPropertyDefinitionsPerLine)
+            {
+                if (!perLineBudgetReported)
+                {
+                    ReportReferenceLookupBudgetHit(
+                        reportDiagnostic,
+                        "reference_swift_property_line_name_budget_exceeded",
+                        $"Swift property lookup retained at most {MaxSwiftPropertyDefinitionsPerLine:N0} properties per line and skipped additional properties.");
+                    perLineBudgetReported = true;
+                }
+
+                continue;
+            }
+
+            lineSymbols.Add(symbol);
+        }
+
+        if (symbols.Count > MaxReferenceLookupSymbols)
+        {
+            ReportReferenceLookupBudgetHit(
+                reportDiagnostic,
+                "reference_swift_property_symbol_budget_exceeded",
+                $"Swift property lookup used the first {MaxReferenceLookupSymbols:N0} symbols and skipped additional symbols.");
+        }
+
+        return byLine.ToDictionary(
+            pair => pair.Key,
+            pair => pair.Value.OrderByDescending(symbol => symbol.StartColumn ?? 0).ToArray());
+    }
+
+    private static List<SymbolRecord> BuildBoundedContainerCandidates(
+        IReadOnlyList<SymbolRecord> symbols,
+        Func<SymbolRecord, bool> predicate,
+        string diagnosticKind,
+        string diagnosticMessage,
+        Action<ReferenceExtractionDiagnostic>? reportDiagnostic)
+    {
+        var candidates = new List<SymbolRecord>(Math.Min(symbols.Count, MaxReferenceContainerCandidates));
+        var truncated = false;
+        foreach (var symbol in symbols)
+        {
+            if (!predicate(symbol))
+                continue;
+
+            if (candidates.Count >= MaxReferenceContainerCandidates)
+            {
+                truncated = true;
+                continue;
+            }
+
+            candidates.Add(symbol);
+        }
+
+        if (truncated)
+            ReportReferenceLookupBudgetHit(reportDiagnostic, diagnosticKind, diagnosticMessage);
+
+        return candidates
+            .OrderBy(symbol => (symbol.BodyEndLine ?? symbol.EndLine) - (symbol.BodyStartLine ?? symbol.StartLine))
+            .ToList();
+    }
+
+    private static void ReportReferenceLookupBudgetHit(
+        Action<ReferenceExtractionDiagnostic>? reportDiagnostic,
+        string kind,
+        string message)
+        => reportDiagnostic?.Invoke(new ReferenceExtractionDiagnostic(kind, message));
 
     private static void EmitPhpLinePreambleReferences(
         string originalLine,

--- a/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
+++ b/src/CodeIndex/Indexer/References/ReferenceExtractor.cs
@@ -6,6 +6,12 @@ using CodeIndex.Models;
 
 namespace CodeIndex.Indexer;
 
+public sealed record ReferenceExtractionDiagnostic(string Kind, string Message);
+
+public sealed record ReferenceExtractionResult(
+    List<ReferenceRecord> References,
+    IReadOnlyList<ReferenceExtractionDiagnostic> Diagnostics);
+
 /// <summary>
 /// Extracts lightweight symbol references such as call sites.
 /// 軽量なシンボル参照（呼び出し箇所など）を抽出する。
@@ -895,6 +901,25 @@ public static partial class ReferenceExtractor
         IReadOnlyList<SymbolRecord>? workspaceSymbols = null,
         CancellationToken cancellationToken = default,
         int? maxReferenceCount = null)
+        => ExtractDetailed(
+            fileId,
+            lang,
+            content,
+            symbols,
+            path,
+            workspaceSymbols,
+            cancellationToken,
+            maxReferenceCount).References;
+
+    public static ReferenceExtractionResult ExtractDetailed(
+        long fileId,
+        string? lang,
+        string content,
+        IReadOnlyList<SymbolRecord> symbols,
+        string? path = null,
+        IReadOnlyList<SymbolRecord>? workspaceSymbols = null,
+        CancellationToken cancellationToken = default,
+        int? maxReferenceCount = null)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var requestedLanguage = lang;
@@ -902,28 +927,37 @@ public static partial class ReferenceExtractor
         if (!TryGetExtractor(lang, out var extractor))
         {
             if (pluginLanguage == null || !ExtractorPluginRegistry.TryGetReferenceExtractor(pluginLanguage, out var pluginExtractor))
-                return [];
+                return new ReferenceExtractionResult([], []);
 
             if (string.IsNullOrEmpty(content))
-                return [];
+                return new ReferenceExtractionResult([], []);
             if (ChunkSplitter.HasOversizeLine(content))
-                return [];
+                return new ReferenceExtractionResult([], []);
             if (content.Contains('\r'))
                 content = content.Replace("\r\n", "\n").Replace("\r", "\n");
             content = FileIndexer.StripLineLeadingInvisibles(content);
             cancellationToken.ThrowIfCancellationRequested();
 
-            return pluginExtractor.Extract(
-                    fileId,
-                    content,
-                    new ExtractionContext(pluginLanguage, path, symbols, workspaceSymbols))
-                .Take(maxReferenceCount ?? int.MaxValue)
-                .ToList();
+            var pluginReferences = pluginExtractor.Extract(
+                fileId,
+                content,
+                new ExtractionContext(pluginLanguage, path, symbols, workspaceSymbols, maxReferenceCount));
+            var references = CopyPluginReferencesWithinLimit(pluginReferences, maxReferenceCount, out var truncated);
+            IReadOnlyList<ReferenceExtractionDiagnostic> diagnostics = truncated
+                ? [
+                    new ReferenceExtractionDiagnostic(
+                        "plugin_reference_count_truncated",
+                        $"Plugin reference extraction for language '{pluginLanguage}' produced {pluginReferences.Count:N0} references, exceeding the materialization budget of {maxReferenceCount!.Value:N0}; only the first {maxReferenceCount.Value:N0} references were retained."),
+                ]
+                : [];
+            return new ReferenceExtractionResult(references, diagnostics);
         }
 
         lang = NormalizeLanguage(lang);
         var language = lang!;
-        return extractor.Extract(new ReferenceExtractionContext(
+        var builtInDiagnostics = new List<ReferenceExtractionDiagnostic>();
+        return new ReferenceExtractionResult(
+            extractor.Extract(new ReferenceExtractionContext(
             fileId,
             language,
             content,
@@ -932,7 +966,34 @@ public static partial class ReferenceExtractor
             workspaceSymbols,
             requestedLanguage,
             cancellationToken,
-            maxReferenceCount));
+            maxReferenceCount,
+            builtInDiagnostics.Add)),
+            builtInDiagnostics);
+    }
+
+    private static List<ReferenceRecord> CopyPluginReferencesWithinLimit(
+        IReadOnlyList<ReferenceRecord> references,
+        int? maxReferenceCount,
+        out bool truncated)
+    {
+        if (maxReferenceCount is not { } limit)
+        {
+            truncated = false;
+            return references.ToList();
+        }
+
+        if (limit <= 0)
+        {
+            truncated = references.Count > 0;
+            return [];
+        }
+
+        var retainedCount = Math.Min(references.Count, limit);
+        var retained = new List<ReferenceRecord>(retainedCount);
+        for (var i = 0; i < retainedCount; i++)
+            retained.Add(references[i]);
+        truncated = references.Count > retainedCount;
+        return retained;
     }
 
     private sealed class BoundedReferenceList(int maxReferenceCount) : List<ReferenceRecord>

--- a/src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
+++ b/src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
@@ -96,7 +96,9 @@ internal static class LanguageMapOverrides
             {
                 if (patternCount >= MaxOverridePatterns)
                 {
-                    reportWarning?.Invoke($"Ignored remaining language-map override patterns in {path} because the pattern count exceeds {MaxOverridePatterns}.");
+                    reportWarning?.Invoke(
+                        $"Ignored remaining language-map override patterns in {DiagnosticSanitizer.ForPath(path)} because the pattern count exceeds {MaxOverridePatterns}.",
+                        $"{path}\npattern-count");
                     return;
                 }
 

--- a/src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
+++ b/src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
@@ -9,6 +9,7 @@ internal static class LanguageMapOverrides
     private const int MaxOverrideFileBytes = 128 * 1024;
     private const int MaxOverrideFileLines = 16384;
     private const int MaxOverrideEntries = 4096;
+    private const int MaxOverridePatterns = 8192;
     private static readonly object WarningLock = new();
     private static readonly HashSet<string> ReportedWarnings = new(StringComparer.Ordinal);
 
@@ -79,6 +80,7 @@ internal static class LanguageMapOverrides
 
         string? pendingExtension = null;
         var entryCount = 0;
+        var patternCount = 0;
         foreach (var rawLine in lines)
         {
             var line = rawLine.Trim();
@@ -87,7 +89,14 @@ internal static class LanguageMapOverrides
 
             if (TryReadScalar(line.TrimStart('-').Trim(), "extension", out var value))
             {
+                if (patternCount >= MaxOverridePatterns)
+                {
+                    reportWarning?.Invoke($"Ignored remaining language-map override patterns in {path} because the pattern count exceeds {MaxOverridePatterns}.");
+                    return;
+                }
+
                 pendingExtension = NormalizeExtension(value);
+                patternCount++;
                 continue;
             }
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.BuildAutomation.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.BuildAutomation.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Xml;
 using CodeIndex.Models;
 
@@ -104,7 +105,10 @@ public static partial class SymbolExtractor
         return symbols;
     }
 
-    internal static bool TryGetXmlStructureIssue(string content, out XmlStructureIssue issue)
+    internal static bool TryGetXmlStructureIssue(
+        string content,
+        out XmlStructureIssue issue,
+        [CallerMemberName] string? callerMemberName = null)
     {
         issue = default;
         var elementCount = 0;
@@ -133,6 +137,10 @@ public static partial class SymbolExtractor
 
                 if (elementCount > XmlExtractionMaxElements)
                 {
+                    // XAML symbol extraction has its own capped diagnostic path; content validation still reports the XML file issue.
+                    if (string.Equals(callerMemberName, nameof(ExtractXmlSymbols), StringComparison.Ordinal))
+                        return false;
+
                     issue = new XmlStructureIssue(
                         "xml_structure_budget_exceeded",
                         lineNumber,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Dockerfile.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Dockerfile.cs
@@ -8,6 +8,7 @@ public static partial class SymbolExtractor
 {
     internal const int DockerfileJsonFormMaxDepth = 8;
     internal const int DockerfileJsonFormMaxItems = 128;
+    internal const int DockerfileJsonFormMaxBodyLength = 32 * 1024;
     internal const int DockerfileJsonFormMaxStringLength = 4096;
     private static readonly JsonDocumentOptions DockerfileJsonFormDocumentOptions = new()
     {
@@ -309,6 +310,12 @@ public static partial class SymbolExtractor
         List<SymbolRecord> symbols,
         string body)
     {
+        if (body.Length > DockerfileJsonFormMaxBodyLength)
+        {
+            AddDockerfileJsonFormDiagnostic(symbols, fileId, lineNumber, line, "dockerfile_json_form_body_budget_exceeded", "Dockerfile JSON-form body exceeded the parse budget; JSON-form symbols were truncated.");
+            return;
+        }
+
         try
         {
             using var document = JsonDocument.Parse(body, DockerfileJsonFormDocumentOptions);
@@ -319,7 +326,10 @@ public static partial class SymbolExtractor
             foreach (var item in document.RootElement.EnumerateArray())
             {
                 if (itemCount >= DockerfileJsonFormMaxItems)
+                {
+                    AddDockerfileJsonFormDiagnostic(symbols, fileId, lineNumber, line, "dockerfile_json_form_array_budget_exceeded", "Dockerfile JSON-form array exceeded the item budget; remaining items were truncated.");
                     break;
+                }
                 itemCount++;
 
                 if (!TryGetDockerfileJsonFormString(item, out var name))
@@ -413,6 +423,11 @@ public static partial class SymbolExtractor
         var body = trimmed[5..].TrimStart();
         if (!body.StartsWith("[", StringComparison.Ordinal))
             return;
+        if (body.Length > DockerfileJsonFormMaxBodyLength)
+        {
+            AddDockerfileJsonFormDiagnostic(symbols, fileId, lineNumber, line, "dockerfile_json_form_body_budget_exceeded", "Dockerfile JSON-form body exceeded the parse budget; JSON-form symbols were truncated.");
+            return;
+        }
 
         try
         {
@@ -471,8 +486,28 @@ public static partial class SymbolExtractor
         if (!TryGetDockerfileInstructionBody(line, instruction, allowOnbuild, out var body))
             return;
 
-        var destination = GetDockerfileShellFormDestination(body)
-            ?? (includeJsonForm ? GetDockerfileJsonFormDestination(body) : null);
+        string? destination;
+        var jsonArrayBudgetExceeded = false;
+        if (includeJsonForm && DockerfileInstructionBodyStartsWithJsonForm(body))
+        {
+            if (DockerfileJsonFormBodyExceedsBudget(body))
+            {
+                AddDockerfileJsonFormDiagnostic(symbols, fileId, lineNumber, line, "dockerfile_json_form_body_budget_exceeded", "Dockerfile JSON-form body exceeded the parse budget; JSON-form symbols were truncated.");
+                return;
+            }
+
+            destination = GetDockerfileJsonFormDestination(body, out jsonArrayBudgetExceeded);
+        }
+        else
+        {
+            destination = GetDockerfileShellFormDestination(body);
+        }
+
+        if (jsonArrayBudgetExceeded)
+        {
+            AddDockerfileJsonFormDiagnostic(symbols, fileId, lineNumber, line, "dockerfile_json_form_array_budget_exceeded", "Dockerfile JSON-form array exceeded the item budget; remaining items were truncated.");
+            return;
+        }
         if (destination is null or "." or "./")
             return;
 
@@ -562,10 +597,13 @@ public static partial class SymbolExtractor
         return arguments.Count >= 2 ? arguments[^1] : null;
     }
 
-    private static string? GetDockerfileJsonFormDestination(string body)
+    private static string? GetDockerfileJsonFormDestination(string body, out bool arrayBudgetExceeded)
     {
+        arrayBudgetExceeded = false;
         var jsonStart = SkipDockerfileInstructionOptions(body);
         if (jsonStart >= body.Length || body[jsonStart] != '[')
+            return null;
+        if (body.Length - jsonStart > DockerfileJsonFormMaxBodyLength)
             return null;
 
         try
@@ -579,7 +617,10 @@ public static partial class SymbolExtractor
             foreach (var item in document.RootElement.EnumerateArray())
             {
                 if (count >= DockerfileJsonFormMaxItems)
+                {
+                    arrayBudgetExceeded = true;
                     return null;
+                }
                 count++;
 
                 if (!TryGetDockerfileJsonFormString(item, out var value))
@@ -594,6 +635,32 @@ public static partial class SymbolExtractor
         {
             return null;
         }
+    }
+
+    private static bool DockerfileJsonFormBodyExceedsBudget(string body)
+    {
+        var jsonStart = SkipDockerfileInstructionOptions(body);
+        return jsonStart < body.Length
+               && body[jsonStart] == '['
+               && body.Length - jsonStart > DockerfileJsonFormMaxBodyLength;
+    }
+
+    private static bool DockerfileInstructionBodyStartsWithJsonForm(string body)
+    {
+        var jsonStart = SkipDockerfileInstructionOptions(body);
+        return jsonStart < body.Length && body[jsonStart] == '[';
+    }
+
+    private static void AddDockerfileJsonFormDiagnostic(
+        List<SymbolRecord> symbols,
+        long fileId,
+        int lineNumber,
+        string line,
+        string category,
+        string message)
+    {
+        var added = false;
+        AddStructuredDataDiagnosticSymbol(symbols, fileId, category, lineNumber, [line], message, ref added);
     }
 
     private static int SkipDockerfileInstructionOptions(string body)

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Markup.cs
@@ -816,20 +816,34 @@ public static partial class SymbolExtractor
             }
         }
 
-        AddWrappedXamlTypeArgumentSymbols(fileId, rawText, lines, lineStarts, symbols);
-        AddWrappedXamlTypeBearingAttributeSymbols(fileId, rawText, lines, lineStarts, symbols);
-        AddWrappedXamlSearchAttributeSymbols(fileId, rawText, lines, lineStarts, symbols);
-        AddXamlTypeObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols);
-        AddXamlTypePropertyElementSymbols(fileId, rawText, lines, lineStarts, symbols);
-        AddXamlTypeMarkupSymbols(fileId, rawText, lines, lineStarts, symbols);
-        AddXamlStaticMemberTypeSymbols(fileId, rawText, lines, lineStarts, symbols);
-        AddXamlReferenceSymbols(fileId, rawText, lines, lineStarts, symbols);
-        AddXamlResourceReferenceSymbols(fileId, rawText, lines, lineStarts, symbols);
-        AddXamlBindingElementNameSymbols(fileId, rawText, lines, lineStarts, symbols);
-        AddXamlBindingObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols);
+        if (symbols.Count < StructuredDataMaxSymbols)
+            AddWrappedXamlTypeArgumentSymbols(fileId, rawText, lines, lineStarts, symbols);
+        if (symbols.Count < StructuredDataMaxSymbols)
+            AddWrappedXamlTypeBearingAttributeSymbols(fileId, rawText, lines, lineStarts, symbols);
+        if (symbols.Count < StructuredDataMaxSymbols)
+            AddWrappedXamlSearchAttributeSymbols(fileId, rawText, lines, lineStarts, symbols);
+        if (symbols.Count < StructuredDataMaxSymbols)
+            AddXamlTypeObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols);
+        if (symbols.Count < StructuredDataMaxSymbols)
+            AddXamlTypePropertyElementSymbols(fileId, rawText, lines, lineStarts, symbols);
+        if (symbols.Count < StructuredDataMaxSymbols)
+            AddXamlTypeMarkupSymbols(fileId, rawText, lines, lineStarts, symbols);
+        if (symbols.Count < StructuredDataMaxSymbols)
+            AddXamlStaticMemberTypeSymbols(fileId, rawText, lines, lineStarts, symbols);
+        if (symbols.Count < StructuredDataMaxSymbols)
+            AddXamlReferenceSymbols(fileId, rawText, lines, lineStarts, symbols);
+        if (symbols.Count < StructuredDataMaxSymbols)
+            AddXamlResourceReferenceSymbols(fileId, rawText, lines, lineStarts, symbols);
+        if (symbols.Count < StructuredDataMaxSymbols)
+            AddXamlBindingElementNameSymbols(fileId, rawText, lines, lineStarts, symbols);
+        if (symbols.Count < StructuredDataMaxSymbols)
+            AddXamlBindingObjectElementSymbols(fileId, rawText, lines, lineStarts, symbols);
 
         foreach (Match bindingMatch in XamlBindingRegex.Matches(rawText))
         {
+            if (symbols.Count >= StructuredDataMaxSymbols)
+                break;
+
             var value = NormalizeXamlBindingValue(bindingMatch.Groups["kind"].Value, bindingMatch.Groups["content"].Value);
             if (value.Length == 0)
                 continue;
@@ -848,7 +862,7 @@ public static partial class SymbolExtractor
             });
         }
 
-        return symbols;
+        return TrimStructuredDataSymbols(symbols, fileId, "structured_data_xml_symbol_budget_exceeded", lines);
     }
 
     private static void AddWrappedXamlTypeArgumentSymbols(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
@@ -294,7 +294,7 @@ public static partial class SymbolExtractor
         added = true;
         var signatureIndex = Math.Clamp(line - 1, 0, Math.Max(0, lines.Length - 1));
         var signature = lines.Length == 0 ? message : $"{message} {lines[signatureIndex].Trim()}";
-        symbols.Add(new SymbolRecord
+        var diagnostic = new SymbolRecord
         {
             FileId = fileId,
             Kind = "extraction_diagnostic",
@@ -303,7 +303,12 @@ public static partial class SymbolExtractor
             StartLine = Math.Max(1, line),
             EndLine = Math.Max(1, line),
             Signature = LimitStructuredDataSignature(signature),
-        });
+        };
+
+        if (symbols.Count >= StructuredDataMaxSymbols)
+            symbols[^1] = diagnostic;
+        else
+            symbols.Add(diagnostic);
     }
 
     private static List<SymbolRecord> TrimStructuredDataSymbols(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuredData.cs
@@ -7,6 +7,10 @@ namespace CodeIndex.Indexer;
 
 public static partial class SymbolExtractor
 {
+    internal const int StructuredDataMaxSymbols = 4096;
+    internal const int StructuredDataMaxTraversalNodes = 8192;
+    internal const int StructuredDataMaxDepth = 64;
+
     private static readonly Regex JsonFallbackPropertyRegex = new(
         @"^\s*""(?<name>(?:\\.|[^""\\])+)""\s*:",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);
@@ -22,6 +26,8 @@ public static partial class SymbolExtractor
         var symbols = new List<SymbolRecord>();
         var lineStarts = BuildLineStarts(lines);
         var searchOffset = 0;
+        var traversalNodes = 0;
+        var truncated = false;
 
         try
         {
@@ -29,10 +35,11 @@ public static partial class SymbolExtractor
             {
                 AllowTrailingCommas = true,
                 CommentHandling = JsonCommentHandling.Skip,
+                MaxDepth = StructuredDataMaxDepth + 2,
             });
 
             if (document.RootElement.ValueKind == JsonValueKind.Object)
-                ExtractJsonObjectSymbols(fileId, content, lines, lineStarts, document.RootElement, parentPath: null, ref searchOffset, symbols);
+                ExtractJsonObjectSymbols(fileId, content, lines, lineStarts, document.RootElement, parentPath: null, ref searchOffset, symbols, depth: 0, ref traversalNodes, ref truncated);
             return symbols;
         }
         catch (JsonException)
@@ -49,10 +56,26 @@ public static partial class SymbolExtractor
         JsonElement element,
         string? parentPath,
         ref int searchOffset,
-        List<SymbolRecord> symbols)
+        List<SymbolRecord> symbols,
+        int depth,
+        ref int traversalNodes,
+        ref bool truncated)
     {
+        if (depth >= StructuredDataMaxDepth)
+        {
+            AddStructuredDataDiagnosticSymbol(symbols, fileId, "structured_data_depth_budget_exceeded", line: 1, lines, "Structured data traversal exceeded the maximum depth; nested symbols were truncated.", ref truncated);
+            return;
+        }
+
         foreach (var property in element.EnumerateObject())
         {
+            if (traversalNodes >= StructuredDataMaxTraversalNodes)
+            {
+                AddStructuredDataDiagnosticSymbol(symbols, fileId, "structured_data_traversal_budget_exceeded", line: 1, lines, "Structured data traversal exceeded the per-file node budget; remaining nodes were truncated.", ref truncated);
+                return;
+            }
+
+            traversalNodes++;
             var name = string.IsNullOrEmpty(parentPath)
                 ? property.Name
                 : parentPath + "." + property.Name;
@@ -62,18 +85,23 @@ public static partial class SymbolExtractor
                 ? "namespace"
                 : "property";
 
-            symbols.Add(CreateStructuredDataSymbol(fileId, kind, name, line, lines, parentPath));
+            if (!TryAddStructuredDataSymbol(symbols, CreateStructuredDataSymbol(fileId, kind, name, line, lines, parentPath), fileId, "structured_data_symbol_budget_exceeded", line, lines, ref truncated))
+                return;
 
             if (property.Value.ValueKind == JsonValueKind.Object)
             {
-                ExtractJsonObjectSymbols(fileId, content, lines, lineStarts, property.Value, name, ref searchOffset, symbols);
+                ExtractJsonObjectSymbols(fileId, content, lines, lineStarts, property.Value, name, ref searchOffset, symbols, depth + 1, ref traversalNodes, ref truncated);
+                if (truncated)
+                    return;
             }
             else if (property.Value.ValueKind == JsonValueKind.Array)
             {
                 foreach (var item in property.Value.EnumerateArray())
                 {
                     if (item.ValueKind == JsonValueKind.Object)
-                        ExtractJsonObjectSymbols(fileId, content, lines, lineStarts, item, name, ref searchOffset, symbols);
+                        ExtractJsonObjectSymbols(fileId, content, lines, lineStarts, item, name, ref searchOffset, symbols, depth + 1, ref traversalNodes, ref truncated);
+                    if (truncated)
+                        return;
                 }
             }
         }
@@ -82,6 +110,7 @@ public static partial class SymbolExtractor
     private static List<SymbolRecord> ExtractJsonFallbackSymbols(long fileId, string[] lines)
     {
         var symbols = new List<SymbolRecord>();
+        var truncated = false;
         for (var i = 0; i < lines.Length; i++)
         {
             var match = JsonFallbackPropertyRegex.Match(lines[i]);
@@ -92,7 +121,8 @@ public static partial class SymbolExtractor
             if (string.IsNullOrWhiteSpace(name))
                 continue;
 
-            symbols.Add(CreateStructuredDataSymbol(fileId, "property", name, i + 1, lines, parentPath: null));
+            if (!TryAddStructuredDataSymbol(symbols, CreateStructuredDataSymbol(fileId, "property", name, i + 1, lines, parentPath: null), fileId, "structured_data_symbol_budget_exceeded", i + 1, lines, ref truncated))
+                break;
         }
 
         return symbols;
@@ -103,9 +133,17 @@ public static partial class SymbolExtractor
         var symbols = new List<SymbolRecord>();
         var stack = new List<YamlPathFrame>();
         int? blockScalarIndent = null;
+        var traversalNodes = 0;
+        var truncated = false;
 
         for (var i = 0; i < lines.Length; i++)
         {
+            if (traversalNodes >= StructuredDataMaxTraversalNodes)
+            {
+                AddStructuredDataDiagnosticSymbol(symbols, fileId, "structured_data_traversal_budget_exceeded", i + 1, lines, "Structured data traversal exceeded the per-file node budget; remaining nodes were truncated.", ref truncated);
+                break;
+            }
+
             var line = lines[i];
             if (string.IsNullOrWhiteSpace(line))
                 continue;
@@ -139,7 +177,9 @@ public static partial class SymbolExtractor
             var isContainer = value.Length == 0 || value is "|" or ">" or "|-" or ">-" or "|+" or ">+";
             var kind = isContainer ? "namespace" : "property";
 
-            symbols.Add(CreateStructuredDataSymbol(fileId, kind, path, i + 1, lines, parentPath));
+            traversalNodes++;
+            if (!TryAddStructuredDataSymbol(symbols, CreateStructuredDataSymbol(fileId, kind, path, i + 1, lines, parentPath), fileId, "structured_data_symbol_budget_exceeded", i + 1, lines, ref truncated))
+                break;
 
             if (isContainer)
             {
@@ -150,6 +190,73 @@ public static partial class SymbolExtractor
         }
 
         return symbols;
+    }
+
+    private static bool TryAddStructuredDataSymbol(
+        List<SymbolRecord> symbols,
+        SymbolRecord symbol,
+        long fileId,
+        string category,
+        int line,
+        string[] lines,
+        ref bool truncated)
+    {
+        if (symbols.Count < StructuredDataMaxSymbols)
+        {
+            symbols.Add(symbol);
+            return true;
+        }
+
+        AddStructuredDataDiagnosticSymbol(symbols, fileId, category, line, lines, "Structured data symbol extraction exceeded the per-file symbol budget; remaining symbols were truncated.", ref truncated);
+        return false;
+    }
+
+    private static void AddStructuredDataDiagnosticSymbol(
+        List<SymbolRecord> symbols,
+        long fileId,
+        string category,
+        int line,
+        string[] lines,
+        string message,
+        ref bool added)
+    {
+        if (added)
+            return;
+
+        added = true;
+        var signatureIndex = Math.Clamp(line - 1, 0, Math.Max(0, lines.Length - 1));
+        symbols.Add(new SymbolRecord
+        {
+            FileId = fileId,
+            Kind = "extraction_diagnostic",
+            Name = category,
+            Line = Math.Max(1, line),
+            StartLine = Math.Max(1, line),
+            EndLine = Math.Max(1, line),
+            Signature = lines.Length == 0 ? message : $"{message} {lines[signatureIndex].Trim()}",
+        });
+    }
+
+    private static List<SymbolRecord> TrimStructuredDataSymbols(
+        List<SymbolRecord> symbols,
+        long fileId,
+        string category,
+        string[] lines)
+    {
+        if (symbols.Count <= StructuredDataMaxSymbols)
+            return symbols;
+
+        var retained = symbols.Take(StructuredDataMaxSymbols).ToList();
+        var added = false;
+        AddStructuredDataDiagnosticSymbol(
+            retained,
+            fileId,
+            category,
+            line: 1,
+            lines,
+            "Structured data symbol extraction exceeded the per-file symbol budget; remaining symbols were truncated.",
+            ref added);
+        return retained;
     }
 
     private static SymbolRecord CreateStructuredDataSymbol(

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.TypeScriptPathAliases.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.TypeScriptPathAliases.cs
@@ -13,6 +13,7 @@ public static partial class SymbolExtractor
     private const int MaxTypeScriptPathAliasRules = 1024;
     private const int MaxTypeScriptPathAliasTargetsPerRule = 32;
     private const int MaxTypeScriptPathAliasTotalTargets = 2048;
+    private const int MaxTypeScriptPathAliasExpansionCandidates = 1024;
     private const int MaxTypeScriptPathAliasPatternLength = 512;
     private const int MaxTypeScriptPathAliasTargetLength = 1024;
     private const int MaxTypeScriptPathAliasModuleSpecifierLength = 4096;
@@ -21,6 +22,7 @@ public static partial class SymbolExtractor
     private const string TypeScriptPathAliasDiagnosticJsonInvalid = "tsconfig_json_invalid";
     private const string TypeScriptPathAliasDiagnosticSizeLimit = "tsconfig_size_limit";
     private const string TypeScriptPathAliasDiagnosticDepthLimit = "path_alias_depth_limit";
+    private const string TypeScriptPathAliasDiagnosticExpansionCandidateLimit = "path_alias_expansion_candidate_limit";
     private static readonly object TypeScriptPathAliasWarningLock = new();
     private static readonly HashSet<string> TypeScriptPathAliasReportedWarnings = new(StringComparer.Ordinal);
     private static readonly JsonDocumentOptions TypeScriptPathAliasConfigJsonOptions = new()
@@ -61,6 +63,8 @@ public static partial class SymbolExtractor
             return moduleName;
         }
 
+        var remainingExpansionCandidates = MaxTypeScriptPathAliasExpansionCandidates;
+        var expansionCandidatesTruncated = false;
         foreach (var rule in config.Rules)
         {
             if (!TryMatchTypeScriptPathAliasPattern(rule.Pattern, moduleName, out var wildcard))
@@ -79,15 +83,44 @@ public static partial class SymbolExtractor
                     ? substituted
                     : Path.Combine(rule.BaseDirectory, substituted);
 
-                if (TryResolveTypeScriptModuleFile(candidate, out var resolvedPath))
+                if (TryResolveTypeScriptModuleFile(
+                        candidate,
+                        ref remainingExpansionCandidates,
+                        out var resolvedPath,
+                        out var candidateBudgetExhausted))
+                {
                     return NormalizeTypeScriptResolvedModulePath(projectRoot ?? config.ProjectDirectory, resolvedPath);
+                }
+
+                if (candidateBudgetExhausted)
+                {
+                    expansionCandidatesTruncated = true;
+                    break;
+                }
             }
+
+            if (expansionCandidatesTruncated)
+                break;
         }
 
-        if (config.HasBaseUrl
-            && TryResolveTypeScriptModuleFile(Path.Combine(config.BaseDirectory, moduleName), out var baseUrlResolvedPath))
+        if (config.HasBaseUrl && !expansionCandidatesTruncated)
         {
-            return NormalizeTypeScriptResolvedModulePath(projectRoot ?? config.ProjectDirectory, baseUrlResolvedPath);
+            if (TryResolveTypeScriptModuleFile(
+                    Path.Combine(config.BaseDirectory, moduleName),
+                    ref remainingExpansionCandidates,
+                    out var baseUrlResolvedPath,
+                    out var baseUrlBudgetExhausted))
+            {
+                return NormalizeTypeScriptResolvedModulePath(projectRoot ?? config.ProjectDirectory, baseUrlResolvedPath);
+            }
+
+            expansionCandidatesTruncated = baseUrlBudgetExhausted;
+        }
+
+        if (expansionCandidatesTruncated)
+        {
+            ReportTypeScriptPathAliasWarningOnce(
+                $"Truncated TypeScript path alias expansion candidates in config {config.ConfigPath} [{TypeScriptPathAliasDiagnosticExpansionCandidateLimit}] to {MaxTypeScriptPathAliasExpansionCandidates} probes.");
         }
 
         return moduleName;
@@ -458,10 +491,22 @@ public static partial class SymbolExtractor
         return true;
     }
 
-    private static bool TryResolveTypeScriptModuleFile(string candidate, out string resolvedPath)
+    private static bool TryResolveTypeScriptModuleFile(
+        string candidate,
+        ref int remainingCandidateBudget,
+        out string resolvedPath,
+        out bool budgetExhausted)
     {
+        budgetExhausted = false;
         foreach (var path in EnumerateTypeScriptModuleCandidates(candidate))
         {
+            if (remainingCandidateBudget <= 0)
+            {
+                budgetExhausted = true;
+                break;
+            }
+
+            remainingCandidateBudget--;
             if (File.Exists(path))
             {
                 resolvedPath = Path.GetFullPath(path);

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -760,6 +760,34 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void LanguageMapOverrides_PatternCountCapTruncatesRemainingOverridesWithWarning_Issue3764()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_langmap_patterns_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            const int maxPatterns = 8192;
+            var configPath = Path.Combine(tempDir, "langmap.yaml");
+            var builder = new StringBuilder("entries:\n");
+            for (var i = 0; i <= maxPatterns; i++)
+                builder.Append("extension:x").Append(i).Append('\n');
+            File.WriteAllText(configPath, builder.ToString());
+
+            var warnings = new List<string>();
+            var map = LanguageMapOverrides.LoadEffectiveMapFromPathsForTesting(
+                new[] { configPath },
+                warnings.Add);
+
+            Assert.Empty(map);
+            Assert.Contains(warnings, warning => warning.Contains("pattern count exceeds 8192", StringComparison.Ordinal));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(tempDir);
+        }
+    }
+
+    [Fact]
     public void LanguageMapOverrides_EntryCountCapIsPerFileSoWorkspaceOverridesStillLoad()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_langmap_per_file_entries_{Guid.NewGuid():N}");

--- a/tests/CodeIndex.Tests/PostExtractionHookTests.cs
+++ b/tests/CodeIndex.Tests/PostExtractionHookTests.cs
@@ -558,27 +558,30 @@ public class PostExtractionHookTests
                 Directory.CreateDirectory(hooksDir);
                 File.Copy(Assembly.GetExecutingAssembly().Location, Path.Combine(hooksDir, "CodeIndex.Tests.dll"));
 
-                using var runner = PostExtractionHookRunner.Discover(
-                    hooksDir,
-                    maxSymbolCount: 2,
-                    maxReferenceCount: 2);
-                var context = new FileContext(projectRoot, "src/App.cs", Path.Combine(projectRoot, "src", "App.cs"), "csharp");
-                var symbols = new List<SymbolRecord>();
-                var references = new List<ReferenceRecord>();
+                {
+                    using var runner = PostExtractionHookRunner.Discover(
+                        hooksDir,
+                        maxSymbolCount: 2,
+                        maxReferenceCount: 2);
+                    var context = new FileContext(projectRoot, "src/App.cs", Path.Combine(projectRoot, "src", "App.cs"), "csharp");
+                    var symbols = new List<SymbolRecord>();
+                    var references = new List<ReferenceRecord>();
 
-                runner.OnSymbolsExtracted(context, symbols);
-                runner.OnReferencesExtracted(context, references);
+                    runner.OnSymbolsExtracted(context, symbols);
+                    runner.OnReferencesExtracted(context, references);
 
-                Assert.True(symbols.Count <= 2);
-                Assert.True(references.Count <= 2);
-                Assert.Contains(
-                    runner.Diagnostics,
-                    diagnostic => diagnostic.Category == "hook_symbol_count_truncated"
-                                  && diagnostic.Message.Contains("materialization budget", StringComparison.Ordinal));
-                Assert.Contains(
-                    runner.Diagnostics,
-                    diagnostic => diagnostic.Category == "hook_reference_count_truncated"
-                                  && diagnostic.Message.Contains("materialization budget", StringComparison.Ordinal));
+                    Assert.True(symbols.Count <= 2);
+                    Assert.True(references.Count <= 2);
+                    Assert.Contains(
+                        runner.Diagnostics,
+                        diagnostic => diagnostic.Category == "hook_symbol_count_truncated"
+                                      && diagnostic.Message.Contains("materialization budget", StringComparison.Ordinal));
+                    Assert.Contains(
+                        runner.Diagnostics,
+                        diagnostic => diagnostic.Category == "hook_reference_count_truncated"
+                                      && diagnostic.Message.Contains("materialization budget", StringComparison.Ordinal));
+                }
+                CollectUnloadedHookAssemblies();
             }
             finally
             {

--- a/tests/CodeIndex.Tests/PostExtractionHookTests.cs
+++ b/tests/CodeIndex.Tests/PostExtractionHookTests.cs
@@ -14,6 +14,7 @@ public class PostExtractionHookTests
     internal const string SlowConstructorHookDelayEnvironmentVariable = "CDIDX_TEST_SLOW_CTOR_POST_EXTRACTION_HOOK_MS";
     internal const string StatefulHookEnvironmentVariable = "CDIDX_TEST_STATEFUL_POST_EXTRACTION_HOOK";
     internal const string ThrowingConstructorHookEnvironmentVariable = "CDIDX_TEST_THROWING_CTOR_POST_EXTRACTION_HOOK";
+    internal const string ExpandingHookEnvironmentVariable = "CDIDX_TEST_EXPANDING_POST_EXTRACTION_HOOK";
 
     [Fact]
     public void Discover_LoadsHooksAndAllowsSymbolAndReferenceMutation()
@@ -331,11 +332,70 @@ public class PostExtractionHookTests
 
                 PostExtractionHookRunner.CallbackBudgetForTesting = () => TimeSpan.FromMilliseconds((double)int.MaxValue + 1);
                 using var capped = PostExtractionHookRunner.Discover(null);
-                Assert.Equal(int.MaxValue, (long)Math.Round(capped.CallbackBudget.TotalMilliseconds, MidpointRounding.AwayFromZero));
+                Assert.Equal(
+                    PostExtractionHookRunner.MaxCallbackBudgetMilliseconds,
+                    (long)Math.Round(capped.CallbackBudget.TotalMilliseconds, MidpointRounding.AwayFromZero));
+                var diagnostic = Assert.Single(capped.Diagnostics);
+                Assert.Equal("hook_callback_budget_clamped", diagnostic.Category);
+                Assert.Contains("clamped", diagnostic.Message, StringComparison.Ordinal);
             }
             finally
             {
                 PostExtractionHookRunner.CallbackBudgetForTesting = originalBudget;
+            }
+        }
+    }
+
+    [Fact]
+    public void Discover_ClampsOversizedDiscoveryLimit()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("post-extraction-hook-discovery-limit-clamp");
+        lock (TestConsoleLock.Gate)
+        {
+            var originalLimit = PostExtractionHookRunner.DiscoveryLimitForTesting;
+            try
+            {
+                PostExtractionHookRunner.DiscoveryLimitForTesting = () => PostExtractionHookRunner.MaxDiscoveryLimit + 1;
+                var hooksDir = Path.Combine(projectRoot, "hooks");
+                Directory.CreateDirectory(hooksDir);
+
+                using var runner = PostExtractionHookRunner.Discover(hooksDir);
+
+                var diagnostic = Assert.Single(runner.Diagnostics);
+                Assert.Equal("hook_discovery_limit_clamped", diagnostic.Category);
+                Assert.Contains(PostExtractionHookRunner.MaxDiscoveryLimit.ToString(), diagnostic.Message, StringComparison.Ordinal);
+            }
+            finally
+            {
+                PostExtractionHookRunner.DiscoveryLimitForTesting = originalLimit;
+                TestProjectHelper.DeleteDirectory(projectRoot);
+            }
+        }
+    }
+
+    [Fact]
+    public void Discover_ClampsOversizedDiscoveryMaxBytes()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("post-extraction-hook-discovery-bytes-clamp");
+        lock (TestConsoleLock.Gate)
+        {
+            var originalMaxBytes = PostExtractionHookRunner.DiscoveryMaxBytesForTesting;
+            try
+            {
+                PostExtractionHookRunner.DiscoveryMaxBytesForTesting = () => PostExtractionHookRunner.MaxDiscoveryMaxBytes + 1;
+                var hooksDir = Path.Combine(projectRoot, "hooks");
+                Directory.CreateDirectory(hooksDir);
+
+                using var runner = PostExtractionHookRunner.Discover(hooksDir);
+
+                var diagnostic = Assert.Single(runner.Diagnostics);
+                Assert.Equal("hook_discovery_bytes_clamped", diagnostic.Category);
+                Assert.Contains(PostExtractionHookRunner.MaxDiscoveryMaxBytes.ToString(), diagnostic.Message, StringComparison.Ordinal);
+            }
+            finally
+            {
+                PostExtractionHookRunner.DiscoveryMaxBytesForTesting = originalMaxBytes;
+                TestProjectHelper.DeleteDirectory(projectRoot);
             }
         }
     }
@@ -479,6 +539,49 @@ public class PostExtractionHookTests
             finally
             {
                 PostExtractionHookRunner.DiscoveryMaxBytesForTesting = originalMaxBytes;
+                TestProjectHelper.DeleteDirectory(projectRoot);
+            }
+        }
+    }
+
+    [Fact]
+    public void Callbacks_TruncateHookMaterializationAndReportDiagnostics_Issue3744()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("post-extraction-hook-materialization-cap");
+        lock (TestConsoleLock.Gate)
+        {
+            using var env = EnvironmentVariableScope.Capture(ExpandingHookEnvironmentVariable);
+            try
+            {
+                env.Set(ExpandingHookEnvironmentVariable, "1");
+                var hooksDir = Path.Combine(projectRoot, "hooks");
+                Directory.CreateDirectory(hooksDir);
+                File.Copy(Assembly.GetExecutingAssembly().Location, Path.Combine(hooksDir, "CodeIndex.Tests.dll"));
+
+                using var runner = PostExtractionHookRunner.Discover(
+                    hooksDir,
+                    maxSymbolCount: 2,
+                    maxReferenceCount: 2);
+                var context = new FileContext(projectRoot, "src/App.cs", Path.Combine(projectRoot, "src", "App.cs"), "csharp");
+                var symbols = new List<SymbolRecord>();
+                var references = new List<ReferenceRecord>();
+
+                runner.OnSymbolsExtracted(context, symbols);
+                runner.OnReferencesExtracted(context, references);
+
+                Assert.True(symbols.Count <= 2);
+                Assert.True(references.Count <= 2);
+                Assert.Contains(
+                    runner.Diagnostics,
+                    diagnostic => diagnostic.Category == "hook_symbol_count_truncated"
+                                  && diagnostic.Message.Contains("materialization budget", StringComparison.Ordinal));
+                Assert.Contains(
+                    runner.Diagnostics,
+                    diagnostic => diagnostic.Category == "hook_reference_count_truncated"
+                                  && diagnostic.Message.Contains("materialization budget", StringComparison.Ordinal));
+            }
+            finally
+            {
                 TestProjectHelper.DeleteDirectory(projectRoot);
             }
         }
@@ -688,5 +791,44 @@ public sealed class LoadContextReportingPostExtractionHook : IPostExtractionHook
 
     public void OnReferencesExtracted(FileContext context, IList<ReferenceRecord> references)
     {
+    }
+}
+
+public sealed class ExpandingPostExtractionHook : IPostExtractionHook
+{
+    public void OnSymbolsExtracted(FileContext context, IList<SymbolRecord> symbols)
+    {
+        if (Environment.GetEnvironmentVariable(PostExtractionHookTests.ExpandingHookEnvironmentVariable) != "1")
+            return;
+
+        for (var index = 0; index < 5; index++)
+        {
+            symbols.Add(new SymbolRecord
+            {
+                Kind = "domain_tag",
+                Name = $"ExpandedHookSymbol{index}",
+                Line = index + 1,
+                StartLine = index + 1,
+                EndLine = index + 1,
+            });
+        }
+    }
+
+    public void OnReferencesExtracted(FileContext context, IList<ReferenceRecord> references)
+    {
+        if (Environment.GetEnvironmentVariable(PostExtractionHookTests.ExpandingHookEnvironmentVariable) != "1")
+            return;
+
+        for (var index = 0; index < 5; index++)
+        {
+            references.Add(new ReferenceRecord
+            {
+                SymbolName = $"ExpandedHookSymbol{index}",
+                ReferenceKind = "domain_reference",
+                Line = index + 1,
+                Column = 1,
+                Context = context.Path,
+            });
+        }
     }
 }

--- a/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
+++ b/tests/CodeIndex.Tests/ReferenceExtractorTests.cs
@@ -170,6 +170,111 @@ public partial class ReferenceExtractorTests
     }
 
     [Fact]
+    public void Extract_CustomReferencePlugin_ReceivesReferenceBudget_Issue3744()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            try
+            {
+                ExtractorPluginRegistry.ResetForTests();
+                ExtractorPluginRegistry.Register(new BudgetReportingReferenceExtractor());
+
+                var result = ReferenceExtractor.ExtractDetailed(
+                    3,
+                    "budgetdsl",
+                    "call Widget",
+                    [],
+                    "demo.budget",
+                    maxReferenceCount: 7);
+
+                var reference = Assert.Single(result.References);
+                Assert.Equal("budget:7", reference.SymbolName);
+                Assert.Empty(result.Diagnostics);
+            }
+            finally
+            {
+                ExtractorPluginRegistry.ResetForTests();
+            }
+        }
+    }
+
+    [Fact]
+    public void Extract_CustomReferencePlugin_TruncatesOversizedPluginOutput_Issue3744()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            try
+            {
+                ExtractorPluginRegistry.ResetForTests();
+                ExtractorPluginRegistry.Register(new NoisyReferenceExtractor(5));
+
+                var result = ReferenceExtractor.ExtractDetailed(
+                    3,
+                    "noisydsl",
+                    "call Widget",
+                    [],
+                    "demo.noisy",
+                    maxReferenceCount: 2);
+
+                Assert.Equal(2, result.References.Count);
+                Assert.Equal(new[] { "Ref0", "Ref1" }, result.References.Select(reference => reference.SymbolName));
+                var diagnostic = Assert.Single(result.Diagnostics);
+                Assert.Equal("plugin_reference_count_truncated", diagnostic.Kind);
+                Assert.Contains("materialization budget", diagnostic.Message, StringComparison.Ordinal);
+            }
+            finally
+            {
+                ExtractorPluginRegistry.ResetForTests();
+            }
+        }
+    }
+
+    [Fact]
+    public void Extract_HighFanoutSymbols_ReportsLookupBudgetDiagnostics_Issue3783()
+    {
+        var symbols = Enumerable
+            .Range(0, ReferenceExtractor.MaxReferenceLookupSymbols + 5)
+            .Select(index => new SymbolRecord
+            {
+                Kind = "function",
+                Name = $"Generated{index}",
+                Line = index + 1,
+                StartLine = index + 1,
+                EndLine = index + 1,
+                BodyStartLine = index + 1,
+                BodyEndLine = index + 1,
+            })
+            .ToList();
+
+        var result = ReferenceExtractor.ExtractDetailed(1, "python", "def use():\n    pass\n", symbols);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Kind == "reference_definition_lookup_symbol_budget_exceeded");
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Kind == "reference_all_definition_lookup_symbol_budget_exceeded");
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Kind == "reference_container_candidate_budget_exceeded");
+    }
+
+    [Fact]
+    public void Extract_SwiftHighFanoutProperties_ReportsPropertyLookupBudgetDiagnostics_Issue3783()
+    {
+        var symbols = Enumerable
+            .Range(0, ReferenceExtractor.MaxSwiftPropertyDefinitionsPerLine + 5)
+            .Select(index => new SymbolRecord
+            {
+                Kind = "property",
+                Name = $"value{index}",
+                Line = 1,
+                StartLine = 1,
+                StartColumn = index + 1,
+                EndLine = 1,
+            })
+            .ToList();
+
+        var result = ReferenceExtractor.ExtractDetailed(1, "swift", "let use = value0\n", symbols);
+
+        Assert.Contains(result.Diagnostics, diagnostic => diagnostic.Kind == "reference_swift_property_line_name_budget_exceeded");
+    }
+
+    [Fact]
     public void Extract_Solution_IndexesProjectPathReferences_Issue3662()
     {
         const string content = """
@@ -16314,6 +16419,42 @@ public partial class ReferenceExtractorTests
         && (type.Name.Contains("Reference", StringComparison.Ordinal)
             || type.Name == "StructuralLineMasker"
             || type.Name == "SqlNameResolver");
+
+    private sealed class BudgetReportingReferenceExtractor : CodeIndex.Indexer.Extensibility.IReferenceExtractor
+    {
+        public string Language => "budgetdsl";
+
+        public IReadOnlyList<ReferenceRecord> Extract(long fileId, string source, ExtractionContext context)
+            =>
+            [
+                new ReferenceRecord
+                {
+                    FileId = fileId,
+                    SymbolName = $"budget:{context.MaxReferenceCount}",
+                    ReferenceKind = "call",
+                    Line = 1,
+                    Column = 1,
+                },
+            ];
+    }
+
+    private sealed class NoisyReferenceExtractor(int referenceCount) : CodeIndex.Indexer.Extensibility.IReferenceExtractor
+    {
+        public string Language => "noisydsl";
+
+        public IReadOnlyList<ReferenceRecord> Extract(long fileId, string source, ExtractionContext context)
+            => Enumerable
+                .Range(0, referenceCount)
+                .Select(index => new ReferenceRecord
+                {
+                    FileId = fileId,
+                    SymbolName = $"Ref{index}",
+                    ReferenceKind = "call",
+                    Line = index + 1,
+                    Column = 1,
+                })
+                .ToList();
+    }
 
     private static IEnumerable<(string Path, Regex Regex)> EnumerateStaticRegexValues(IEnumerable<Type> types)
     {

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19717,6 +19717,52 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScript_ExcessivePathAliasExpansionCandidatesTruncatesWithWarning_Issue3764()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("tsconfig_alias_expansion_candidates_symbols");
+        try
+        {
+            var maxExpansionCandidates = GetSymbolExtractorIntConstant("MaxTypeScriptPathAliasExpansionCandidates");
+            var moduleBody = new string('a', 80);
+            var ruleCount = (maxExpansionCandidates / 20) + 4;
+            var paths = new StringBuilder();
+            for (var i = 0; i < ruleCount; i++)
+            {
+                if (i > 0)
+                    paths.Append(',');
+
+                var prefixLength = i % 40;
+                var suffixLength = i / 40;
+                var pattern = "@/"
+                    + moduleBody[..prefixLength]
+                    + "*"
+                    + (suffixLength == 0 ? string.Empty : moduleBody[^suffixLength..]);
+                paths.Append('"').Append(pattern).Append("\":[\"missing").Append(i).Append("/*\"]");
+            }
+
+            WriteFile(
+                projectRoot,
+                "tsconfig.json",
+                "{\"compilerOptions\":{\"baseUrl\":\".\",\"paths\":{" + paths + "}}}");
+            var moduleName = "@/" + moduleBody;
+            var sourcePath = WriteFile(projectRoot, "src/main.ts", "import value from \"" + moduleName + "\";\n");
+
+            List<SymbolRecord> symbols = [];
+            var stderr = ConsoleCapture.CaptureError(() =>
+                symbols = SymbolExtractor.Extract(1, "typescript", File.ReadAllText(sourcePath), sourcePath));
+
+            Assert.Contains(symbols, s => s.Kind == "import" && s.Name == moduleName);
+            Assert.Contains("Truncated TypeScript path alias expansion candidates", stderr, StringComparison.Ordinal);
+            Assert.Contains("path_alias_expansion_candidate_limit", stderr, StringComparison.Ordinal);
+            Assert.DoesNotContain(moduleName, stderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Extract_JavaScript_ResolvesJsconfigPathAliasImportsAndKeepsMissesLiteral()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("jsconfig_alias_symbols");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -154,6 +154,85 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_JsonBroadObject_EmitsStructuredDataTruncationDiagnostic_Issue3765()
+    {
+        var properties = string.Join(",\n", Enumerable.Range(0, SymbolExtractor.StructuredDataMaxSymbols + 5).Select(index => $"  \"p{index}\": {index}"));
+        var content = "{\n" + properties + "\n}";
+
+        var symbols = SymbolExtractor.Extract(1, "json", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "extraction_diagnostic" && symbol.Name == "structured_data_symbol_budget_exceeded");
+        Assert.True(symbols.Count <= SymbolExtractor.StructuredDataMaxSymbols + 1);
+    }
+
+    [Fact]
+    public void Extract_JsonDeepObject_EmitsStructuredDataDepthDiagnostic_Issue3765()
+    {
+        var builder = new StringBuilder();
+        for (var index = 0; index <= SymbolExtractor.StructuredDataMaxDepth; index++)
+            builder.Append("{\"p").Append(index).Append("\":");
+        builder.Append('0');
+        for (var index = 0; index <= SymbolExtractor.StructuredDataMaxDepth; index++)
+            builder.Append('}');
+
+        var symbols = SymbolExtractor.Extract(1, "json", builder.ToString());
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "extraction_diagnostic" && symbol.Name == "structured_data_depth_budget_exceeded");
+    }
+
+    [Fact]
+    public void Extract_YamlBroadMapping_EmitsStructuredDataTruncationDiagnostic_Issue3765()
+    {
+        var content = string.Join('\n', Enumerable.Range(0, SymbolExtractor.StructuredDataMaxSymbols + 5).Select(index => $"p{index}: {index}"));
+
+        var symbols = SymbolExtractor.Extract(1, "yaml", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "extraction_diagnostic" && symbol.Name == "structured_data_symbol_budget_exceeded");
+        Assert.True(symbols.Count <= SymbolExtractor.StructuredDataMaxSymbols + 1);
+    }
+
+    [Fact]
+    public void Extract_XmlBroadXaml_EmitsStructuredDataTruncationDiagnostic_Issue3765()
+    {
+        var elements = string.Join('\n', Enumerable.Range(0, SymbolExtractor.StructuredDataMaxSymbols + 5).Select(index => $"""  <Button x:Name="Button{index}" />"""));
+        var content = $$"""
+            <Window x:Class="App.MainWindow" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+            {{elements}}
+            </Window>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "xml", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "extraction_diagnostic" && symbol.Name == "structured_data_xml_symbol_budget_exceeded");
+        Assert.True(symbols.Count <= SymbolExtractor.StructuredDataMaxSymbols + 1);
+    }
+
+    [Fact]
+    public void Extract_DockerfileJsonFormVolume_EmitsArrayTruncationDiagnostic_Issue3765()
+    {
+        var items = string.Join(", ", Enumerable.Range(0, SymbolExtractor.DockerfileJsonFormMaxItems + 1).Select(index => $"\"/data/{index}\""));
+        var content = $"FROM alpine\nVOLUME [{items}]\n";
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "extraction_diagnostic" && symbol.Name == "dockerfile_json_form_array_budget_exceeded");
+    }
+
+    [Fact]
+    public void Extract_DockerfileJsonFormCopy_EmitsBodyTruncationDiagnostic_Issue3765()
+    {
+        var longPath = "/" + new string('a', SymbolExtractor.DockerfileJsonFormMaxBodyLength + 1);
+        var content = $$"""
+            FROM alpine
+            COPY ["src", "{{longPath}}"]
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "dockerfile", content);
+
+        Assert.Contains(symbols, symbol => symbol.Kind == "extraction_diagnostic" && symbol.Name == "dockerfile_json_form_body_budget_exceeded");
+    }
+
+    [Fact]
     public void Extract_Solution_IndexesProjectEntries_Issue3662()
     {
         const string content = """


### PR DESCRIPTION
## Summary
- Clamp post-extraction hook callback/discovery budgets and cap hook callback materialized symbol/reference payloads.
- Cap plugin reference extraction output, reference lookup materialization, TypeScript alias expansion, language-map patterns, structured-data traversal, and Dockerfile JSON-form fanout.
- Add bilingual changelog fragments for #3734, #3744, #3764, #3765, and #3783.
- Merge latest `origin/main` through `3857f1027ec083c526a1ce1296cf76b5583f550a` and resolve the post-extraction hook conflict by preserving both cancellation and materialization-budget behavior.
- Stabilize the #3744 hook materialization test cleanup by unloading hook assemblies before deleting the temporary hook project on Windows.

## Issues
Fixes #3783
Fixes #3744
Fixes #3765
Fixes #3764
Fixes #3734

## Validation
- `git diff --check`
- `dotnet ./tools/CodeIndex.Changelog/bin/Release/net8.0/CodeIndex.Changelog.dll check`
- `dotnet build src/CodeIndex/CodeIndex.csproj --configuration Release --framework net8.0 --no-restore -p:UseSharedCompilation=false -p:BuildInParallel=false -p:RunAnalyzers=false /m:1 /nr:false -v:minimal`
- `dotnet restore tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:NuGetAudit=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --configuration Release --framework net8.0 --no-restore -p:UseSharedCompilation=false -p:BuildInParallel=false /m:1 --filter "FullyQualifiedName~PostExtractionHookTests.Callbacks_TruncateHookMaterializationAndReportDiagnostics_Issue3744|FullyQualifiedName~PostExtractionHookTests.OnSymbolsExtracted_CancellationWhileWaitingForCallback_KillsWorker_Issue3773"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --configuration Release --framework net8.0 --no-build --filter "FullyQualifiedName~Extract_XmlBroadXaml_EmitsStructuredDataTruncationDiagnostic_Issue3765|FullyQualifiedName~Extract_Json_CapsBroadObjects_Issue3808|FullyQualifiedName~Extract_Yaml_CapsBroadMappings_Issue3808" -v:minimal` attempted earlier; local VSTest TCP listener bind was blocked in that environment (`SocketException (13): Permission denied`).
- GitHub Actions will re-run for `d7c09685f6e27240c54e1f12f073c725a8076b6d`.

## Documentation And Changelog
- `changelog.d/unreleased/3734.fixed.md`
- `changelog.d/unreleased/3744.fixed.md`
- `changelog.d/unreleased/3764.fixed.md`
- `changelog.d/unreleased/3765.fixed.md`
- `changelog.d/unreleased/3783.fixed.md`

## Review
- Codex adversarial review performed; it found a JSON depth-budget continuation issue in the structured-data extractor, which was fixed before this PR.
- CI/conflict follow-up reviews performed for `89511305`, `84e1fd4d`, `bf111fd0f`, and the latest `origin/main` merge `d7c09685f`; no blocking/actionable issues found.