### PR TITLE
Harden LSP framing and session budgets

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -2197,9 +2197,14 @@ conservative `hover`, `completion`, `documentHighlight`, `semanticTokens/full`,
 `codeLens`, and `inlayHint` providers backed by indexed symbols and references
 where available.
 Open buffers sent through `textDocument/didOpen`, `textDocument/didChange`, and
-`textDocument/didClose` are kept in a bounded in-memory cache. Position-based
-requests read the live buffer first, so unsaved edits can drive token lookup
-without writing back to the CodeIndex database.
+`textDocument/didClose` are kept in a bounded in-memory cache: each document is
+capped at 4194304 bytes, the session holds at most 64 live documents and
+16777216 aggregate live-document bytes, and older entries are evicted when a
+budget is exceeded. `textDocument/didChange` processes only the last 64 change
+entries in an oversized `contentChanges` array, preserving the latest full-text
+update without retaining unbounded intermediate edits. Position-based requests
+read the live buffer first, so unsaved edits can drive token lookup without
+writing back to the CodeIndex database.
 Incoming `textDocument.uri` values must be strings, must be absolute `file:`
 URIs, and are rejected before URI parsing when they exceed 4096 characters,
 matching the MCP resource URI limit and keeping error responses bounded. LSP
@@ -2207,7 +2212,9 @@ frame parsing also rejects more than 64 header lines, more than 65536 aggregate
 header bytes, any one header line above 8192 bytes, duplicate, negative,
 malformed, or body-over-limit `Content-Length` headers, and bodies above
 8388608 bytes before reading the message body. JSON parse errors report only
-sanitized payload-size and max-depth context, not payload text.
+sanitized payload-size and max-depth context, not payload text. Outgoing LSP
+responses are also capped at 8388608 body bytes; an oversized result is replaced
+with a bounded JSON-RPC error.
 The stdio loop observes the CLI cancellation token while reading headers and
 message bodies, so Ctrl-C / host cancellation can interrupt pending frame reads
 instead of waiting for another complete request.
@@ -2223,6 +2230,9 @@ hierarchical `DocumentSymbol` children when container metadata is available,
 returns at most 1000 indexed symbols, truncates each `detail` string to 512
 characters with `...`, and trims the tree before the result array exceeds
 524288 JSON bytes.
+`textDocument/hover` renders indexed paths relative to the project/workspace
+root when possible and uses `[outside workspace]` for absolute paths outside the
+known roots.
 Position-based `definition` and `references` lookups read at most 16384
 characters from the target source line before returning an empty result.
 `textDocument/references` honors `context.includeDeclaration`; when true, the
@@ -4750,16 +4760,21 @@ indexed symbols / references で答えられる範囲に限定した `hover`、`
 `documentHighlight`、`semanticTokens/full`、`codeLens`、`inlayHint` provider を
 advertise します。
 `textDocument/didOpen`、`textDocument/didChange`、`textDocument/didClose` で送られた
-open buffer は上限付きの in-memory cache に保持されます。position-based request は
-live buffer を先に読むため、未保存の編集内容でも CodeIndex database に書き戻さず token lookup に
-利用できます。
+open buffer は上限付きの in-memory cache に保持されます。各 document は 4194304 bytes、
+session 全体では最大 64 live documents / 16777216 aggregate live-document bytes に制限され、
+budget を超えた場合は古い entry から evict されます。`textDocument/didChange` は過大な
+`contentChanges` array では最後の 64 change entries だけを処理し、unbounded な intermediate edit を
+保持せずに最新の full-text update を維持します。position-based request は live buffer を先に読むため、
+未保存の編集内容でも CodeIndex database に書き戻さず token lookup に利用できます。
 受信した `textDocument.uri` は string かつ absolute `file:` URI である必要があり、
 4096 文字を超える場合は URI parse の前に拒否されます。これは MCP resource URI の上限と
 揃えており、エラー応答が過大にならないようにします。
 LSP frame parsing は、message body を読む前に 64 行を超える header、合計 65536 bytes を
 超える header、8192 bytes を超える単一 header 行、重複・負数・不正形式・body 上限超過の
 `Content-Length` header、8388608 bytes を超える body を拒否します。JSON parse error は
-payload 本文ではなく、sanitized された payload size と max depth context だけを報告します。
+payload 本文ではなく、sanitized された payload size と max depth context だけを報告します。送信する
+LSP response も body 8388608 bytes で上限をかけ、過大な result は bounded な JSON-RPC error に
+置き換えます。
 stdio loop は header / message body 読み取り中も CLI cancellation token を監視するため、
 Ctrl-C や host cancellation が次の完全な request を待たずに pending frame read を中断できます。
 method-not-found diagnostic で echo する method name は最大 240 文字に制限され、
@@ -4772,6 +4787,8 @@ invalid request として拒否します。
 clamp します。`textDocument/documentSymbol` は container metadata がある場合に階層化された
 `DocumentSymbol` children を返し、最大 1000 件の indexed symbol を返し、各 `detail` string を
 `...` 付きの 512 文字に切り詰め、result tree が 524288 JSON bytes を超える前に trim します。
+`textDocument/hover` は indexed path を可能な場合は project / workspace root からの相対 path として
+表示し、既知の root 外の absolute path は `[outside workspace]` に置き換えます。
 position-based な `definition` / `references` lookup は、対象 source line を最大 16384 文字まで読み、
 超過時は空の result を返します。
 `textDocument/references` は `context.includeDeclaration` を尊重し、true の場合は definition location を

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -2204,8 +2204,10 @@ Incoming `textDocument.uri` values must be strings, must be absolute `file:`
 URIs, and are rejected before URI parsing when they exceed 4096 characters,
 matching the MCP resource URI limit and keeping error responses bounded. LSP
 frame parsing also rejects more than 64 header lines, more than 65536 aggregate
-header bytes, any one header line above 8192 bytes, duplicate `Content-Length`
-headers, or a body above 8388608 bytes before reading the message body.
+header bytes, any one header line above 8192 bytes, duplicate, negative,
+malformed, or body-over-limit `Content-Length` headers, and bodies above
+8388608 bytes before reading the message body. JSON parse errors report only
+sanitized payload-size and max-depth context, not payload text.
 The stdio loop observes the CLI cancellation token while reading headers and
 message bodies, so Ctrl-C / host cancellation can interrupt pending frame reads
 instead of waiting for another complete request.
@@ -4755,8 +4757,9 @@ live buffer を先に読むため、未保存の編集内容でも CodeIndex dat
 4096 文字を超える場合は URI parse の前に拒否されます。これは MCP resource URI の上限と
 揃えており、エラー応答が過大にならないようにします。
 LSP frame parsing は、message body を読む前に 64 行を超える header、合計 65536 bytes を
-超える header、8192 bytes を超える単一 header 行、重複した `Content-Length` header、
-8388608 bytes を超える body を拒否します。
+超える header、8192 bytes を超える単一 header 行、重複・負数・不正形式・body 上限超過の
+`Content-Length` header、8388608 bytes を超える body を拒否します。JSON parse error は
+payload 本文ではなく、sanitized された payload size と max depth context だけを報告します。
 stdio loop は header / message body 読み取り中も CLI cancellation token を監視するため、
 Ctrl-C や host cancellation が次の完全な request を待たずに pending frame read を中断できます。
 method-not-found diagnostic で echo する method name は最大 240 文字に制限され、

--- a/changelog.d/unreleased/3757.fixed.md
+++ b/changelog.d/unreleased/3757.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3757
+affected:
+  - src/CodeIndex/Lsp/LspServer.cs
+  - tests/CodeIndex.Tests/LspServerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **LSP frame parsing now reports bounded diagnostics for malformed input (#3757)** — `cdidx lsp` now distinguishes duplicate, negative, malformed, and over-limit `Content-Length` headers, while JSON parse errors include only sanitized payload size and depth context.
+
+## 日本語
+
+- **LSP frame parsing が malformed input に bounded diagnostic を返すようになりました (#3757)** — `cdidx lsp` は重複・負数・不正形式・上限超過の `Content-Length` header を区別し、JSON parse error では sanitized された payload size と depth context だけを含めます。

--- a/changelog.d/unreleased/3799.security.md
+++ b/changelog.d/unreleased/3799.security.md
@@ -1,0 +1,18 @@
+---
+category: security
+issues:
+  - 3799
+affected:
+  - src/CodeIndex/Lsp/LspServer.cs
+  - src/CodeIndex/Cli/BoundedHttpContentReader.cs
+  - tests/CodeIndex.Tests/LspServerTests.cs
+  - tests/CodeIndex.Tests/BoundedHttpContentReaderTests.cs
+---
+
+## English
+
+- **LSP and HTTP payload reads now clear pooled buffers before reuse (#3799)** — temporary payload buffers now have explicit rent/direct-allocation boundaries and clear sensitive bytes before returning pooled storage.
+
+## 日本語
+
+- **LSP と HTTP payload read が pooled buffer の再利用前に内容を clear するようになりました (#3799)** — temporary payload buffer は rent / direct allocation の境界を明示し、pooled storage に戻す前に sensitive bytes を clear します。

--- a/changelog.d/unreleased/3817.changed.md
+++ b/changelog.d/unreleased/3817.changed.md
@@ -1,0 +1,17 @@
+---
+category: changed
+issues:
+  - 3817
+affected:
+  - src/CodeIndex/Lsp/LspServer.cs
+  - tests/CodeIndex.Tests/LspServerBudgetTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **LSP sessions now enforce aggregate live-document and response budgets (#3817)** — `cdidx lsp` now evicts live documents by aggregate byte budget, bounds oversized `contentChanges` arrays, caches per-file line lookups for semantic tokens and inlay hints, redacts hover paths outside known roots, and rejects oversized response frames.
+
+## 日本語
+
+- **LSP session が aggregate live-document budget と response budget を enforce するようになりました (#3817)** — `cdidx lsp` は aggregate byte budget による live document eviction、過大な `contentChanges` array の制限、semantic tokens / inlay hints 向け per-file line lookup cache、既知 root 外の hover path redaction、過大な response frame の拒否を行います。

--- a/src/CodeIndex/Cli/BoundedHttpContentReader.cs
+++ b/src/CodeIndex/Cli/BoundedHttpContentReader.cs
@@ -4,7 +4,7 @@ namespace CodeIndex.Cli;
 
 internal static class BoundedHttpContentReader
 {
-    private const int BufferSize = 81920;
+    internal const int PooledCopyBufferSize = 81920;
 
     internal static async Task<byte[]> ReadAsByteArrayAsync(
         HttpContent content,
@@ -53,7 +53,7 @@ internal static class BoundedHttpContentReader
             Mode = FileMode.CreateNew,
             Access = FileAccess.Write,
             Share = FileShare.None,
-            BufferSize = BufferSize,
+            BufferSize = PooledCopyBufferSize,
             Options = FileOptions.SequentialScan,
         };
 
@@ -69,7 +69,7 @@ internal static class BoundedHttpContentReader
         long maxBytes,
         CancellationToken cancellationToken)
     {
-        var buffer = ArrayPool<byte>.Shared.Rent(BufferSize);
+        var buffer = ArrayPool<byte>.Shared.Rent(PooledCopyBufferSize);
         try
         {
             long copied = 0;
@@ -90,8 +90,19 @@ internal static class BoundedHttpContentReader
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(buffer);
+            ClearSensitiveCopyBuffer(buffer);
+            ArrayPool<byte>.Shared.Return(buffer, clearArray: false);
         }
+    }
+
+    internal static void ClearSensitiveCopyBufferForTests(byte[] buffer) =>
+        ClearSensitiveCopyBuffer(buffer);
+
+    private static void ClearSensitiveCopyBuffer(byte[] buffer)
+    {
+        if (buffer.Length == 0)
+            return;
+        Array.Clear(buffer, 0, buffer.Length);
     }
 
     private static void ThrowIfContentLengthExceedsLimit(HttpContent content, long maxBytes)

--- a/src/CodeIndex/Lsp/LspServer.cs
+++ b/src/CodeIndex/Lsp/LspServer.cs
@@ -17,12 +17,15 @@ internal sealed class LspServer : IDisposable
     internal const int MaxWorkspaceSymbols = 1000;
     private const int MaxWorkspaceFolders = 32;
     internal const int MaxLspFrameBytes = 8 * 1024 * 1024;
+    internal const int MaxLspResponseFrameBytes = MaxLspFrameBytes;
     internal const int MaxLspHeaderLineBytes = 8 * 1024;
     internal const int MaxLspHeaderCount = 64;
     internal const int MaxLspHeaderBytes = 64 * 1024;
     internal const int MaxPositionDocumentBytes = 4 * 1024 * 1024;
+    internal const int MaxLiveDocumentBytes = 16 * 1024 * 1024;
     internal const int MaxPooledPayloadBufferBytes = 1024 * 1024;
     internal const int MaxLiveDocuments = 64;
+    internal const int MaxContentChangesPerNotification = 64;
     internal const int MaxTextDocumentUriChars = McpBoundedText.MaxResourceUriChars;
     internal const int MaxLspRequestIdRawBytes = 4 * 1024;
     internal const int MaxJsonDepth = 32;
@@ -124,7 +127,12 @@ internal sealed class LspServer : IDisposable
     private bool _exitRequestedBeforeShutdown;
     private readonly List<string> _workspaceFolders = [];
     private readonly Dictionary<string, string> _liveDocuments;
+    private readonly Dictionary<string, int> _liveDocumentByteCounts;
     private readonly List<string> _liveDocumentOrder = [];
+    private long _liveDocumentBytes;
+    private long _liveDocumentEvictionCount;
+    private long _liveDocumentEvictedBytes;
+    private long _contentChangeEntriesDropped;
 
     private readonly record struct PositionTokenContext(string Token, string IndexedPath, string? WorkspaceRoot, int Line, int StartCharacter, int EndCharacter);
     private readonly record struct DocumentSymbolNode(SymbolResult Symbol, JsonObject Item);
@@ -175,9 +183,18 @@ internal sealed class LspServer : IDisposable
             _pathStringComparison == StringComparison.OrdinalIgnoreCase
                 ? StringComparer.OrdinalIgnoreCase
                 : StringComparer.Ordinal);
+        _liveDocumentByteCounts = new Dictionary<string, int>(_liveDocuments.Comparer);
         if (_projectRoot != null)
             _workspaceFolders.Add(Path.GetFullPath(_projectRoot));
     }
+
+    internal long LiveDocumentBytesForTests => _liveDocumentBytes;
+
+    internal long LiveDocumentEvictionCountForTests => _liveDocumentEvictionCount;
+
+    internal long LiveDocumentEvictedBytesForTests => _liveDocumentEvictedBytes;
+
+    internal long ContentChangeEntriesDroppedForTests => _contentChangeEntriesDropped;
 
     /// <summary>
     /// Compatibility wrapper that runs without caller cancellation. Prefer the overload that
@@ -195,7 +212,7 @@ internal sealed class LspServer : IDisposable
             var response = HandleMessage(payload);
             cancellationToken.ThrowIfCancellationRequested();
             if (response != null)
-                WriteMessage(output, response.ToJsonString(_jsonOptions));
+                WriteResponseMessage(output, response);
             if (_exitRequested)
                 break;
         }
@@ -469,8 +486,18 @@ internal sealed class LspServer : IDisposable
             return null;
 
         string? latestText = null;
-        foreach (var change in changes.EnumerateArray())
+        var changeCount = changes.GetArrayLength();
+        var startIndex = 0;
+        if (changeCount > MaxContentChangesPerNotification)
         {
+            startIndex = changeCount - MaxContentChangesPerNotification;
+            _contentChangeEntriesDropped += startIndex;
+            Activity.Current?.SetTag("lsp.content_changes.dropped", _contentChangeEntriesDropped);
+        }
+
+        for (var i = startIndex; i < changeCount; i++)
+        {
+            var change = changes[i];
             if (change.ValueKind == JsonValueKind.Object
                 && change.TryGetProperty("text", out var textElement)
                 && textElement.ValueKind == JsonValueKind.String)
@@ -497,39 +524,55 @@ internal sealed class LspServer : IDisposable
         if (!TryGetLiveDocumentKeyFromUri(uri, out var key))
             return;
 
-        if (Encoding.UTF8.GetByteCount(text) > MaxPositionDocumentBytes)
+        var textBytes = Encoding.UTF8.GetByteCount(text);
+        if (textBytes > MaxPositionDocumentBytes || textBytes > MaxLiveDocumentBytes)
         {
             RemoveLiveDocument(key);
             return;
         }
 
-        EnsureLiveDocumentCapacity(key);
+        if (!_liveDocuments.ContainsKey(key))
+            _liveDocumentOrder.Add(key);
+        else if (_liveDocumentByteCounts.TryGetValue(key, out var previousBytes))
+            _liveDocumentBytes = Math.Max(0, _liveDocumentBytes - previousBytes);
+
         _liveDocuments[key] = text;
+        _liveDocumentByteCounts[key] = textBytes;
+        _liveDocumentBytes += textBytes;
+        EnsureLiveDocumentCapacity();
+        Activity.Current?.SetTag("lsp.live_documents.bytes", _liveDocumentBytes);
+        Activity.Current?.SetTag("lsp.live_documents.eviction_count", _liveDocumentEvictionCount);
     }
 
-    private void EnsureLiveDocumentCapacity(string key)
+    private void EnsureLiveDocumentCapacity()
     {
-        if (_liveDocuments.ContainsKey(key))
-            return;
-
-        while (_liveDocuments.Count >= MaxLiveDocuments && _liveDocumentOrder.Count > 0)
+        while ((_liveDocuments.Count > MaxLiveDocuments || _liveDocumentBytes > MaxLiveDocumentBytes)
+            && _liveDocumentOrder.Count > 0)
         {
             var oldestKey = _liveDocumentOrder[0];
-            _liveDocumentOrder.RemoveAt(0);
-            _liveDocuments.Remove(oldestKey);
+            RemoveLiveDocument(oldestKey, recordEviction: true);
         }
 
-        if (_liveDocuments.Count >= MaxLiveDocuments)
+        if (_liveDocuments.Count > MaxLiveDocuments || _liveDocumentBytes > MaxLiveDocumentBytes)
         {
             _liveDocuments.Clear();
+            _liveDocumentByteCounts.Clear();
             _liveDocumentOrder.Clear();
+            _liveDocumentBytes = 0;
         }
-
-        _liveDocumentOrder.Add(key);
     }
 
-    private void RemoveLiveDocument(string key)
+    private void RemoveLiveDocument(string key, bool recordEviction = false)
     {
+        if (_liveDocumentByteCounts.Remove(key, out var bytes))
+        {
+            _liveDocumentBytes = Math.Max(0, _liveDocumentBytes - bytes);
+            if (recordEviction)
+            {
+                _liveDocumentEvictionCount++;
+                _liveDocumentEvictedBytes += bytes;
+            }
+        }
         _liveDocuments.Remove(key);
         _liveDocumentOrder.RemoveAll(existing => string.Equals(existing, key, _pathStringComparison));
     }
@@ -800,10 +843,11 @@ internal sealed class LspServer : IDisposable
         if (!TryResolveIndexedDocument(root, out var document))
             return new JsonObject { ["data"] = new JsonArray() };
 
+        var lineCache = new Dictionary<int, string?>();
         var symbols = GetDocumentSymbols(document.IndexedPath, MaxSemanticTokenItems)
             .Where(symbol => !string.IsNullOrWhiteSpace(symbol.Name))
             .Take(MaxSemanticTokenItems)
-            .Select(symbol => BuildSemanticToken(document, symbol))
+            .Select(symbol => BuildSemanticToken(document, symbol, lineCache))
             .Where(token => token.HasValue)
             .Select(token => token!.Value)
             .OrderBy(token => token.Line)
@@ -845,11 +889,12 @@ internal sealed class LspServer : IDisposable
             return [];
 
         var array = new JsonArray();
+        var lineCache = new Dictionary<int, string?>();
         foreach (var symbol in GetDocumentSymbols(document.IndexedPath, MaxInlayHintItems)
             .Where(symbol => !string.IsNullOrWhiteSpace(symbol.ReturnType))
             .Take(MaxInlayHintItems))
         {
-            array.Add((JsonNode)ToInlayHint(document, symbol));
+            array.Add((JsonNode)ToInlayHint(document, symbol, lineCache));
         }
         return array;
     }
@@ -871,18 +916,40 @@ internal sealed class LspServer : IDisposable
         ["sortText"] = index.ToString("D4", CultureInfo.InvariantCulture) + "_" + symbol.Name,
     };
 
-    private static string FormatHoverText(SymbolResult symbol)
+    private string FormatHoverText(SymbolResult symbol)
     {
         var builder = new StringBuilder();
         builder.Append(symbol.Kind).Append(' ').Append(symbol.Name);
         if (!string.IsNullOrWhiteSpace(symbol.Signature))
             builder.AppendLine().Append(symbol.Signature);
-        builder.AppendLine().Append(symbol.Path).Append(':').Append(symbol.Line.ToString(CultureInfo.InvariantCulture));
+        builder.AppendLine().Append(FormatHoverPath(symbol.Path)).Append(':').Append(symbol.Line.ToString(CultureInfo.InvariantCulture));
         if (!string.IsNullOrWhiteSpace(symbol.ContainerName))
             builder.AppendLine().Append("container: ").Append(symbol.ContainerName);
         if (!string.IsNullOrWhiteSpace(symbol.ReturnType))
             builder.AppendLine().Append("returns: ").Append(symbol.ReturnType);
         return builder.ToString();
+    }
+
+    private string FormatHoverPath(string path)
+    {
+        if (!Path.IsPathRooted(path))
+            return path.Replace('\\', '/');
+
+        foreach (var root in EnumerateHoverRoots())
+        {
+            if (TryGetRelativePath(root, path, out var relativePath) && relativePath != null)
+                return relativePath.Replace('\\', '/');
+        }
+
+        return "[outside workspace]";
+    }
+
+    private IEnumerable<string> EnumerateHoverRoots()
+    {
+        if (_projectRoot != null)
+            yield return _projectRoot;
+        foreach (var workspaceFolder in _workspaceFolders)
+            yield return workspaceFolder;
     }
 
     private static string FormatSymbolDetail(SymbolResult symbol)
@@ -937,9 +1004,9 @@ internal sealed class LspServer : IDisposable
         },
     };
 
-    private JsonObject ToInlayHint(IndexedDocumentContext document, SymbolResult symbol)
+    private JsonObject ToInlayHint(IndexedDocumentContext document, SymbolResult symbol, Dictionary<int, string?> lineCache)
     {
-        var startCharacter = FindSymbolStartCharacter(document, symbol);
+        var startCharacter = FindSymbolStartCharacter(document, symbol, lineCache);
         return new JsonObject
         {
             ["position"] = ToPosition(symbol.Line, startCharacter + symbol.Name.Length + 1),
@@ -951,13 +1018,13 @@ internal sealed class LspServer : IDisposable
 
     private readonly record struct SemanticToken(int Line, int StartCharacter, int Length, int TokenType, int TokenModifiers);
 
-    private SemanticToken? BuildSemanticToken(IndexedDocumentContext document, SymbolResult symbol)
+    private SemanticToken? BuildSemanticToken(IndexedDocumentContext document, SymbolResult symbol, Dictionary<int, string?> lineCache)
     {
         var line = Math.Max(symbol.Line, symbol.StartLine);
         if (line <= 0)
             return null;
 
-        var startCharacter = FindSymbolStartCharacter(document, symbol);
+        var startCharacter = FindSymbolStartCharacter(document, symbol, lineCache);
         var length = Math.Max(symbol.Name.Length, 1);
         return new SemanticToken(
             line - 1,
@@ -967,13 +1034,13 @@ internal sealed class LspServer : IDisposable
             1 << 1);
     }
 
-    private int FindSymbolStartCharacter(IndexedDocumentContext document, SymbolResult symbol)
+    private int FindSymbolStartCharacter(IndexedDocumentContext document, SymbolResult symbol, Dictionary<int, string?>? lineCache = null)
     {
         var line = Math.Max(symbol.Line, symbol.StartLine);
         if (line <= 0 || string.IsNullOrWhiteSpace(symbol.Name))
             return 0;
 
-        return TryReadPositionLine(document.ResolvedPath, line - 1, out var sourceLine, out _)
+        return TryReadPositionLineCached(document.ResolvedPath, line - 1, lineCache, out var sourceLine)
             ? Math.Max(0, sourceLine.IndexOf(symbol.Name, StringComparison.Ordinal))
             : 0;
     }
@@ -1288,6 +1355,24 @@ internal sealed class LspServer : IDisposable
             return TryReadPositionLineFromText(liveText, targetLine, out sourceLine, out failureReason);
 
         return TryReadPositionLineFromFile(path, targetLine, out sourceLine, out failureReason);
+    }
+
+    private bool TryReadPositionLineCached(
+        string path,
+        int targetLine,
+        Dictionary<int, string?>? lineCache,
+        out string sourceLine)
+    {
+        if (lineCache != null && lineCache.TryGetValue(targetLine, out var cachedLine))
+        {
+            sourceLine = cachedLine ?? string.Empty;
+            return cachedLine != null;
+        }
+
+        var found = TryReadPositionLine(path, targetLine, out sourceLine, out _);
+        if (lineCache != null)
+            lineCache[targetLine] = found ? sourceLine : null;
+        return found;
     }
 
     private static bool TryReadPositionLineFromText(string text, int targetLine, out string sourceLine, out string? failureReason)
@@ -1982,13 +2067,36 @@ internal sealed class LspServer : IDisposable
             "LSP input ended before a frame was available."),
     };
 
+    private void WriteResponseMessage(Stream output, JsonObject response)
+    {
+        var payload = response.ToJsonString(_jsonOptions);
+        if (TryWriteMessage(output, payload, out _))
+            return;
+
+        var id = response["id"]?.DeepClone();
+        var errorPayload = Error(id, JsonRpcInternalErrorCode, "Response too large").ToJsonString(_jsonOptions);
+        if (!TryWriteMessage(output, errorPayload, out _))
+            throw new InvalidOperationException("LSP response error exceeded the response frame byte limit.");
+    }
+
     internal static void WriteMessage(Stream output, string payload)
     {
+        if (!TryWriteMessage(output, payload, out _))
+            throw new InvalidOperationException($"LSP response body exceeded the {MaxLspResponseFrameBytes} byte limit.");
+    }
+
+    internal static bool TryWriteMessage(Stream output, string payload, out int bodyBytes)
+    {
         var body = Encoding.UTF8.GetBytes(payload);
+        bodyBytes = body.Length;
+        if (body.Length > MaxLspResponseFrameBytes)
+            return false;
+
         var header = Encoding.ASCII.GetBytes($"Content-Length: {body.Length}\r\n\r\n");
         output.Write(header);
         output.Write(body);
         output.Flush();
+        return true;
     }
 
     private static string? ReadAsciiLine(

--- a/src/CodeIndex/Lsp/LspServer.cs
+++ b/src/CodeIndex/Lsp/LspServer.cs
@@ -55,6 +55,16 @@ internal sealed class LspServer : IDisposable
     private const string FailurePositionLineMissing = "position_line_missing";
     private const string FailurePositionFileUnreadable = "position_file_unreadable";
     private const string FailureNoTokenAtPosition = "no_token_at_position";
+    internal const string ReadDiagnosticEndOfStream = "end_of_stream";
+    internal const string ReadDiagnosticIncompleteHeader = "incomplete_header";
+    internal const string ReadDiagnosticHeaderLineTooLarge = "header_line_too_large";
+    internal const string ReadDiagnosticHeaderSectionTooLarge = "header_section_too_large";
+    internal const string ReadDiagnosticDuplicateContentLength = "duplicate_content_length";
+    internal const string ReadDiagnosticMalformedContentLength = "malformed_content_length";
+    internal const string ReadDiagnosticNegativeContentLength = "negative_content_length";
+    internal const string ReadDiagnosticContentLengthTooLarge = "content_length_too_large";
+    internal const string ReadDiagnosticMissingContentLength = "missing_content_length";
+    internal const string ReadDiagnosticIncompleteBody = "incomplete_body";
     private static readonly string[] SemanticTokenTypes =
     [
         "namespace",
@@ -118,6 +128,18 @@ internal sealed class LspServer : IDisposable
     private readonly record struct PositionTokenContext(string Token, string IndexedPath, string? WorkspaceRoot, int Line, int StartCharacter, int EndCharacter);
     private readonly record struct DocumentSymbolNode(SymbolResult Symbol, JsonObject Item);
     private readonly record struct IndexedDocumentContext(string DocumentPath, string ResolvedPath, string IndexedPath, string? WorkspaceRoot);
+    internal readonly record struct LspMessageReadDiagnostic(
+        string Code,
+        string Message,
+        int? ContentLength = null,
+        int? MaxContentLength = null);
+    private enum LspHeaderLineReadFailure
+    {
+        None,
+        EndOfStream,
+        IncompleteHeader,
+        LineTooLarge,
+    }
 
     public LspServer(DbReader reader, string version, JsonSerializerOptions jsonOptions, string? projectRoot = null)
     {
@@ -167,7 +189,7 @@ internal sealed class LspServer : IDisposable
         }
         catch (JsonException)
         {
-            return Error(null, -32700, "Parse error");
+            return Error(null, -32700, FormatParseErrorMessage(payload));
         }
 
         using (document)
@@ -1775,6 +1797,11 @@ internal sealed class LspServer : IDisposable
         },
     };
 
+    private static string FormatParseErrorMessage(string payload)
+        => string.Create(
+            CultureInfo.InvariantCulture,
+            $"Parse error (payload_bytes={Encoding.UTF8.GetByteCount(payload)}, max_json_depth={MaxJsonDepth})");
+
     /// <summary>
     /// Compatibility wrapper that reads without caller cancellation. Prefer the overload that
     /// accepts <see cref="CancellationToken"/> for cancellable transports.
@@ -1785,8 +1812,16 @@ internal sealed class LspServer : IDisposable
         TryReadMessage(input, out payload, CancellationToken.None);
 
     internal static bool TryReadMessage(Stream input, out string payload, CancellationToken cancellationToken)
+        => TryReadMessage(input, out payload, out _, cancellationToken);
+
+    internal static bool TryReadMessage(
+        Stream input,
+        out string payload,
+        out LspMessageReadDiagnostic? diagnostic,
+        CancellationToken cancellationToken = default)
     {
         payload = string.Empty;
+        diagnostic = null;
         var contentLength = -1;
         var hasContentLength = false;
         var headerCount = 0;
@@ -1794,15 +1829,23 @@ internal sealed class LspServer : IDisposable
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var line = ReadAsciiLine(input, cancellationToken);
+            var line = ReadAsciiLine(input, cancellationToken, out var lineFailure);
             if (line == null)
+            {
+                diagnostic = CreateHeaderReadDiagnostic(lineFailure);
                 return false;
+            }
             if (line.Length == 0)
                 break;
             headerCount++;
             headerBytes += line.Length;
             if (headerCount > MaxLspHeaderCount || headerBytes > MaxLspHeaderBytes)
+            {
+                diagnostic = new LspMessageReadDiagnostic(
+                    ReadDiagnosticHeaderSectionTooLarge,
+                    $"LSP headers exceeded {MaxLspHeaderCount} lines or {MaxLspHeaderBytes} bytes.");
                 return false;
+            }
             var colon = line.IndexOf(':');
             if (colon <= 0)
                 continue;
@@ -1811,11 +1854,36 @@ internal sealed class LspServer : IDisposable
             if (string.Equals(name, "Content-Length", StringComparison.OrdinalIgnoreCase))
             {
                 if (hasContentLength)
-                    return false;
-                if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed)
-                    || parsed < 0
-                    || parsed > MaxLspFrameBytes)
                 {
+                    diagnostic = new LspMessageReadDiagnostic(
+                        ReadDiagnosticDuplicateContentLength,
+                        "LSP frame contained more than one Content-Length header.");
+                    return false;
+                }
+
+                if (value.StartsWith("-", StringComparison.Ordinal))
+                {
+                    diagnostic = new LspMessageReadDiagnostic(
+                        ReadDiagnosticNegativeContentLength,
+                        "LSP Content-Length must not be negative.");
+                    return false;
+                }
+
+                if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed))
+                {
+                    diagnostic = new LspMessageReadDiagnostic(
+                        ReadDiagnosticMalformedContentLength,
+                        "LSP Content-Length must be a base-10 byte count.");
+                    return false;
+                }
+
+                if (parsed > MaxLspFrameBytes)
+                {
+                    diagnostic = new LspMessageReadDiagnostic(
+                        ReadDiagnosticContentLengthTooLarge,
+                        $"LSP Content-Length exceeded the {MaxLspFrameBytes} byte limit.",
+                        parsed,
+                        MaxLspFrameBytes);
                     return false;
                 }
 
@@ -1825,7 +1893,12 @@ internal sealed class LspServer : IDisposable
         }
 
         if (contentLength < 0)
+        {
+            diagnostic = new LspMessageReadDiagnostic(
+                ReadDiagnosticMissingContentLength,
+                "LSP frame did not include a Content-Length header.");
             return false;
+        }
 
         var buffer = ArrayPool<byte>.Shared.Rent(contentLength);
         try
@@ -1835,7 +1908,14 @@ internal sealed class LspServer : IDisposable
             {
                 var read = Read(input, buffer, offset, contentLength - offset, cancellationToken);
                 if (read == 0)
+                {
+                    diagnostic = new LspMessageReadDiagnostic(
+                        ReadDiagnosticIncompleteBody,
+                        "LSP frame ended before the declared Content-Length body was complete.",
+                        contentLength,
+                        MaxLspFrameBytes);
                     return false;
+                }
                 offset += read;
             }
             payload = Encoding.UTF8.GetString(buffer, 0, contentLength);
@@ -1847,6 +1927,19 @@ internal sealed class LspServer : IDisposable
         }
     }
 
+    private static LspMessageReadDiagnostic CreateHeaderReadDiagnostic(LspHeaderLineReadFailure failure) => failure switch
+    {
+        LspHeaderLineReadFailure.LineTooLarge => new LspMessageReadDiagnostic(
+            ReadDiagnosticHeaderLineTooLarge,
+            $"LSP header line exceeded the {MaxLspHeaderLineBytes} byte limit."),
+        LspHeaderLineReadFailure.IncompleteHeader => new LspMessageReadDiagnostic(
+            ReadDiagnosticIncompleteHeader,
+            "LSP frame ended before the header section was complete."),
+        _ => new LspMessageReadDiagnostic(
+            ReadDiagnosticEndOfStream,
+            "LSP input ended before a frame was available."),
+    };
+
     internal static void WriteMessage(Stream output, string payload)
     {
         var body = Encoding.UTF8.GetBytes(payload);
@@ -1856,8 +1949,12 @@ internal sealed class LspServer : IDisposable
         output.Flush();
     }
 
-    private static string? ReadAsciiLine(Stream input, CancellationToken cancellationToken)
+    private static string? ReadAsciiLine(
+        Stream input,
+        CancellationToken cancellationToken,
+        out LspHeaderLineReadFailure failure)
     {
+        failure = LspHeaderLineReadFailure.None;
         var buffer = ArrayPool<byte>.Shared.Rent(MaxLspHeaderLineBytes + 1);
         var length = 0;
         try
@@ -1866,7 +1963,12 @@ internal sealed class LspServer : IDisposable
             {
                 var read = Read(input, buffer, length, 1, cancellationToken);
                 if (read == 0)
-                    return length == 0 ? null : Encoding.ASCII.GetString(buffer, 0, length);
+                {
+                    failure = length == 0
+                        ? LspHeaderLineReadFailure.EndOfStream
+                        : LspHeaderLineReadFailure.IncompleteHeader;
+                    return null;
+                }
 
                 var value = buffer[length];
                 if (value == '\n')
@@ -1874,7 +1976,10 @@ internal sealed class LspServer : IDisposable
                 if (value != '\r')
                 {
                     if (length >= MaxLspHeaderLineBytes)
+                    {
+                        failure = LspHeaderLineReadFailure.LineTooLarge;
                         return null;
+                    }
                     length++;
                 }
             }

--- a/src/CodeIndex/Lsp/LspServer.cs
+++ b/src/CodeIndex/Lsp/LspServer.cs
@@ -21,6 +21,7 @@ internal sealed class LspServer : IDisposable
     internal const int MaxLspHeaderCount = 64;
     internal const int MaxLspHeaderBytes = 64 * 1024;
     internal const int MaxPositionDocumentBytes = 4 * 1024 * 1024;
+    internal const int MaxPooledPayloadBufferBytes = 1024 * 1024;
     internal const int MaxLiveDocuments = 64;
     internal const int MaxTextDocumentUriChars = McpBoundedText.MaxResourceUriChars;
     internal const int MaxLspRequestIdRawBytes = 4 * 1024;
@@ -133,6 +134,28 @@ internal sealed class LspServer : IDisposable
         string Message,
         int? ContentLength = null,
         int? MaxContentLength = null);
+    private readonly struct SensitivePayloadBufferLease : IDisposable
+    {
+        private readonly bool _rented;
+        private readonly int _usedBytes;
+
+        internal SensitivePayloadBufferLease(byte[] buffer, int usedBytes, bool rented)
+        {
+            Buffer = buffer;
+            _usedBytes = usedBytes;
+            _rented = rented;
+        }
+
+        internal byte[] Buffer { get; }
+
+        public void Dispose()
+        {
+            ClearSensitivePayloadBuffer(Buffer, _usedBytes);
+            if (_rented)
+                ArrayPool<byte>.Shared.Return(Buffer, clearArray: false);
+        }
+    }
+
     private enum LspHeaderLineReadFailure
     {
         None,
@@ -299,7 +322,8 @@ internal sealed class LspServer : IDisposable
     {
         rawIdBytes = 0;
         var payloadByteCount = Encoding.UTF8.GetByteCount(payload);
-        var buffer = ArrayPool<byte>.Shared.Rent(payloadByteCount);
+        using var lease = RentSensitivePayloadBuffer(payloadByteCount);
+        var buffer = lease.Buffer;
         try
         {
             _ = Encoding.UTF8.GetBytes(payload.AsSpan(), buffer);
@@ -335,10 +359,34 @@ internal sealed class LspServer : IDisposable
         {
             return false;
         }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-        }
+    }
+
+    internal static bool ShouldRentPayloadBuffer(int byteCount)
+    {
+        if (byteCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(byteCount), byteCount, "Byte count must be non-negative.");
+        return byteCount <= MaxPooledPayloadBufferBytes;
+    }
+
+    internal static void ClearSensitivePayloadBufferForTests(byte[] buffer, int usedBytes) =>
+        ClearSensitivePayloadBuffer(buffer, usedBytes);
+
+    private static SensitivePayloadBufferLease RentSensitivePayloadBuffer(int byteCount)
+    {
+        if (byteCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(byteCount), byteCount, "Byte count must be non-negative.");
+        var rented = ShouldRentPayloadBuffer(byteCount);
+        var buffer = rented
+            ? ArrayPool<byte>.Shared.Rent(byteCount)
+            : new byte[byteCount];
+        return new SensitivePayloadBufferLease(buffer, byteCount, rented);
+    }
+
+    private static void ClearSensitivePayloadBuffer(byte[] buffer, int usedBytes)
+    {
+        if (usedBytes <= 0 || buffer.Length == 0)
+            return;
+        Array.Clear(buffer, 0, Math.Min(usedBytes, buffer.Length));
     }
 
     private static string SanitizeUnknownMethod(string method)
@@ -1900,31 +1948,25 @@ internal sealed class LspServer : IDisposable
             return false;
         }
 
-        var buffer = ArrayPool<byte>.Shared.Rent(contentLength);
-        try
+        using var lease = RentSensitivePayloadBuffer(contentLength);
+        var buffer = lease.Buffer;
+        var offset = 0;
+        while (offset < contentLength)
         {
-            var offset = 0;
-            while (offset < contentLength)
+            var read = Read(input, buffer, offset, contentLength - offset, cancellationToken);
+            if (read == 0)
             {
-                var read = Read(input, buffer, offset, contentLength - offset, cancellationToken);
-                if (read == 0)
-                {
-                    diagnostic = new LspMessageReadDiagnostic(
-                        ReadDiagnosticIncompleteBody,
-                        "LSP frame ended before the declared Content-Length body was complete.",
-                        contentLength,
-                        MaxLspFrameBytes);
-                    return false;
-                }
-                offset += read;
+                diagnostic = new LspMessageReadDiagnostic(
+                    ReadDiagnosticIncompleteBody,
+                    "LSP frame ended before the declared Content-Length body was complete.",
+                    contentLength,
+                    MaxLspFrameBytes);
+                return false;
             }
-            payload = Encoding.UTF8.GetString(buffer, 0, contentLength);
-            return true;
+            offset += read;
         }
-        finally
-        {
-            ArrayPool<byte>.Shared.Return(buffer);
-        }
+        payload = Encoding.UTF8.GetString(buffer, 0, contentLength);
+        return true;
     }
 
     private static LspMessageReadDiagnostic CreateHeaderReadDiagnostic(LspHeaderLineReadFailure failure) => failure switch

--- a/tests/CodeIndex.Tests/BoundedHttpContentReaderTests.cs
+++ b/tests/CodeIndex.Tests/BoundedHttpContentReaderTests.cs
@@ -55,6 +55,19 @@ public class BoundedHttpContentReaderTests
     }
 
     [Fact]
+    public async Task ReadAsByteArrayAsync_ReadsNormalUnknownLengthPayload_Issue3799()
+    {
+        var payload = Encoding.UTF8.GetBytes("normal payload");
+
+        var bytes = await BoundedHttpContentReader.ReadAsByteArrayAsync(
+            new UnknownLengthContent(payload),
+            maxBytes: 1024,
+            CancellationToken.None);
+
+        Assert.Equal(payload, bytes);
+    }
+
+    [Fact]
     public async Task ReadAsByteArrayAsync_RejectsDeclaredLengthOverLimit()
     {
         using var content = new ByteArrayContent([1]);
@@ -64,6 +77,18 @@ public class BoundedHttpContentReaderTests
             BoundedHttpContentReader.ReadAsByteArrayAsync(content, maxBytes: 4, CancellationToken.None));
 
         Assert.Contains("4 byte limit", ex.Message);
+    }
+
+    [Fact]
+    public void ClearSensitiveCopyBufferForTests_ClearsWholePooledBuffer_Issue3799()
+    {
+        var buffer = Enumerable.Range(1, BoundedHttpContentReader.PooledCopyBufferSize)
+            .Select(i => (byte)(i % 251))
+            .ToArray();
+
+        BoundedHttpContentReader.ClearSensitiveCopyBufferForTests(buffer);
+
+        Assert.All(buffer, value => Assert.Equal(0, value));
     }
 
     private const UnixFileMode PermissionBits =

--- a/tests/CodeIndex.Tests/LspServerBudgetTests.cs
+++ b/tests/CodeIndex.Tests/LspServerBudgetTests.cs
@@ -1,0 +1,204 @@
+using System.Text.Json;
+using CodeIndex.Cli;
+using CodeIndex.Database;
+using CodeIndex.Lsp;
+
+namespace CodeIndex.Tests;
+
+[Collection("SQLite pool sensitive")]
+public class LspServerBudgetTests
+{
+    [Fact]
+    public void TryWriteMessage_RejectsOversizedResponseFrame_Issue3817()
+    {
+        using var output = new MemoryStream();
+        var payload = new string('x', LspServer.MaxLspResponseFrameBytes + 1);
+
+        Assert.False(LspServer.TryWriteMessage(output, payload, out var bodyBytes));
+
+        Assert.Equal(LspServer.MaxLspResponseFrameBytes + 1, bodyBytes);
+        Assert.Equal(0, output.Length);
+    }
+
+    [Fact]
+    public void HandleMessage_LiveDocumentSync_EvictsOldestBufferWhenAggregateBudgetIsFull_Issue3817()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_lsp_live_sync_byte_bound");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            using var db = new DbContext(dbPath);
+            using var server = new LspServer(new DbReader(db), "1.2.3", ProgramRunner.CreateDefaultJsonOptions(), projectRoot);
+            var text = new string('x', LspServer.MaxPositionDocumentBytes);
+            for (var i = 0; i < 5; i++)
+            {
+                var sourcePath = Path.Combine(projectRoot, $"large{i}.cs");
+                Assert.Null(server.HandleMessage(CreateDidOpenRequest(sourcePath, text, version: i + 1)));
+            }
+
+            Assert.True(server.LiveDocumentBytesForTests <= LspServer.MaxLiveDocumentBytes);
+            Assert.True(server.LiveDocumentEvictionCountForTests > 0);
+            Assert.True(server.LiveDocumentEvictedBytesForTests > 0);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void HandleMessage_LiveDocumentSync_UsesLatestTextWhenContentChangesAreOverLimit_Issue3817()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_lsp_live_sync_changes_bound");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var sourcePath = Path.Combine(projectRoot, "app.cs");
+            var diskSource = "class App { void Needle() { } void Call() { Missing(); } }\n";
+            var latestSource = "class App { void Needle() { } void Call() { Needle(); } }\n";
+            File.WriteAllText(sourcePath, diskSource);
+            TestProjectHelper.InsertIndexedFile(dbPath, "app.cs", "csharp", diskSource);
+            using var db = new DbContext(dbPath);
+            using var server = new LspServer(new DbReader(db), "1.2.3", ProgramRunner.CreateDefaultJsonOptions(), projectRoot);
+            var contentChanges = Enumerable.Range(0, LspServer.MaxContentChangesPerNotification + 5)
+                .Select(i => new { text = i == LspServer.MaxContentChangesPerNotification + 4 ? latestSource : diskSource })
+                .ToArray();
+            var changeRequest = JsonSerializer.Serialize(new
+            {
+                jsonrpc = "2.0",
+                method = "textDocument/didChange",
+                @params = new
+                {
+                    textDocument = new
+                    {
+                        uri = new Uri(sourcePath).AbsoluteUri,
+                        version = 3817,
+                    },
+                    contentChanges,
+                },
+            });
+
+            Assert.Null(server.HandleMessage(CreateDidOpenRequest(sourcePath, diskSource, version: 1)));
+            Assert.Null(server.HandleMessage(changeRequest));
+            var response = server.HandleMessage(CreateDefinitionRequest(
+                sourcePath,
+                3817,
+                0,
+                latestSource.LastIndexOf("Needle();", StringComparison.Ordinal)));
+
+            Assert.NotNull(response);
+            Assert.NotEmpty(response!["result"]!.AsArray());
+            Assert.Equal(5, server.ContentChangeEntriesDroppedForTests);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void HandleMessage_Hover_UsesWorkspaceRelativePath_Issue3817()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_lsp_hover_relative_path");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var sourcePath = Path.Combine(projectRoot, "app.cs");
+            var source = "class App { int Count() { return 1; } void Call() { Count(); } }\n";
+            File.WriteAllText(sourcePath, source);
+            TestProjectHelper.InsertIndexedFile(dbPath, "app.cs", "csharp", source);
+            MarkGraphReady(dbPath);
+            using var db = new DbContext(dbPath);
+            using var server = new LspServer(new DbReader(db), "1.2.3", ProgramRunner.CreateDefaultJsonOptions(), projectRoot);
+
+            var hover = server.HandleMessage(CreatePositionRequest(
+                "textDocument/hover",
+                sourcePath,
+                38170,
+                0,
+                source.LastIndexOf("Count();", StringComparison.Ordinal)));
+
+            Assert.NotNull(hover);
+            var value = hover!["result"]!["contents"]!["value"]!.GetValue<string>();
+            Assert.Contains("app.cs:", value, StringComparison.Ordinal);
+            Assert.DoesNotContain(projectRoot, value, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void HandleMessage_Hover_RedactsAbsolutePathWithoutWorkspaceRoot_Issue3817()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_lsp_hover_redacted_path");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var sourcePath = Path.Combine(projectRoot, "app.cs");
+            var source = "class App { int Count() { return 1; } void Call() { Count(); } }\n";
+            File.WriteAllText(sourcePath, source);
+            TestProjectHelper.InsertIndexedFile(dbPath, sourcePath, "csharp", source);
+            MarkGraphReady(dbPath);
+            using var db = new DbContext(dbPath);
+            using var server = new LspServer(new DbReader(db), "1.2.3", ProgramRunner.CreateDefaultJsonOptions());
+
+            var hover = server.HandleMessage(CreatePositionRequest(
+                "textDocument/hover",
+                sourcePath,
+                38171,
+                0,
+                source.LastIndexOf("Count();", StringComparison.Ordinal)));
+
+            Assert.NotNull(hover);
+            var value = hover!["result"]!["contents"]!["value"]!.GetValue<string>();
+            Assert.Contains("[outside workspace]:", value, StringComparison.Ordinal);
+            Assert.DoesNotContain(sourcePath, value, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    private static string CreateDefinitionRequest(string sourcePath, int id, int line, int character) =>
+        CreatePositionRequest("textDocument/definition", sourcePath, id, line, character);
+
+    private static string CreatePositionRequest(string method, string sourcePath, int id, int line, int character) =>
+        JsonSerializer.Serialize(new
+        {
+            jsonrpc = "2.0",
+            id,
+            method,
+            @params = new
+            {
+                textDocument = new { uri = new Uri(sourcePath).AbsoluteUri },
+                position = new { line, character },
+            },
+        });
+
+    private static string CreateDidOpenRequest(string sourcePath, string text, int version) =>
+        JsonSerializer.Serialize(new
+        {
+            jsonrpc = "2.0",
+            method = "textDocument/didOpen",
+            @params = new
+            {
+                textDocument = new
+                {
+                    uri = new Uri(sourcePath).AbsoluteUri,
+                    languageId = "csharp",
+                    version,
+                    text,
+                },
+            },
+        });
+
+    private static void MarkGraphReady(string dbPath)
+    {
+        using var db = new DbContext(dbPath);
+        var writer = new DbWriter(db.Connection);
+        writer.MarkGraphReady();
+    }
+}

--- a/tests/CodeIndex.Tests/LspServerTests.cs
+++ b/tests/CodeIndex.Tests/LspServerTests.cs
@@ -83,8 +83,12 @@ public class LspServerTests
         var bytes = Encoding.UTF8.GetBytes($"Content-Length: {LspServer.MaxLspFrameBytes + 1}\r\n\r\n");
         using var stream = new MemoryStream(bytes);
 
-        Assert.False(LspServer.TryReadMessage(stream, out var actual));
+        Assert.False(LspServer.TryReadMessage(stream, out var actual, out var diagnostic));
         Assert.Equal(string.Empty, actual);
+        Assert.NotNull(diagnostic);
+        Assert.Equal(LspServer.ReadDiagnosticContentLengthTooLarge, diagnostic.Value.Code);
+        Assert.Equal(LspServer.MaxLspFrameBytes + 1, diagnostic.Value.ContentLength);
+        Assert.Equal(LspServer.MaxLspFrameBytes, diagnostic.Value.MaxContentLength);
     }
 
     [Theory]
@@ -95,8 +99,37 @@ public class LspServerTests
         var bytes = Encoding.UTF8.GetBytes($"Content-Length: {firstLength}\r\nContent-Length: {secondLength}\r\n\r\n{{}}");
         using var stream = new MemoryStream(bytes);
 
-        Assert.False(LspServer.TryReadMessage(stream, out var actual));
+        Assert.False(LspServer.TryReadMessage(stream, out var actual, out var diagnostic));
         Assert.Equal(string.Empty, actual);
+        Assert.NotNull(diagnostic);
+        Assert.Equal(LspServer.ReadDiagnosticDuplicateContentLength, diagnostic.Value.Code);
+    }
+
+    [Fact]
+    public void TryReadMessage_RejectsNegativeContentLength_Issue3757()
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("Content-Length: -1\r\n\r\n"));
+
+        Assert.False(LspServer.TryReadMessage(stream, out var actual, out var diagnostic));
+
+        Assert.Equal(string.Empty, actual);
+        Assert.NotNull(diagnostic);
+        Assert.Equal(LspServer.ReadDiagnosticNegativeContentLength, diagnostic.Value.Code);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("abc")]
+    [InlineData("+2")]
+    public void TryReadMessage_RejectsMalformedContentLength_Issue3757(string value)
+    {
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes($"Content-Length: {value}\r\n\r\n"));
+
+        Assert.False(LspServer.TryReadMessage(stream, out var actual, out var diagnostic));
+
+        Assert.Equal(string.Empty, actual);
+        Assert.NotNull(diagnostic);
+        Assert.Equal(LspServer.ReadDiagnosticMalformedContentLength, diagnostic.Value.Code);
     }
 
     [Fact]
@@ -349,6 +382,9 @@ public class LspServerTests
             Assert.NotNull(response);
             Assert.Equal(-32700, response!["error"]!["code"]!.GetValue<int>());
             Assert.Null(response["id"]);
+            var message = response["error"]!["message"]!.GetValue<string>();
+            Assert.Contains("payload_bytes=", message, StringComparison.Ordinal);
+            Assert.Contains($"max_json_depth={LspServer.MaxJsonDepth}", message, StringComparison.Ordinal);
         }
         finally
         {
@@ -670,6 +706,9 @@ public class LspServerTests
             using var parseError = JsonDocument.Parse(parseErrorPayload);
             Assert.Equal(-32700, parseError.RootElement.GetProperty("error").GetProperty("code").GetInt32());
             Assert.Equal(JsonValueKind.Null, parseError.RootElement.GetProperty("id").ValueKind);
+            Assert.Equal(
+                $"Parse error (payload_bytes=1, max_json_depth={LspServer.MaxJsonDepth})",
+                parseError.RootElement.GetProperty("error").GetProperty("message").GetString());
 
             Assert.True(LspServer.TryReadMessage(output, out var initializePayload));
             using var initialize = JsonDocument.Parse(initializePayload);

--- a/tests/CodeIndex.Tests/LspServerTests.cs
+++ b/tests/CodeIndex.Tests/LspServerTests.cs
@@ -31,6 +31,38 @@ public class LspServerTests
     }
 
     [Fact]
+    public void TryReadMessage_ReadsDirectAllocatedPayloadAbovePoolThreshold_Issue3799()
+    {
+        var payload = new string('x', LspServer.MaxPooledPayloadBufferBytes + 1);
+        var bytes = Encoding.UTF8.GetBytes($"Content-Length: {Encoding.UTF8.GetByteCount(payload)}\r\n\r\n{payload}");
+        using var stream = new MemoryStream(bytes);
+
+        Assert.True(LspServer.TryReadMessage(stream, out var actual));
+
+        Assert.Equal(payload.Length, actual.Length);
+        Assert.Equal(payload, actual);
+    }
+
+    [Theory]
+    [InlineData(0, true)]
+    [InlineData(LspServer.MaxPooledPayloadBufferBytes, true)]
+    [InlineData(LspServer.MaxPooledPayloadBufferBytes + 1, false)]
+    public void ShouldRentPayloadBuffer_DefinesPoolBoundary_Issue3799(int byteCount, bool expected)
+    {
+        Assert.Equal(expected, LspServer.ShouldRentPayloadBuffer(byteCount));
+    }
+
+    [Fact]
+    public void ClearSensitivePayloadBufferForTests_ClearsOnlyUsedBytes_Issue3799()
+    {
+        var buffer = new byte[] { 1, 2, 3, 4, 5 };
+
+        LspServer.ClearSensitivePayloadBufferForTests(buffer, usedBytes: 3);
+
+        Assert.Equal(new byte[] { 0, 0, 0, 4, 5 }, buffer);
+    }
+
+    [Fact]
     public void TryReadMessage_AcceptsHeaderLineAtMaxLength()
     {
         const string payload = "{}";


### PR DESCRIPTION
## Summary

- Adds explicit LSP frame read diagnostics for duplicate, negative, malformed, and oversized `Content-Length` headers, plus sanitized JSON parse context.
- Hardens LSP and HTTP payload buffer handling by defining pooled-buffer boundaries and clearing temporary payload buffers before reuse.
- Adds LSP live-document aggregate byte budgeting, bounded `contentChanges` handling, semantic/inlay line lookup caching, hover path redaction, and response-frame size enforcement.

## Validation

- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false -m:1`
- `dotnet test CodeIndex.sln -c Release --no-build -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false --filter FullyQualifiedName~LspServerTests`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false --filter FullyQualifiedName~Issue3799`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false -f net8.0 --filter FullyQualifiedName~Issue3817`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false -f net9.0 --filter FullyQualifiedName~Issue3817`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: No blocking/actionable issues found.

## Documentation and Changelog

- Updated `USER_GUIDE.md` LSP English and Japanese sections.
- Added changelog fragments:
  - `changelog.d/unreleased/3757.fixed.md`
  - `changelog.d/unreleased/3799.security.md`
  - `changelog.d/unreleased/3817.changed.md`

## Follow-up Candidates

- None.

Fixes #3757
Fixes #3799
Fixes #3817