### PR TITLE
Fix search fanout and count budget issues

### DIFF
--- a/changelog.d/unreleased/3659.fixed.md
+++ b/changelog.d/unreleased/3659.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3659
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **Upgrade installer temporary cleanup is now boundary-checked (#3659)** — `cdidx upgrade` validates that recursive installer-directory cleanup targets stay under the expected temporary root, keep the `cdidx-install-` prefix, and are not symbolic links or reparse points; cleanup failures now emit bounded warnings instead of being silently swallowed.
+
+## 日本語
+
+- **upgrade installer の temporary cleanup に boundary check を追加しました (#3659)** — `cdidx upgrade` は recursive な installer-directory cleanup の対象が expected temporary root 配下にあり、`cdidx-install-` prefix を保持し、symbolic link/reparse point ではないことを検証します。cleanup failure は黙殺せず bounded warning として出力します。

--- a/changelog.d/unreleased/3677.fixed.md
+++ b/changelog.d/unreleased/3677.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3677
+affected:
+  - src/CodeIndex/Cli/IndexWatchRunner.cs
+  - src/CodeIndex/Mcp/McpServer.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
+  - src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
+---
+
+## English
+
+- **Reduced sync-over-async in watch and documented required sync bridges (#3677)** — `index --watch` now uses an async delay loop for cancellation-friendly polling, while remaining MCP and worker sync wrappers document why they stay at compatibility or bounded subprocess protocol boundaries.
+
+## 日本語
+
+- **watch の sync-over-async を減らし、必要な同期 bridge を明文化しました (#3677)** — `index --watch` は cancellation しやすい async delay loop で polling し、残る MCP / worker の同期 wrapper は互換境界または bounded subprocess protocol 境界として残す理由を明記しました。

--- a/changelog.d/unreleased/3678.fixed.md
+++ b/changelog.d/unreleased/3678.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3678
+affected:
+  - src/CodeIndex/Database/DbContext.cs
+  - tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
+---
+
+## English
+
+- **DB migrations now guard foreign-key restoration on failure paths (#3678)** — migration windows that temporarily change `PRAGMA foreign_keys` now restore the original setting through a shared boundary and report a structured database error if restoration itself fails.
+
+## 日本語
+
+- **DB マイグレーション失敗時の foreign-key 復元を保護しました (#3678)** — `PRAGMA foreign_keys` を一時変更する migration window は共通境界で元の設定を復元し、復元自体が失敗した場合は構造化された database error を報告するようになりました。

--- a/changelog.d/unreleased/3685.fixed.md
+++ b/changelog.d/unreleased/3685.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3685
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **Upgrade installer launches now have an explicit safe process contract (#3685)** — `cdidx upgrade` now fixes the installer working directory, keeps shell expansion disabled through `ArgumentList`, and reports installer process-start failures as bounded install errors instead of surfacing raw process-launch exceptions.
+
+## 日本語
+
+- **upgrade installer の起動契約を明示的に安全化しました (#3685)** — `cdidx upgrade` は installer の working directory を固定し、`ArgumentList` によって shell expansion を無効のまま保ち、installer process の起動失敗を生の process 起動例外ではなく bounded な install error として報告するようになりました。

--- a/changelog.d/unreleased/3699.fixed.md
+++ b/changelog.d/unreleased/3699.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3699
+affected:
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+---
+
+## English
+
+- **Import archive entry validation is now centralized (#3699)** — `cdidx import` rejects missing manifests plus duplicate and unexpected archive entries before database extraction, then reports a missing `codeindex.db` only after manifest validation so existing manifest diagnostics stay intact.
+
+## 日本語
+
+- **import archive entry の検証を中央化しました (#3699)** — `cdidx import` は database 展開前に、欠落した manifest と重複・想定外の archive entry を拒否し、`codeindex.db` の欠落は manifest 検証後に報告することで既存の manifest diagnostic を維持します。

--- a/changelog.d/unreleased/3706.fixed.md
+++ b/changelog.d/unreleased/3706.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 3706
+affected:
+  - src/CodeIndex/BoundedLineReader.cs
+  - src/CodeIndex/Cli/SolutionProjectResolver.cs
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Small config and sidecar readers now share bounded UTF-8 line handling (#3706)** — language-map overrides, `.gitmodules`, and solution parsing now use the shared bounded line reader so byte, line-count, and line-length failures are handled consistently.
+
+## 日本語
+
+- **小さな設定ファイルと sidecar の読み取りで bounded UTF-8 line 処理を共有しました (#3706)** — language-map override、`.gitmodules`、solution 解析が共通の bounded line reader を使うようになり、byte・行数・行長の上限超過を一貫して扱います。

--- a/changelog.d/unreleased/3707.fixed.md
+++ b/changelog.d/unreleased/3707.fixed.md
@@ -1,0 +1,22 @@
+---
+category: fixed
+issues:
+  - 3707
+affected:
+  - src/CodeIndex/Cli/FileSystemTraversalFailure.cs
+  - src/CodeIndex/Cli/SolutionProjectResolver.cs
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Cli/DbCommandRunner.cs
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/DbCommandRunnerTests.cs
+---
+
+## English
+
+- **Filesystem traversal failures now use shared expected-exception classification (#3707)** — project discovery, marker fingerprint traversal, checkpoint inspection, and import cleanup now handle permission, unsupported-path, invalid-path, path-too-long, and I/O traversal failures through the same bounded diagnostic paths.
+
+## 日本語
+
+- **ファイルシステム走査失敗の expected exception 分類を共通化しました (#3707)** — project discovery、marker fingerprint traversal、checkpoint inspection、import cleanup は、permission / unsupported path / invalid path / path too long / I/O の走査失敗を同じ上限付き diagnostic 経路で扱うようになりました。

--- a/changelog.d/unreleased/3733.fixed.md
+++ b/changelog.d/unreleased/3733.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3733
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **Upgrade installer trust-boundary checks were hardened (#3733)** — `cdidx upgrade` now rejects filesystem roots, symbolic links, reparse points, and group- or world-writable install directories before running the installer, and prints the installer verification and trust-boundary diagnostic on pre-install failures.
+
+## 日本語
+
+- **upgrade installer の trust-boundary check を強化しました (#3733)** — `cdidx upgrade` は installer 実行前に filesystem root、symbolic link、reparse point、group/world writable な install directory を拒否し、pre-install failure では installer verification と trust-boundary diagnostic を出力するようになりました。

--- a/changelog.d/unreleased/3741.fixed.md
+++ b/changelog.d/unreleased/3741.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3741
+affected:
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+---
+
+## English
+
+- **Grouped file search counts now stream database counts directly (#3741)** — `search --group-by file --count` no longer builds snippet/display rows when origin filters are not requested.
+
+## 日本語
+
+- **file grouped search count がデータベース件数を直接ストリーム集計するようになりました (#3741)** — origin filter がない場合、`search --group-by file --count` は snippet/display row を構築しなくなりました。

--- a/changelog.d/unreleased/3742.fixed.md
+++ b/changelog.d/unreleased/3742.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 3742
+affected:
+  - src/CodeIndex/Cli/SearchSnippetFormatter.cs
+---
+
+## English
+
+- **Preferred-line snippet scans are now bounded (#3742)** — snippet selection stops scanning after fixed line and character budgets when searching for a preferred match line.
+
+## 日本語
+
+- **preferred-line snippet scan に上限を追加しました (#3742)** — preferred match line を探す際、固定の行数・文字数budgetに達したら snippet selection の走査を停止します。

--- a/changelog.d/unreleased/3747.fixed.md
+++ b/changelog.d/unreleased/3747.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 3747
+affected:
+  - src/CodeIndex/Mcp/AuditLogSink.cs
+  - src/CodeIndex/Mcp/HttpMcpTransport.cs
+  - src/CodeIndex/Mcp/McpServer.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+  - tests/CodeIndex.Tests/McpAuditLogTests.cs
+---
+
+## English
+
+- **Audit and HTTP request logging no longer run synchronous log IO/callback work on hot request paths (#3747)** — audit records and HTTP request log records now drain through bounded queues with queue depth/drop diagnostics, and health status reports degraded logging when those queues saturate.
+
+## 日本語
+
+- **audit と HTTP request logging が hot request path 上で同期的なログ IO / callback を実行しないようになりました (#3747)** — audit record と HTTP request log record は bounded queue 経由で drain され、queue depth / drop diagnostics を持ち、queue 飽和時は health status に degraded logging として表示されます。

--- a/changelog.d/unreleased/3751.fixed.md
+++ b/changelog.d/unreleased/3751.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3751
+affected:
+  - src/CodeIndex/Cli/SearchAuditRecipes.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+---
+
+## English
+
+- **External search-audit recipe validation now reports bounded query and label diagnostics (#3751)** — oversized recipe sources remain capped before parsing, while excessive recipe counts, overlong queries, and invalid or overlong labels now produce bounded diagnostics instead of silently dropping label entries.
+
+## 日本語
+
+- **外部 search-audit recipe の検証が query と label の bounded diagnostic を返すようになりました (#3751)** — oversized recipe source は parse 前に引き続き制限しつつ、recipe 数超過、過長 query、不正または過長な label は label entry を黙って落とさず bounded diagnostic として報告します。

--- a/changelog.d/unreleased/3766.fixed.md
+++ b/changelog.d/unreleased/3766.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3766
+affected:
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+  - tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+---
+
+## English
+
+- **Import/export archive limits and cancellation are stricter (#3766)** — `cdidx import` now rejects abnormal `codeindex.db` compression metadata and oversized unknown-extension path samples before extraction, while import/export database copy loops report progress internally and honor command cancellation with interrupted exit codes.
+
+## 日本語
+
+- **import/export archive の制限とキャンセル処理を強化しました (#3766)** — `cdidx import` は展開前に異常な `codeindex.db` 圧縮 metadata と過大な unknown-extension path sample を拒否し、import/export の database copy loop は内部 progress を報告しつつコマンドキャンセル時に interrupted exit code を返します。

--- a/changelog.d/unreleased/3771.fixed.md
+++ b/changelog.d/unreleased/3771.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3771
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.UpdateTargets.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Unified JSON heartbeat shutdown without blocking waits (#3771)** — full-scan and update-target indexing now share a heartbeat stop helper that cancels heartbeat tasks without `Task.Wait` teardown.
+
+## 日本語
+
+- **JSON heartbeat shutdown を共通化し、blocking wait をなくしました (#3771)** — full-scan と update-target indexing は共通の heartbeat stop helper を使い、`Task.Wait` による停止処理を行わずに heartbeat task を cancel します。

--- a/changelog.d/unreleased/3782.fixed.md
+++ b/changelog.d/unreleased/3782.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 3782
+affected:
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+---
+
+## English
+
+- **MCP search summaries now count top files in a single pass (#3782)** — top-file histograms avoid materializing grouped result buckets before selecting the highest-count files.
+
+## 日本語
+
+- **MCP search summary の top files を1パスで集計するようになりました (#3782)** — 件数上位のファイルを選ぶ前に grouped result bucket を materialize しないようにしました。

--- a/changelog.d/unreleased/3791.fixed.md
+++ b/changelog.d/unreleased/3791.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3791
+affected:
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **MCP argument parsing now rejects malformed scalar and batch shapes consistently (#3791)** — numeric MCP arguments now use type-safe reads after validation, and `batch_query.queries` rejects non-array JSON values as invalid arguments instead of relying on direct array casts.
+
+## 日本語
+
+- **MCP 引数解析が不正な scalar / batch 形状を一貫して拒否するようになりました (#3791)** — 数値 MCP 引数は検証後も型安全な読み取りを使い、`batch_query.queries` は直接の配列castに頼らず、配列でない JSON 値を invalid argument として拒否します。

--- a/changelog.d/unreleased/3794.fixed.md
+++ b/changelog.d/unreleased/3794.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3794
+affected:
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - src/CodeIndex/Database/DbReader.cs
+---
+
+## English
+
+- **Search fanout now fails with bounded diagnostics (#3794)** — raw FTS column lists, literal search token growth, and path glob fanout now have explicit caps with stable usage errors.
+
+## 日本語
+
+- **検索 fanout が上限付き診断で停止するようになりました (#3794)** — raw FTS のカラムリスト、literal 検索トークンの成長、path glob の fanout に明示的な上限と安定した usage error を追加しました。

--- a/changelog.d/unreleased/3803.fixed.md
+++ b/changelog.d/unreleased/3803.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3803
+affected:
+  - src/CodeIndex/Cli/IndexWatchRunner.cs
+  - tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
+---
+
+## English
+
+- **Bounded `index --watch` sub-run capture and large path batches (#3803)** — watch sub-runs now cap in-memory stdout capture, preserve JSON sub-run output through a spool stream, and split large `--files` updates before command-line argument limits are reached.
+
+## 日本語
+
+- **`index --watch` のサブ実行 capture と大量パス batch を制限しました (#3803)** — watch のサブ実行は stdout のメモリ capture を上限付きにし、JSON のサブ実行出力は spool stream で保持し、`--files` 更新はコマンドライン引数上限に達する前に分割します。

--- a/changelog.d/unreleased/3819.fixed.md
+++ b/changelog.d/unreleased/3819.fixed.md
@@ -1,0 +1,23 @@
+---
+category: fixed
+issues:
+  - 3819
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.TypeScriptPathAliases.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **Sidecar config diagnostics now sanitize config paths (#3819)** — TypeScript path-alias and language-map warnings now sanitize config paths before writing diagnostics, while preserving per-file warning de-duplication internally.
+
+- **`.gitmodules` submodule parsing is bounded and quote-aware (#3819)** — parsing now caps accepted submodule paths and preserves `#` / `;` characters inside quoted path values instead of treating them as inline comments.
+
+## 日本語
+
+- **sidecar config diagnostics の config path をサニタイズするようになりました (#3819)** — TypeScript path-alias と language-map の警告は、診断出力前に config path をサニタイズするようになりました。内部の per-file warning 重複排除は維持しています。
+
+- **`.gitmodules` の submodule 解析を bounded かつ quote-aware にしました (#3819)** — 受け入れる submodule path 数に上限を設け、quoted path 値の中にある `#` / `;` を inline comment として扱わず保持します。

--- a/changelog.d/unreleased/3820.fixed.md
+++ b/changelog.d/unreleased/3820.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3820
+affected:
+  - src/CodeIndex/Database/DbReader.GraphQueries.cs
+  - src/CodeIndex/Models/QueryResults.cs
+---
+
+## English
+
+- **Impact traversal now has explicit graph-state and boundary-probe budgets (#3820)** — dense caller graphs stop with stable truncation and termination reasons instead of probing unbounded boundary edges.
+
+## 日本語
+
+- **impact traversal に graph-state と boundary-probe の明示的なbudgetを追加しました (#3820)** — dense caller graph では boundary edge を無制限に探索せず、安定した truncation/termination reason で停止します。

--- a/changelog.d/unreleased/3828.fixed.md
+++ b/changelog.d/unreleased/3828.fixed.md
@@ -1,0 +1,22 @@
+---
+category: fixed
+issues:
+  - 3828
+affected:
+  - src/CodeIndex/Cli/DbPathResolver.cs
+  - src/CodeIndex/Cli/IndexFreshnessChecker.cs
+  - src/CodeIndex/Cli/PathCasing.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Indexer/Scanning/CaseSensitivityProbeDirectory.cs
+  - tests/CodeIndex.Tests/DbPathResolverTests.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+  - tests/CodeIndex.Tests/IndexFreshnessCheckerTests.cs
+---
+
+## English
+
+- **Read-only query and status paths reuse the persisted case-sensitivity stamp (#3828)** — `workspace_path_case_sensitive` now seeds path comparisons and status freshness checks before filesystem write probes run, while probe cleanup failures downgrade to bounded `.cdidx/probes` diagnostics after a result is obtained.
+
+## 日本語
+
+- **読み取り専用の query/status 経路で永続化済み case-sensitivity stamp を再利用するようになりました (#3828)** — `workspace_path_case_sensitive` が filesystem write probe より先に path 比較と status freshness check を seed し、probe cleanup 失敗は結果取得後に `.cdidx/probes` の bounded diagnostic へ downgrade します。

--- a/changelog.d/unreleased/3837.fixed.md
+++ b/changelog.d/unreleased/3837.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3837
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Mcp/McpServer.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **Aligned CLI search cursor validation and pruned completed MCP request tasks (#3837)** — recipe search cursors now reject non-finite scores and negative chunk ids like the MCP parser, and the concurrent MCP frame loop prunes completed request tasks during long-lived sessions.
+
+## 日本語
+
+- **CLI search cursor validation を MCP と揃え、完了済み MCP request task を prune するようにしました (#3837)** — recipe search cursor は MCP parser と同じく非有限 score と負の chunk id を拒否し、並行 MCP frame loop は長時間 session 中に完了済み request task を prune します。

--- a/changelog.d/unreleased/3862.internal.md
+++ b/changelog.d/unreleased/3862.internal.md
@@ -1,0 +1,15 @@
+---
+category: internal
+issues:
+  - 3862
+affected:
+  - tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+---
+
+## English
+
+- **Stabilized the HTTP MCP health test (#3862)** — the HTTP test harness now waits for the server health provider to become ready before querying `/healthz`, avoiding transient `starting` status observations during full-suite runs.
+
+## 日本語
+
+- **HTTP MCP health テストを安定化しました (#3862)** — HTTP テストハーネスは `/healthz` を確認する前にサーバーの health provider が ready になるのを待つようになり、フルスイート実行時に一時的な `starting` 状態を観測する不安定さを避けます。

--- a/src/CodeIndex/BoundedLineReader.cs
+++ b/src/CodeIndex/BoundedLineReader.cs
@@ -23,6 +23,23 @@ internal sealed class BoundedLineLengthException : IOException
     internal int MaxUtf8Bytes { get; }
 }
 
+internal enum BoundedTextFileReadFailureKind
+{
+    None,
+    BytesExceeded,
+    LinesExceeded,
+    LineLengthExceeded,
+    ReadFailed,
+}
+
+internal readonly record struct BoundedTextFileReadFailure(
+    BoundedTextFileReadFailureKind Kind,
+    string Reason,
+    int? LineNumber = null,
+    int? CharactersRead = null,
+    int? Limit = null,
+    string? ExceptionType = null);
+
 internal static class WorkerProtocolLineLimits
 {
     // Worker requests carry source content as JSON. Keep this above the default 4 MiB source
@@ -51,6 +68,119 @@ internal static class BoundedLineReader
 {
     private const int AsyncReadBufferSize = 4096;
     private static readonly ConditionalWeakTable<TextReader, AsyncReadBuffer> AsyncBuffers = new();
+
+    internal static bool TryReadUtf8File(
+        string path,
+        int maxBytes,
+        int maxLines,
+        int maxLineCharacters,
+        out IReadOnlyList<string> lines,
+        out BoundedTextFileReadFailure failure,
+        Func<string, Stream>? openFile = null)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        if (maxBytes <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxBytes), maxBytes, "Maximum file bytes must be positive.");
+        if (maxLines <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxLines), maxLines, "Maximum line count must be positive.");
+        if (maxLineCharacters <= 0)
+            throw new ArgumentOutOfRangeException(nameof(maxLineCharacters), maxLineCharacters, "Maximum line characters must be positive.");
+
+        lines = [];
+        failure = default;
+
+        try
+        {
+            using var stream = openFile?.Invoke(path)
+                ?? new FileStream(
+                    path,
+                    FileMode.Open,
+                    FileAccess.Read,
+                    FileShare.ReadWrite | FileShare.Delete,
+                    bufferSize: 8192,
+                    useAsync: false);
+
+            if (stream.CanSeek && stream.Length > maxBytes)
+            {
+                failure = new(
+                    BoundedTextFileReadFailureKind.BytesExceeded,
+                    $"it exceeds {maxBytes} bytes",
+                    Limit: maxBytes);
+                return false;
+            }
+
+            using var accumulator = new MemoryStream(stream.CanSeek ? (int)Math.Min(stream.Length, maxBytes) : 0);
+            var buffer = new byte[8192];
+            long total = 0;
+            int read;
+            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+            {
+                total += read;
+                if (total > maxBytes)
+                {
+                    failure = new(
+                        BoundedTextFileReadFailureKind.BytesExceeded,
+                        $"it exceeds {maxBytes} bytes",
+                        Limit: maxBytes);
+                    return false;
+                }
+
+                accumulator.Write(buffer, 0, read);
+            }
+
+            var text = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(accumulator.ToArray());
+            if (text.Length > 0 && text[0] == '\uFEFF')
+                text = text[1..];
+
+            var result = new List<string>();
+            using var reader = new StringReader(text);
+            while (true)
+            {
+                string? line;
+                try
+                {
+                    line = ReadLine(reader, maxLineCharacters, maxBytes);
+                }
+                catch (BoundedLineLengthException ex)
+                {
+                    var lineNumber = result.Count + 1;
+                    failure = new(
+                        BoundedTextFileReadFailureKind.LineLengthExceeded,
+                        $"line {lineNumber} exceeds {maxLineCharacters} characters",
+                        lineNumber,
+                        ex.CharactersRead,
+                        maxLineCharacters);
+                    return false;
+                }
+
+                if (line == null)
+                    break;
+
+                if (result.Count >= maxLines)
+                {
+                    failure = new(
+                        BoundedTextFileReadFailureKind.LinesExceeded,
+                        $"it exceeds {maxLines} lines",
+                        Limit: maxLines);
+                    return false;
+                }
+
+                result.Add(line);
+            }
+
+            lines = result;
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            var reason = $"it could not be read ({ex.GetType().Name}: {CollapseLineBreaks(ex.Message)})";
+            failure = new(
+                BoundedTextFileReadFailureKind.ReadFailed,
+                reason,
+                ExceptionType: ex.GetType().Name);
+            return false;
+        }
+    }
 
     internal static string? ReadLine(TextReader reader, int maxCharacters, int maxUtf8Bytes)
     {
@@ -230,4 +360,7 @@ internal static class BoundedLineReader
                 throw new BoundedLineLengthException(_charactersRead, _utf8BytesRead, _maxCharacters, _maxUtf8Bytes);
         }
     }
+
+    private static string CollapseLineBreaks(string value)
+        => value.Replace('\r', ' ').Replace('\n', ' ');
 }

--- a/src/CodeIndex/Cli/DbCommandRunner.cs
+++ b/src/CodeIndex/Cli/DbCommandRunner.cs
@@ -835,11 +835,7 @@ public static class DbCommandRunner
         => new(code, message, ConsoleUi.FormatBoundedValue(path));
 
     private static bool IsRecoverableFilesystemException(Exception ex)
-        => ex is IOException
-            or UnauthorizedAccessException
-            or ArgumentException
-            or NotSupportedException
-            or PathTooLongException;
+        => FileSystemTraversalFailure.IsExpected(ex);
 
     private static bool IsRecoverableRestoreException(Exception ex)
         => IsRecoverableFilesystemException(ex) || ex is InvalidOperationException;

--- a/src/CodeIndex/Cli/DbPathResolver.cs
+++ b/src/CodeIndex/Cli/DbPathResolver.cs
@@ -173,6 +173,11 @@ public static class DbPathResolver
         if (indexedProjectRoot == null && !string.Equals(dbPath, fullDbPath, StringComparison.Ordinal))
             indexedProjectRoot = TryReadIndexedProjectRoot(fullDbPath);
 
+        var pathCaseSensitive = TryReadWorkspacePathCaseSensitive(dbPath);
+        if (!pathCaseSensitive.HasValue && !string.Equals(dbPath, fullDbPath, StringComparison.Ordinal))
+            pathCaseSensitive = TryReadWorkspacePathCaseSensitive(fullDbPath);
+        SeedPathCasingFromWorkspaceStamp(indexedProjectRoot, fullDbPath, pathCaseSensitive);
+
         var projectLocalRoot = TryResolveProjectLocalRoot(fullDbPath, dbPath, dbPathExplicit, indexedProjectRoot);
         if (projectLocalRoot != null)
             return projectLocalRoot;
@@ -287,6 +292,23 @@ public static class DbPathResolver
 
     private static string? TryReadIndexedProjectRoot(string dbPath)
         => TryReadMetaString(dbPath, CodeIndex.Database.DbContext.IndexedProjectRootMetaKey);
+
+    private static bool? TryReadWorkspacePathCaseSensitive(string dbPath)
+    {
+        var raw = TryReadMetaString(dbPath, CodeIndex.Database.DbContext.WorkspacePathCaseSensitiveMetaKey);
+        return bool.TryParse(raw, out var pathCaseSensitive) ? pathCaseSensitive : null;
+    }
+
+    private static void SeedPathCasingFromWorkspaceStamp(string? indexedProjectRoot, string fullDbPath, bool? pathCaseSensitive)
+    {
+        if (!pathCaseSensitive.HasValue)
+            return;
+
+        var ignoreCase = !pathCaseSensitive.Value;
+        if (!string.IsNullOrWhiteSpace(indexedProjectRoot))
+            PathCasing.SeedFromWorkspace(indexedProjectRoot, ignoreCase);
+        PathCasing.SeedFromReferencePath(fullDbPath, ignoreCase);
+    }
 
     /// <summary>
     /// Best-effort read of the persisted git HEAD commit stamped at the end of the

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -13,12 +13,15 @@ internal static class ExportImportCommandRunner
 {
     private const string ManifestEntryName = "manifest.json";
     private const string DatabaseEntryName = "codeindex.db";
+    private static readonly string[] ExpectedImportArchiveEntryNames = [ManifestEntryName, DatabaseEntryName];
     internal const int MaxImportManifestBytes = 64 * 1024;
     internal const int MaxImportManifestJsonDepth = 16;
     internal const long MaxImportDatabaseBytes = 8L * 1024 * 1024 * 1024;
+    internal const long MaxImportDatabaseCompressionRatio = 1000;
     private const int ImportCopyBufferSize = 81920;
     private const int ManifestUnknownExtensionFileLimit = DbContext.UnknownExtensionFilePathSampleLimit;
     private const int ManifestUnknownExtensionPathCharLimit = 4096;
+    private const int ManifestUnknownExtensionFilesTotalCharLimit = 32 * 1024;
     private static readonly DateTimeOffset DeterministicZipTimestamp = new(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
     private const string ExportCommandName = "export";
     private const string ImportCommandName = "import";
@@ -35,15 +38,19 @@ internal static class ExportImportCommandRunner
     private const string ImportUsage = "cdidx import <archive> [--db <path>] [--prune-paths] [--dry-run|--check] [--json]";
     private const string CtagsExportUsage = "cdidx export ctags [--output <path>] [--db <path>] [--json] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests]";
 
-    public static int RunExport(string[] args, JsonSerializerOptions jsonOptions, string appVersion)
+    public static int RunExport(
+        string[] args,
+        JsonSerializerOptions jsonOptions,
+        string appVersion,
+        CancellationToken cancellationToken = default)
     {
         if (args.Length > 0 && args[0] == "ctags")
             return RunExportCtags(args[1..], jsonOptions);
 
-        return RunExportArchive(args, jsonOptions, appVersion);
+        return RunExportArchive(args, jsonOptions, appVersion, cancellationToken);
     }
 
-    public static int RunImport(string[] args, JsonSerializerOptions jsonOptions)
+    public static int RunImport(string[] args, JsonSerializerOptions jsonOptions, CancellationToken cancellationToken = default)
     {
         string? archivePath = null;
         string? dbPath = null;
@@ -103,6 +110,8 @@ internal static class ExportImportCommandRunner
         var phase = PhaseOpenArchive;
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (dryRun)
             {
                 tempDirectory = DataDirectorySecurity.CreateSensitiveTempDirectory("codeindex-import-").FullName;
@@ -117,10 +126,25 @@ internal static class ExportImportCommandRunner
             using (var archive = ZipFile.OpenRead(archivePath))
             {
                 AddImportValidationPhase(validationPhases, PhaseOpenArchive);
+                if (!TryValidateImportArchiveEntries(
+                        archive,
+                        out var manifestEntry,
+                        out var dbEntry,
+                        out var entryValidationPhase,
+                        out var entryValidationErrorCode,
+                        out var entryValidationMessage))
+                {
+                    return WriteImportError(
+                        wantsJson,
+                        jsonOptions,
+                        entryValidationPhase,
+                        entryValidationErrorCode,
+                        entryValidationMessage,
+                        "use an archive produced by `cdidx export <archive>`.",
+                        ImportUsage);
+                }
+
                 phase = PhaseManifest;
-                var manifestEntry = archive.GetEntry(ManifestEntryName);
-                if (manifestEntry == null)
-                    return WriteImportError(wantsJson, jsonOptions, PhaseManifest, "import_manifest_missing", "archive is missing manifest.json.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
                 if (!TryReadManifest(manifestEntry, jsonOptions, out var manifest, out var manifestError))
                     return WriteImportError(wantsJson, jsonOptions, PhaseManifest, "import_manifest_invalid", $"archive manifest is invalid: {manifestError}.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
                 if (!TryValidateManifestHeader(manifest, out var manifestHeaderError))
@@ -129,13 +153,13 @@ internal static class ExportImportCommandRunner
                 AddImportValidationPhase(validationPhases, PhaseManifest);
 
                 phase = PhaseDatabaseEntry;
-                var dbEntry = archive.GetEntry(DatabaseEntryName);
                 if (dbEntry == null)
-                    return WriteImportError(wantsJson, jsonOptions, PhaseDatabaseEntry, "import_database_entry_missing", "archive is missing codeindex.db.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
+                    return WriteImportError(wantsJson, jsonOptions, PhaseDatabaseEntry, "import_database_entry_missing", $"archive is missing {DatabaseEntryName}.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
+
                 if (!TryValidateDatabaseEntrySize(dbEntry.Length, dbEntry.CompressedLength, out var sizeValidationMessage))
                     return WriteImportError(wantsJson, jsonOptions, PhaseDatabaseEntry, "import_database_entry_too_large", sizeValidationMessage, "re-export a smaller CodeIndex database or rebuild a smaller index.", ImportUsage);
 
-                ExtractDatabaseEntryToFile(dbEntry, tempPath);
+                ExtractDatabaseEntryToFile(dbEntry, tempPath, cancellationToken);
                 AddImportValidationPhase(validationPhases, PhaseDatabaseEntry);
 
                 phase = PhaseSha256;
@@ -224,6 +248,18 @@ internal static class ExportImportCommandRunner
             }
             return CommandExitCodes.Success;
         }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return WriteImportError(
+                wantsJson,
+                jsonOptions,
+                phase,
+                "import_interrupted",
+                "import was interrupted before it completed.",
+                "rerun `cdidx import <archive>` when you are ready to retry.",
+                ImportUsage,
+                CommandExitCodes.Interrupted);
+        }
         catch (Exception ex) when (ex is IOException or InvalidDataException or UnauthorizedAccessException or SqliteException)
         {
             return WriteImportError(wantsJson, jsonOptions, phase, "import_failed", $"import failed ({CommandErrorWriter.FormatSanitizedException(ex)}).", "check the archive path and destination database permissions.", ImportUsage);
@@ -240,7 +276,11 @@ internal static class ExportImportCommandRunner
         }
     }
 
-    private static int RunExportArchive(string[] args, JsonSerializerOptions jsonOptions, string appVersion)
+    private static int RunExportArchive(
+        string[] args,
+        JsonSerializerOptions jsonOptions,
+        string appVersion,
+        CancellationToken cancellationToken)
     {
         string? outputPath = null;
         string? dbPath = null;
@@ -291,6 +331,8 @@ internal static class ExportImportCommandRunner
         var phase = PhaseWriteArchive;
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             snapshotDirectory = DataDirectorySecurity.CreateSensitiveTempDirectory("codeindex-export-").FullName;
             snapshotPath = Path.Combine(snapshotDirectory, "codeindex.db");
             var outputDirectory = Path.GetDirectoryName(fullOutputPath);
@@ -298,7 +340,7 @@ internal static class ExportImportCommandRunner
                 Directory.CreateDirectory(outputDirectory);
 
             phase = PhaseSqliteValidate;
-            CreateDatabaseSnapshot(normalizedDbPath, snapshotPath);
+            CreateDatabaseSnapshot(normalizedDbPath, snapshotPath, cancellationToken);
             ExportManifest manifest;
             using (var snapshotConnection = new SqliteConnection(CreateUnpooledConnectionString(snapshotPath)))
             {
@@ -309,13 +351,25 @@ internal static class ExportImportCommandRunner
             phase = PhaseSha256;
             manifest = manifest with { DatabaseSha256 = ComputeSha256(snapshotPath) };
             phase = PhaseWriteArchive;
-            WriteExportArchiveFile(fullOutputPath, snapshotPath, manifest, jsonOptions);
+            WriteExportArchiveFile(fullOutputPath, snapshotPath, manifest, jsonOptions, cancellationToken);
 
             if (wantsJson)
                 Console.WriteLine(JsonSerializer.Serialize(new ExportArchiveResult("1", fullOutputPath, fullSourceDbPath), jsonOptions));
             else
                 Console.WriteLine($"Exported CodeIndex archive to {fullOutputPath}");
             return CommandExitCodes.Success;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return WriteExportError(
+                wantsJson,
+                jsonOptions,
+                phase,
+                "export_interrupted",
+                "export was interrupted before archive writing completed.",
+                "rerun `cdidx export <archive>` when you are ready to retry.",
+                "cdidx export <archive> [--db <path>] [--json]",
+                CommandExitCodes.Interrupted);
         }
         catch (Exception ex)
         {
@@ -611,7 +665,12 @@ internal static class ExportImportCommandRunner
         writer.Write(content);
     }
 
-    internal static void WriteExportArchiveFile(string outputPath, string snapshotPath, ExportManifest manifest, JsonSerializerOptions jsonOptions)
+    internal static void WriteExportArchiveFile(
+        string outputPath,
+        string snapshotPath,
+        ExportManifest manifest,
+        JsonSerializerOptions jsonOptions,
+        CancellationToken cancellationToken = default)
     {
         var fullOutputPath = Path.GetFullPath(outputPath);
         AtomicFileWriter.Write(
@@ -624,7 +683,7 @@ internal static class ExportImportCommandRunner
                 dbEntry.LastWriteTime = DeterministicZipTimestamp;
                 using var source = File.OpenRead(snapshotPath);
                 using var target = dbEntry.Open();
-                source.CopyTo(target);
+                CopyToWithLimit(source, target, long.MaxValue, DatabaseEntryName, cancellationToken);
             });
     }
 
@@ -651,6 +710,67 @@ internal static class ExportImportCommandRunner
         using var stream = File.OpenRead(path);
         return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
     }
+
+    private static bool TryValidateImportArchiveEntries(
+        ZipArchive archive,
+        out ZipArchiveEntry manifestEntry,
+        out ZipArchiveEntry? databaseEntry,
+        out string phase,
+        out string errorCode,
+        out string message)
+    {
+        manifestEntry = null!;
+        databaseEntry = null!;
+        phase = PhaseOpenArchive;
+        errorCode = string.Empty;
+        message = string.Empty;
+
+        var entries = new Dictionary<string, ZipArchiveEntry>(StringComparer.Ordinal);
+        foreach (var entry in archive.Entries)
+        {
+            if (!IsExpectedImportArchiveEntryName(entry.FullName))
+            {
+                errorCode = "import_archive_unexpected_entry";
+                message = $"archive contains unexpected entry {ConsoleUi.FormatBoundedValue(entry.FullName)}; expected only {FormatExpectedImportArchiveEntryNames()}.";
+                return false;
+            }
+
+            if (entries.ContainsKey(entry.FullName))
+            {
+                phase = GetImportArchiveEntryPhase(entry.FullName);
+                errorCode = "import_archive_duplicate_entry";
+                message = $"archive contains duplicate entry {ConsoleUi.FormatBoundedValue(entry.FullName)}.";
+                return false;
+            }
+
+            entries.Add(entry.FullName, entry);
+        }
+
+        if (!entries.TryGetValue(ManifestEntryName, out var foundManifestEntry))
+        {
+            phase = PhaseManifest;
+            errorCode = "import_manifest_missing";
+            message = $"archive is missing {ManifestEntryName}.";
+            return false;
+        }
+
+        manifestEntry = foundManifestEntry;
+        entries.TryGetValue(DatabaseEntryName, out databaseEntry);
+        return true;
+    }
+
+    private static bool IsExpectedImportArchiveEntryName(string name)
+        => Array.Exists(ExpectedImportArchiveEntryNames, expected => string.Equals(expected, name, StringComparison.Ordinal));
+
+    private static string GetImportArchiveEntryPhase(string name)
+        => string.Equals(name, ManifestEntryName, StringComparison.Ordinal)
+            ? PhaseManifest
+            : string.Equals(name, DatabaseEntryName, StringComparison.Ordinal)
+                ? PhaseDatabaseEntry
+                : PhaseOpenArchive;
+
+    private static string FormatExpectedImportArchiveEntryNames()
+        => string.Join(", ", ExpectedImportArchiveEntryNames.Select(name => $"`{name}`"));
 
     internal static string FormatImportManifestReadException(Exception ex)
         => CommandErrorWriter.FormatSanitizedException(ex);
@@ -799,11 +919,25 @@ internal static class ExportImportCommandRunner
 
         if (manifest.UnknownExtensionFiles != null)
         {
+            var totalPathChars = 0;
             foreach (var path in manifest.UnknownExtensionFiles)
             {
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    message = "unknown_extension_files contains an empty path";
+                    return false;
+                }
+
                 if (path.Length > ManifestUnknownExtensionPathCharLimit)
                 {
                     message = $"unknown_extension_files contains a path longer than {ManifestUnknownExtensionPathCharLimit} characters";
+                    return false;
+                }
+
+                totalPathChars += path.Length;
+                if (totalPathChars > ManifestUnknownExtensionFilesTotalCharLimit)
+                {
+                    message = $"unknown_extension_files total path text exceeds the manifest limit of {ManifestUnknownExtensionFilesTotalCharLimit} characters";
                     return false;
                 }
             }
@@ -1016,32 +1150,64 @@ internal static class ExportImportCommandRunner
             return false;
         }
 
+        if (uncompressedLength > 0 && compressedLength == 0)
+        {
+            message = "archive codeindex.db compression metadata is invalid: non-empty entry has zero compressed bytes";
+            return false;
+        }
+
+        if (compressedLength > 0 && uncompressedLength > compressedLength * MaxImportDatabaseCompressionRatio)
+        {
+            message = $"archive codeindex.db compression ratio exceeds the import limit of {MaxImportDatabaseCompressionRatio}:1";
+            return false;
+        }
+
         message = string.Empty;
         return true;
     }
 
-    private static void ExtractDatabaseEntryToFile(ZipArchiveEntry dbEntry, string destinationPath)
+    private static void ExtractDatabaseEntryToFile(ZipArchiveEntry dbEntry, string destinationPath, CancellationToken cancellationToken)
     {
         using var source = dbEntry.Open();
         using var target = File.Open(destinationPath, FileMode.Create, FileAccess.Write, FileShare.None);
-        CopyToWithLimit(source, target, MaxImportDatabaseBytes);
+        CopyToWithLimit(source, target, MaxImportDatabaseBytes, DatabaseEntryName, cancellationToken);
     }
 
     internal static long CopyToWithLimit(Stream source, Stream target, long maxBytes)
         => CopyToWithLimit(source, target, maxBytes, DatabaseEntryName);
 
-    private static long CopyToWithLimit(Stream source, Stream target, long maxBytes, string entryName)
+    internal static long CopyToWithLimit(
+        Stream source,
+        Stream target,
+        long maxBytes,
+        CancellationToken cancellationToken,
+        IProgress<long>? progress = null)
+        => CopyToWithLimit(source, target, maxBytes, DatabaseEntryName, cancellationToken, progress);
+
+    private static long CopyToWithLimit(
+        Stream source,
+        Stream target,
+        long maxBytes,
+        string entryName,
+        CancellationToken cancellationToken = default,
+        IProgress<long>? progress = null)
     {
         var buffer = new byte[ImportCopyBufferSize];
         long totalBytes = 0;
         int bytesRead;
-        while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
+        while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+            bytesRead = source.Read(buffer, 0, buffer.Length);
+            if (bytesRead == 0)
+                break;
+
             if (totalBytes > maxBytes - bytesRead)
                 throw new InvalidDataException($"archive {entryName} exceeds the import limit of {ConsoleUi.FormatBytes(maxBytes)}.");
 
             target.Write(buffer, 0, bytesRead);
             totalBytes += bytesRead;
+            progress?.Report(totalBytes);
         }
 
         return totalBytes;
@@ -1081,14 +1247,17 @@ internal static class ExportImportCommandRunner
             ? $"{prefix}; pruned paths to project root {importTargetProjectRoot}"
             : prefix;
 
-    internal static void CreateDatabaseSnapshot(string sourceDbPath, string snapshotPath)
+    internal static void CreateDatabaseSnapshot(string sourceDbPath, string snapshotPath, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         using var source = new SqliteConnection(CreateUnpooledConnectionString(sourceDbPath));
         using var destination = new SqliteConnection(CreateUnpooledConnectionString(snapshotPath));
         source.Open();
         destination.Open();
         DataDirectorySecurity.ApplyPrivateFileMode(snapshotPath);
+        cancellationToken.ThrowIfCancellationRequested();
         source.BackupDatabase(destination);
+        cancellationToken.ThrowIfCancellationRequested();
         DataDirectorySecurity.ApplyPrivateFileMode(snapshotPath);
     }
 
@@ -1326,8 +1495,12 @@ internal static class ExportImportCommandRunner
         return false;
     }
 
-    private static int WriteError(string message, string hint, string usage)
-        => CommandErrorWriter.Write(message, CommandExitCodes.UsageError, hint, usage);
+    private static int WriteError(
+        string message,
+        string hint,
+        string usage,
+        int exitCode = CommandExitCodes.UsageError)
+        => CommandErrorWriter.Write(message, exitCode, hint, usage);
 
     private static int WriteImportError(
         bool json,
@@ -1336,8 +1509,9 @@ internal static class ExportImportCommandRunner
         string errorCode,
         string message,
         string hint,
-        string usage)
-        => WriteStructuredError(json, jsonOptions, ImportCommandName, phase, errorCode, message, hint, usage);
+        string usage,
+        int exitCode = CommandExitCodes.UsageError)
+        => WriteStructuredError(json, jsonOptions, ImportCommandName, phase, errorCode, message, hint, usage, exitCode);
 
     private static int WriteExportError(
         bool json,
@@ -1346,8 +1520,9 @@ internal static class ExportImportCommandRunner
         string errorCode,
         string message,
         string hint,
-        string usage)
-        => WriteStructuredError(json, jsonOptions, ExportCommandName, phase, errorCode, message, hint, usage);
+        string usage,
+        int exitCode = CommandExitCodes.UsageError)
+        => WriteStructuredError(json, jsonOptions, ExportCommandName, phase, errorCode, message, hint, usage, exitCode);
 
     private static int WriteStructuredError(
         bool json,
@@ -1357,17 +1532,18 @@ internal static class ExportImportCommandRunner
         string errorCode,
         string message,
         string hint,
-        string usage)
+        string usage,
+        int exitCode = CommandExitCodes.UsageError)
     {
         if (json)
         {
             Console.WriteLine(JsonSerializer.Serialize(
                 new ExportImportErrorResult("1", "error", command, phase, errorCode, message, hint, usage),
                 CliJsonSerializerContextFactory.Create(jsonOptions).ExportImportErrorResult));
-            return CommandExitCodes.UsageError;
+            return exitCode;
         }
 
-        return WriteError(message, hint, usage);
+        return WriteError(message, hint, usage, exitCode);
     }
 
     private static void AddImportValidationPhase(

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -1356,11 +1356,7 @@ internal static class ExportImportCommandRunner
     }
 
     private static bool IsRecoverableReplacementException(Exception ex)
-        => ex is IOException
-            or UnauthorizedAccessException
-            or ArgumentException
-            or NotSupportedException
-            or PathTooLongException;
+        => FileSystemTraversalFailure.IsExpected(ex);
 
     private static void DeleteSqliteSidecars(string dbPath, string? cleanupDescription = null)
     {
@@ -1382,7 +1378,7 @@ internal static class ExportImportCommandRunner
             else
                 File.Delete(path);
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException or PathTooLongException)
+        catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
         {
             if (!string.IsNullOrWhiteSpace(cleanupDescription))
                 CommandErrorWriter.WriteStderr($"Warning: failed to delete {cleanupDescription} {ConsoleUi.FormatBoundedValue(path)} ({CommandErrorWriter.FormatSanitizedException(ex)}).");
@@ -1398,7 +1394,7 @@ internal static class ExportImportCommandRunner
 
             Directory.Delete(path);
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException or PathTooLongException)
+        catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
         {
             if (!string.IsNullOrWhiteSpace(cleanupDescription))
                 CommandErrorWriter.WriteStderr($"Warning: failed to delete {cleanupDescription} {ConsoleUi.FormatBoundedValue(path)} ({CommandErrorWriter.FormatSanitizedException(ex)}).");

--- a/src/CodeIndex/Cli/FileSystemTraversalFailure.cs
+++ b/src/CodeIndex/Cli/FileSystemTraversalFailure.cs
@@ -1,0 +1,24 @@
+namespace CodeIndex.Cli;
+
+internal static class FileSystemTraversalFailure
+{
+    internal static bool IsExpected(Exception ex)
+        => ex is IOException
+            or UnauthorizedAccessException
+            or ArgumentException
+            or NotSupportedException
+            or PathTooLongException;
+
+    internal static string DescribeReason(Exception ex)
+        => ex switch
+        {
+            UnauthorizedAccessException => "permissions",
+            PathTooLongException => "a path that is too long",
+            ArgumentException => "an invalid path",
+            NotSupportedException => "an unsupported path",
+            _ => "an I/O error",
+        };
+
+    internal static string ExceptionTypeName(Exception ex)
+        => ex.GetType().Name;
+}

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -681,20 +681,7 @@ public static partial class IndexCommandRunner
     }
 
     private static void StopFullScanJsonPhaseHeartbeat((CancellationTokenSource Cts, Task Task)? heartbeat)
-    {
-        if (heartbeat == null)
-            return;
-
-        heartbeat.Value.Cts.Cancel();
-        try
-        {
-            heartbeat.Value.Task.Wait(TimeSpan.FromSeconds(1));
-        }
-        catch (AggregateException ex) when (ex.InnerExceptions.All(inner => inner is OperationCanceledException or TaskCanceledException))
-        {
-        }
-        heartbeat.Value.Cts.Dispose();
-    }
+        => StopObservedJsonPhaseHeartbeat(heartbeat);
 
     private static int RunFullScan(
         DbWriter writer,

--- a/src/CodeIndex/Cli/IndexCommandRunner.UpdateTargets.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.UpdateTargets.cs
@@ -184,18 +184,32 @@ public static partial class IndexCommandRunner
     }
 
     private static void StopIndexJsonPhaseHeartbeat((CancellationTokenSource Cts, Task Task)? heartbeat)
+        => StopObservedJsonPhaseHeartbeat(heartbeat);
+
+    internal static void StopObservedJsonPhaseHeartbeat((CancellationTokenSource Cts, Task Task)? heartbeat)
     {
         if (heartbeat == null)
             return;
 
-        heartbeat.Value.Cts.Cancel();
-        try
+        var cts = heartbeat.Value.Cts;
+        var task = heartbeat.Value.Task;
+        cts.Cancel();
+        if (task.IsCompleted)
         {
-            heartbeat.Value.Task.Wait(TimeSpan.FromSeconds(1));
+            cts.Dispose();
+            return;
         }
-        catch (AggregateException ex) when (ex.InnerExceptions.All(inner => inner is OperationCanceledException or TaskCanceledException))
-        {
-        }
-        heartbeat.Value.Cts.Dispose();
+
+        _ = task.ContinueWith(
+            static (completedTask, state) =>
+            {
+                if (completedTask.IsFaulted)
+                    _ = completedTask.Exception;
+                ((CancellationTokenSource)state!).Dispose();
+            },
+            cts,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 }

--- a/src/CodeIndex/Cli/IndexFreshnessChecker.cs
+++ b/src/CodeIndex/Cli/IndexFreshnessChecker.cs
@@ -13,7 +13,8 @@ internal static class IndexFreshnessChecker
     internal static IndexFreshnessCheckResult Check(
         DbReader reader,
         string? projectRoot,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        bool? pathCaseSensitive = null)
     {
         if (string.IsNullOrWhiteSpace(projectRoot))
         {
@@ -51,7 +52,11 @@ internal static class IndexFreshnessChecker
             HeadChanged = headChanged,
         };
 
-        var ignoreCase = GitHelper.ResolveIgnoreCase(projectRoot, cancellationToken);
+        var ignoreCase = pathCaseSensitive.HasValue
+            ? !pathCaseSensitive.Value
+            : GitHelper.ResolveIgnoreCase(projectRoot, cancellationToken);
+        if (pathCaseSensitive.HasValue)
+            PathCasing.SeedFromWorkspace(projectRoot, ignoreCase);
         var ignoreRuleRoot = GitHelper.TryGetRepositoryRoot(projectRoot, cancellationToken) ?? Path.GetFullPath(projectRoot);
         var indexer = new FileIndexer(projectRoot, ignoreCase, ignoreRuleRoot);
         var scan = indexer.ScanFilesDetailed(cancellationToken: cancellationToken);

--- a/src/CodeIndex/Cli/IndexWatchRunner.cs
+++ b/src/CodeIndex/Cli/IndexWatchRunner.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.Text;
 using System.Text.Json;
 using CodeIndex.Diagnostics;
 using CodeIndex.Indexer;
@@ -22,6 +23,7 @@ internal static class IndexWatchRunner
     internal const int MaxHumanSummarySubRunJsonChars = 64 * 1024;
     internal const int MaxHumanSummaryJsonDepth = 16;
     internal const int BatchPathSampleLimit = 20;
+    internal const int MaxSubRunArgumentChars = 64 * 1024;
     internal const int BatchPathSampleMaxChars = 160;
     internal const int MaxWatchDiagnosticChars = 256;
     private const int InternalBufferSize = 64 * 1024;
@@ -56,6 +58,18 @@ internal static class IndexWatchRunner
     }
 
     internal static int RunCore(
+        IndexCommandOptions baseOptions,
+        JsonSerializerOptions jsonOptions,
+        string projectRoot,
+        string resolvedDbPath,
+        CancellationToken cancellationToken)
+        // Preserve the existing synchronous CLI/test entry point while the watch loop itself
+        // runs through RunCoreAsync so cancellation does not block on Task.Delay.
+        => RunCoreAsync(baseOptions, jsonOptions, projectRoot, resolvedDbPath, cancellationToken)
+            .GetAwaiter()
+            .GetResult();
+
+    internal static async Task<int> RunCoreAsync(
         IndexCommandOptions baseOptions,
         JsonSerializerOptions jsonOptions,
         string projectRoot,
@@ -136,7 +150,7 @@ internal static class IndexWatchRunner
             {
                 try
                 {
-                    Task.Delay(PollIntervalMs, cancellationToken).GetAwaiter().GetResult();
+                    await Task.Delay(PollIntervalMs, cancellationToken).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
                 {
@@ -178,14 +192,66 @@ internal static class IndexWatchRunner
         IReadOnlyList<string> changedPaths,
         string resolvedDbPath)
     {
-        var stopwatch = Stopwatch.StartNew();
-        var args = BuildSubRunArgs(baseOptions, resolvedDbPath);
-        args.Add("--files");
-        foreach (var path in changedPaths)
-            args.Add(path);
+        var baseArgs = BuildSubRunArgs(baseOptions, resolvedDbPath);
+        var batches = BuildPartialUpdateBatches(baseArgs, changedPaths);
+        if (batches == null)
+            return RunFullRescan(baseOptions, jsonOptions, resolvedDbPath);
 
-        return InvokeSubRunAndEmit(baseOptions, jsonOptions, args, stopwatch, "updated", changedPaths.Count, "incremental", changedPaths);
+        var exitCode = CommandExitCodes.Success;
+        foreach (var batch in batches)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var args = new List<string>(baseArgs.Count + 1 + batch.Count);
+            args.AddRange(baseArgs);
+            args.Add("--files");
+            args.AddRange(batch);
+
+            var subRunExitCode = InvokeSubRunAndEmit(baseOptions, jsonOptions, args, stopwatch, "updated", batch.Count, "incremental", batch);
+            RecordSubRunExitCode(ref exitCode, subRunExitCode);
+        }
+
+        return exitCode;
     }
+
+    internal static List<List<string>>? BuildPartialUpdateBatches(IReadOnlyList<string> baseArgs, IReadOnlyList<string> changedPaths)
+    {
+        var baseArgumentChars = EstimateSubRunArgumentChars(baseArgs) + EstimateSubRunArgumentChars("--files");
+        var batches = new List<List<string>>();
+        var current = new List<string>();
+        var currentArgumentChars = baseArgumentChars;
+
+        foreach (var path in changedPaths)
+        {
+            var pathArgumentChars = EstimateSubRunArgumentChars(path);
+            if (baseArgumentChars + pathArgumentChars > MaxSubRunArgumentChars)
+                return null;
+
+            if (current.Count > 0 && currentArgumentChars + pathArgumentChars > MaxSubRunArgumentChars)
+            {
+                batches.Add(current);
+                current = new List<string>();
+                currentArgumentChars = baseArgumentChars;
+            }
+
+            current.Add(path);
+            currentArgumentChars += pathArgumentChars;
+        }
+
+        if (current.Count > 0)
+            batches.Add(current);
+        return batches;
+    }
+
+    private static int EstimateSubRunArgumentChars(IEnumerable<string> args)
+    {
+        var total = 0;
+        foreach (var arg in args)
+            total += EstimateSubRunArgumentChars(arg);
+        return total;
+    }
+
+    private static int EstimateSubRunArgumentChars(string arg)
+        => arg.Length + 1;
 
     private static int RunFullRescan(
         IndexCommandOptions baseOptions,
@@ -270,20 +336,41 @@ internal static class IndexWatchRunner
         IReadOnlyList<string>? batchPaths)
     {
         string capturedJson;
+        string? spoolPath = null;
         int subRunExitCode;
         var previousOut = Console.Out;
-        using var captureWriter = new StringWriter();
-        Console.SetOut(captureWriter);
+        WatchSubRunCaptureWriter? captureWriter = null;
         try
         {
-            subRunExitCode = IndexCommandRunner.Run(args.ToArray(), jsonOptions);
+            TextWriter? spoolWriter = null;
+            if (baseOptions.Json)
+            {
+                spoolPath = Path.Combine(Path.GetTempPath(), $"cdidx-watch-subrun-{Guid.NewGuid():N}.jsonl");
+                spoolWriter = new StreamWriter(
+                    new FileStream(spoolPath, FileMode.CreateNew, FileAccess.Write, FileShare.Read),
+                    new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+            }
+
+            captureWriter = new WatchSubRunCaptureWriter(MaxHumanSummarySubRunJsonChars + 1, spoolWriter);
+            Console.SetOut(captureWriter);
+            try
+            {
+                subRunExitCode = IndexCommandRunner.Run(args.ToArray(), jsonOptions);
+            }
+            finally
+            {
+                Console.SetOut(previousOut);
+            }
+
+            captureWriter.Flush();
+            capturedJson = captureWriter.CapturedText;
         }
         finally
         {
             Console.SetOut(previousOut);
+            captureWriter?.Dispose();
         }
         stopwatch.Stop();
-        capturedJson = captureWriter.ToString();
         var eventStatus = subRunExitCode == CommandExitCodes.Success ? status : "failed";
         var failureReason = subRunExitCode == CommandExitCodes.Success
             ? null
@@ -314,9 +401,16 @@ internal static class IndexWatchRunner
                 Reason = failureReason,
             }, CliJsonSerializerContextFactory.Create(jsonOptions).IndexWatchEventJsonResult));
 
-            var trimmed = capturedJson.TrimEnd('\r', '\n');
-            if (!string.IsNullOrEmpty(trimmed))
-                Console.Out.WriteLine(trimmed);
+            if (!TryWriteSpooledSubRunOutput(spoolPath, out var endedWithLineBreak))
+            {
+                var trimmed = capturedJson.TrimEnd('\r', '\n');
+                if (!string.IsNullOrEmpty(trimmed))
+                    Console.Out.WriteLine(trimmed);
+            }
+            else if (!endedWithLineBreak)
+            {
+                Console.Out.WriteLine();
+            }
         }
         else
         {
@@ -324,8 +418,112 @@ internal static class IndexWatchRunner
             CommandErrorWriter.WriteStderr(human);
         }
 
+        DeleteSpoolFile(spoolPath);
         return subRunExitCode;
     }
+
+    private static bool TryWriteSpooledSubRunOutput(string? spoolPath, out bool endedWithLineBreak)
+    {
+        endedWithLineBreak = true;
+        if (string.IsNullOrWhiteSpace(spoolPath) || !File.Exists(spoolPath) || new FileInfo(spoolPath).Length == 0)
+            return false;
+
+        var buffer = new char[8192];
+        var wroteAny = false;
+        char lastChar = '\0';
+        using var reader = new StreamReader(spoolPath, Encoding.UTF8);
+        int read;
+        while ((read = reader.Read(buffer, 0, buffer.Length)) > 0)
+        {
+            Console.Out.Write(buffer, 0, read);
+            wroteAny = true;
+            lastChar = buffer[read - 1];
+        }
+
+        endedWithLineBreak = !wroteAny || lastChar is '\n' or '\r';
+        return wroteAny;
+    }
+
+    private static void DeleteSpoolFile(string? spoolPath)
+    {
+        if (string.IsNullOrWhiteSpace(spoolPath))
+            return;
+        try
+        {
+            File.Delete(spoolPath);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+        }
+    }
+
+    internal sealed class WatchSubRunCaptureWriter : TextWriter
+    {
+        private readonly int _maxCapturedChars;
+        private readonly TextWriter? _inner;
+        private readonly StringBuilder _captured = new();
+
+        internal WatchSubRunCaptureWriter(int maxCapturedChars, TextWriter? inner)
+        {
+            _maxCapturedChars = Math.Max(0, maxCapturedChars);
+            _inner = inner;
+        }
+
+        public override Encoding Encoding => _inner?.Encoding ?? Encoding.UTF8;
+
+        internal string CapturedText => _captured.ToString();
+
+        internal bool Truncated { get; private set; }
+
+        public override void Write(char value)
+        {
+            Capture(stackalloc char[] { value });
+            _inner?.Write(value);
+        }
+
+        public override void Write(string? value)
+        {
+            if (value != null)
+                Capture(value.AsSpan());
+            _inner?.Write(value);
+        }
+
+        public override void Write(char[] buffer, int index, int count)
+        {
+            Capture(buffer.AsSpan(index, count));
+            _inner?.Write(buffer, index, count);
+        }
+
+        public override void Flush()
+        {
+            _inner?.Flush();
+            base.Flush();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _inner?.Dispose();
+            base.Dispose(disposing);
+        }
+
+        private void Capture(ReadOnlySpan<char> value)
+        {
+            var remaining = _maxCapturedChars - _captured.Length;
+            if (remaining <= 0)
+            {
+                if (value.Length > 0)
+                    Truncated = true;
+                return;
+            }
+
+            var take = Math.Min(remaining, value.Length);
+            _captured.Append(value[..take]);
+            if (take < value.Length)
+                Truncated = true;
+        }
+    }
+
 
     private static string FormatHumanSummary(string status, int? batchSize, long elapsedMs, string subRunJson, int exitCode)
     {

--- a/src/CodeIndex/Cli/PathCasing.cs
+++ b/src/CodeIndex/Cli/PathCasing.cs
@@ -77,7 +77,15 @@ internal static class PathCasing
     {
         if (string.IsNullOrEmpty(workspaceRoot))
             return;
-        var anchor = ResolveAnchor(workspaceRoot);
+        SeedFromReferencePath(workspaceRoot, ignoreCase);
+        SeedFromReferencePath(Path.Combine(workspaceRoot, CaseSensitivityProbeDirectory.DataDirectoryName), ignoreCase);
+    }
+
+    public static void SeedFromReferencePath(string referencePath, bool ignoreCase)
+    {
+        if (string.IsNullOrEmpty(referencePath))
+            return;
+        var anchor = ResolveAnchor(referencePath);
         _ignoreCaseByAnchor[anchor] = ignoreCase;
     }
 

--- a/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
@@ -248,8 +248,8 @@ internal static partial class ProgramRunner
         {
             "upgrade" => RunUpgrade(subArgs, context.JsonOptions, context.AppVersion, context.CancellationToken),
             "index" => IndexCommandRunner.Run(subArgs, context.JsonOptions),
-            "export" => ExportImportCommandRunner.RunExport(subArgs, context.JsonOptions, context.AppVersion),
-            "import" => ExportImportCommandRunner.RunImport(subArgs, context.JsonOptions),
+            "export" => ExportImportCommandRunner.RunExport(subArgs, context.JsonOptions, context.AppVersion, context.CancellationToken),
+            "import" => ExportImportCommandRunner.RunImport(subArgs, context.JsonOptions, context.CancellationToken),
             "diff" => DiffCommandRunner.Run(subArgs, context.JsonOptions),
             "hooks" => HookCommandRunner.Run(subArgs, context.JsonOptions),
             "backfill-fold" => IndexCommandRunner.RunBackfillFold(subArgs, context.JsonOptions),

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
+using System.ComponentModel;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
@@ -26,6 +27,7 @@ internal static partial class ProgramRunner
     private const string ReleaseAssetUrlTemplate = "https://github.com/Widthdom/CodeIndex/releases/download/{0}/{1}";
     private const string ReleasePageUrlTemplate = "https://github.com/Widthdom/CodeIndex/releases/tag/{0}";
     private const string InstallerScriptAssetName = "install.sh";
+    private const string UpgradeInstallerDirectoryPrefix = "cdidx-install-";
     private const string ReleaseChecksumAssetName = "sha256sums.txt";
     private const long MaxInstallerScriptBytes = 1024 * 1024;
     internal const long MaxReleaseChecksumBytes = 256 * 1024;
@@ -45,7 +47,6 @@ internal static partial class ProgramRunner
     };
     private static readonly TimeSpan InstallerRunTimeout = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan InstallerKillWaitTimeout = TimeSpan.FromSeconds(5);
-    private const string UpgradeInstallerDirectoryPrefix = "cdidx-install-";
     private static readonly HashSet<string> NonLogGlobalOptionNames =
         CliFlagSchema.GetTopLevelGlobalOptionNames(includeLogOptions: false);
     private static readonly HashSet<string> TopLevelValueOptionNames =
@@ -3067,6 +3068,7 @@ internal static partial class ProgramRunner
                 CommandErrorWriter.WriteStderr($"Error: install directory is not writable: {installDir}");
                 if (installDirectoryError != null)
                     CommandErrorWriter.WriteStderr($"Reason: {installDirectoryError}");
+                WriteUpgradeInstallerTrustDiagnostic();
                 CommandErrorWriter.WriteStderr("Hint: rerun with permissions that can write this directory, or reinstall cdidx into a per-user directory.");
             }
             return CommandExitCodes.UsageError;
@@ -3148,6 +3150,7 @@ internal static partial class ProgramRunner
             else
             {
                 CommandErrorWriter.WriteStderr($"Error: upgrade failed before install.sh completed ({ex.GetType().Name}: {ex.Message}).");
+                WriteUpgradeInstallerTrustDiagnostic();
                 CommandErrorWriter.WriteStderr("Hint: rerun `install.sh` manually for the desired release.");
             }
             return CommandExitCodes.InstallError;
@@ -3246,6 +3249,9 @@ internal static partial class ProgramRunner
     private static bool IsPrereleaseTag(string releaseTag)
         => releaseTag.Contains('-', StringComparison.Ordinal);
 
+    private static void WriteUpgradeInstallerTrustDiagnostic()
+        => CommandErrorWriter.WriteStderr($"Installer verification: {UpgradeInstallerVerification}; {UpgradeInstallerTrustBoundary}");
+
     internal static UpgradeHandoff CreateWindowsUpgradeHandoff(string releaseTag, Architecture processArchitecture)
     {
         var normalizedTag = releaseTag.Trim();
@@ -3307,12 +3313,14 @@ internal static partial class ProgramRunner
 
     internal static ProcessStartInfo CreateInstallerProcessStartInfo(string scriptPath, string releaseTag, string installDir)
     {
+        var fullScriptPath = Path.GetFullPath(scriptPath);
         var startInfo = new ProcessStartInfo
         {
             FileName = ResolveTrustedBashPath(),
             UseShellExecute = false,
+            WorkingDirectory = Path.GetDirectoryName(fullScriptPath) ?? string.Empty,
         };
-        startInfo.ArgumentList.Add(scriptPath);
+        startInfo.ArgumentList.Add(fullScriptPath);
         startInfo.ArgumentList.Add(releaseTag);
         startInfo.Environment["CDIDX_INSTALL_DIR"] = installDir;
         return startInfo;
@@ -3351,28 +3359,75 @@ internal static partial class ProgramRunner
             startInfo.RedirectStandardError = true;
         }
 
-        using var process = Process.Start(startInfo);
-        if (process == null)
+        Process? process;
+        try
+        {
+            process = Process.Start(startInfo);
+        }
+        catch (Exception ex) when (IsInstallerProcessStartException(ex))
         {
             if (!suppressOutput)
-                CommandErrorWriter.WriteStderr("Error: failed to start install.sh for upgrade.");
+            {
+                CommandErrorWriter.WriteStderr($"Error: failed to start install.sh for upgrade ({CommandErrorWriter.FormatSanitizedException(ex)}).");
+                CommandErrorWriter.WriteStderr("Hint: rerun `install.sh` manually for the desired release.");
+            }
             return InstallerProcessResult.Failure(CommandExitCodes.InstallError);
         }
 
-        var outputDrainTask = suppressOutput
-            ? DrainSuppressedInstallerOutputAsync(process)
-            : Task.FromResult(SuppressedInstallerOutputResult.Empty);
-
-        try
+        if (process == null)
         {
-            var waitTask = process.WaitForExitAsync(cancellationToken);
-            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            var timeoutTask = Task.Delay(ToWaitMilliseconds(timeout), timeoutCts.Token);
-            var completedTask = Task.WhenAny(waitTask, timeoutTask).GetAwaiter().GetResult();
-            if (completedTask == waitTask)
+            if (!suppressOutput)
             {
-                timeoutCts.Cancel();
-                waitTask.GetAwaiter().GetResult();
+                CommandErrorWriter.WriteStderr("Error: failed to start install.sh for upgrade.");
+                CommandErrorWriter.WriteStderr("Hint: rerun `install.sh` manually for the desired release.");
+            }
+            return InstallerProcessResult.Failure(CommandExitCodes.InstallError);
+        }
+
+        using (process)
+        {
+            var outputDrainTask = suppressOutput
+                ? DrainSuppressedInstallerOutputAsync(process)
+                : Task.FromResult(SuppressedInstallerOutputResult.Empty);
+
+            try
+            {
+                var waitTask = process.WaitForExitAsync(cancellationToken);
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                var timeoutTask = Task.Delay(ToWaitMilliseconds(timeout), timeoutCts.Token);
+                var completedTask = Task.WhenAny(waitTask, timeoutTask).GetAwaiter().GetResult();
+                if (completedTask == waitTask)
+                {
+                    timeoutCts.Cancel();
+                    waitTask.GetAwaiter().GetResult();
+                    var output = outputDrainTask.GetAwaiter().GetResult();
+                    return new InstallerProcessResult(
+                        process.ExitCode,
+                        output.StdoutTail,
+                        output.StderrTail,
+                        output.Truncated);
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                    waitTask.GetAwaiter().GetResult();
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                TryKillProcessTree(process);
+                if (!process.WaitForExit(ToWaitMilliseconds(InstallerKillWaitTimeout)))
+                {
+                    if (!suppressOutput)
+                        CommandErrorWriter.WriteStderr("Error: install.sh was cancelled and did not exit after cancellation.");
+                }
+                else
+                {
+                    outputDrainTask.GetAwaiter().GetResult();
+                }
+                throw;
+            }
+
+            if (process.HasExited)
+            {
                 var output = outputDrainTask.GetAwaiter().GetResult();
                 return new InstallerProcessResult(
                     process.ExitCode,
@@ -3381,57 +3436,37 @@ internal static partial class ProgramRunner
                     output.Truncated);
             }
 
-            if (cancellationToken.IsCancellationRequested)
-                waitTask.GetAwaiter().GetResult();
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
             TryKillProcessTree(process);
             if (!process.WaitForExit(ToWaitMilliseconds(InstallerKillWaitTimeout)))
             {
                 if (!suppressOutput)
-                    CommandErrorWriter.WriteStderr("Error: install.sh was cancelled and did not exit after cancellation.");
+                    CommandErrorWriter.WriteStderr("Error: install.sh timed out and did not exit after cancellation.");
             }
             else
             {
                 outputDrainTask.GetAwaiter().GetResult();
+                if (!suppressOutput)
+                    CommandErrorWriter.WriteStderr($"Error: install.sh timed out after {FormatDuration(timeout)}.");
             }
-            throw;
-        }
-
-        if (process.HasExited)
-        {
-            var output = outputDrainTask.GetAwaiter().GetResult();
+            if (!suppressOutput)
+                CommandErrorWriter.WriteStderr("Hint: rerun `install.sh` manually for the desired release.");
+            var timeoutOutput = outputDrainTask.IsCompletedSuccessfully
+                ? outputDrainTask.GetAwaiter().GetResult()
+                : SuppressedInstallerOutputResult.Empty;
             return new InstallerProcessResult(
-                process.ExitCode,
-                output.StdoutTail,
-                output.StderrTail,
-                output.Truncated);
+                CommandExitCodes.InstallError,
+                timeoutOutput.StdoutTail,
+                timeoutOutput.StderrTail,
+                timeoutOutput.Truncated);
         }
-
-        TryKillProcessTree(process);
-        if (!process.WaitForExit(ToWaitMilliseconds(InstallerKillWaitTimeout)))
-        {
-            if (!suppressOutput)
-                CommandErrorWriter.WriteStderr("Error: install.sh timed out and did not exit after cancellation.");
-        }
-        else
-        {
-            outputDrainTask.GetAwaiter().GetResult();
-            if (!suppressOutput)
-                CommandErrorWriter.WriteStderr($"Error: install.sh timed out after {FormatDuration(timeout)}.");
-        }
-        if (!suppressOutput)
-            CommandErrorWriter.WriteStderr("Hint: rerun `install.sh` manually for the desired release.");
-        var timeoutOutput = outputDrainTask.IsCompletedSuccessfully
-            ? outputDrainTask.GetAwaiter().GetResult()
-            : SuppressedInstallerOutputResult.Empty;
-        return new InstallerProcessResult(
-            CommandExitCodes.InstallError,
-            timeoutOutput.StdoutTail,
-            timeoutOutput.StderrTail,
-            timeoutOutput.Truncated);
     }
+
+    private static bool IsInstallerProcessStartException(Exception ex)
+        => ex is Win32Exception
+            or InvalidOperationException
+            or FileNotFoundException
+            or DirectoryNotFoundException
+            or UnauthorizedAccessException;
 
     private static async Task<SuppressedInstallerOutputResult> DrainSuppressedInstallerOutputAsync(Process process)
     {
@@ -3555,7 +3590,7 @@ internal static partial class ProgramRunner
         }
     }
 
-    private static bool TryValidateUpgradeInstallerDirectoryCleanupTarget(
+    internal static bool TryValidateUpgradeInstallerDirectoryCleanupTarget(
         string path,
         out string fullPath,
         out string failureReason)
@@ -3582,10 +3617,13 @@ internal static partial class ProgramRunner
             var longPath = LongPath.EnsureWindowsPrefix(fullPath);
             if (Directory.Exists(longPath))
             {
-                var attributes = File.GetAttributes(longPath);
-                if ((attributes & (FileAttributes.ReparsePoint | FileAttributes.Device)) != 0)
+                var directoryInfo = new DirectoryInfo(fullPath);
+                directoryInfo.Refresh();
+                var attributes = directoryInfo.Attributes;
+                if ((attributes & (FileAttributes.ReparsePoint | FileAttributes.Device)) != 0
+                    || !string.IsNullOrEmpty(directoryInfo.LinkTarget))
                 {
-                    failureReason = "target is not a regular temporary directory";
+                    failureReason = "target is a symbolic link, reparse point, or device";
                     return false;
                 }
             }
@@ -3770,8 +3808,20 @@ internal static partial class ProgramRunner
         var createdProbe = false;
         try
         {
-            Directory.CreateDirectory(directory);
-            probe = Path.Combine(directory, $".cdidx-write-test-{Guid.NewGuid():N}");
+            if (!TryResolveUpgradeInstallDirectory(directory, out var fullDirectory, out diagnostic))
+                return false;
+
+            Directory.CreateDirectory(fullDirectory);
+            if (!TryValidateExistingUpgradeInstallDirectory(fullDirectory, out diagnostic))
+                return false;
+
+            probe = Path.GetFullPath(Path.Combine(fullDirectory, $".cdidx-write-test-{Guid.NewGuid():N}"));
+            if (!IsPathEqualOrChildNoProbe(fullDirectory, probe) || string.Equals(fullDirectory, probe, InstallDirectoryPathComparison))
+            {
+                diagnostic = "install directory write probe escaped the install directory.";
+                return false;
+            }
+
             File.WriteAllText(probe, "");
             createdProbe = true;
             return true;
@@ -3786,6 +3836,97 @@ internal static partial class ProgramRunner
             if (createdProbe && probe != null)
                 TryDeleteInstallDirectoryWriteProbe(probe);
         }
+    }
+
+    private static bool TryResolveUpgradeInstallDirectory(string directory, out string fullDirectory, out string? diagnostic)
+    {
+        fullDirectory = string.Empty;
+        diagnostic = null;
+        if (string.IsNullOrWhiteSpace(directory))
+        {
+            diagnostic = "install directory is empty.";
+            return false;
+        }
+
+        try
+        {
+            fullDirectory = NormalizeDirectoryBoundaryPath(Path.GetFullPath(directory));
+            var root = Path.GetPathRoot(fullDirectory);
+            if (!string.IsNullOrEmpty(root) && string.Equals(fullDirectory, NormalizeDirectoryBoundaryPath(root), InstallDirectoryPathComparison))
+            {
+                diagnostic = "install directory must not be the filesystem root.";
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            diagnostic = CommandErrorWriter.FormatSanitizedException(ex);
+            return false;
+        }
+    }
+
+    private static bool TryValidateExistingUpgradeInstallDirectory(string fullDirectory, out string? diagnostic)
+    {
+        diagnostic = null;
+        try
+        {
+            var directoryInfo = new DirectoryInfo(fullDirectory);
+            directoryInfo.Refresh();
+            if (!directoryInfo.Exists)
+            {
+                diagnostic = "install directory does not exist after creation.";
+                return false;
+            }
+
+            if ((directoryInfo.Attributes & FileAttributes.ReparsePoint) != 0 || !string.IsNullOrEmpty(directoryInfo.LinkTarget))
+            {
+                diagnostic = "install directory must not be a symbolic link or reparse point.";
+                return false;
+            }
+
+            if (!OperatingSystem.IsWindows())
+            {
+                var mode = File.GetUnixFileMode(fullDirectory);
+                if ((mode & (UnixFileMode.GroupWrite | UnixFileMode.OtherWrite)) != 0)
+                {
+                    diagnostic = "install directory must not be group- or world-writable.";
+                    return false;
+                }
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            diagnostic = CommandErrorWriter.FormatSanitizedException(ex);
+            return false;
+        }
+    }
+
+    private static string NormalizeDirectoryBoundaryPath(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var root = Path.GetPathRoot(fullPath);
+        if (!string.IsNullOrEmpty(root) && string.Equals(fullPath, root, InstallDirectoryPathComparison))
+            return fullPath;
+        return fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    private static StringComparison InstallDirectoryPathComparison
+        => OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+
+    private static bool IsPathEqualOrChildNoProbe(string normalizedParent, string normalizedChild)
+    {
+        if (string.Equals(normalizedParent, normalizedChild, InstallDirectoryPathComparison))
+            return true;
+
+        var trimmedParent = normalizedParent.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        return normalizedChild.StartsWith(trimmedParent + Path.DirectorySeparatorChar, InstallDirectoryPathComparison)
+            || normalizedChild.StartsWith(trimmedParent + Path.AltDirectorySeparatorChar, InstallDirectoryPathComparison);
     }
 
     private static void TryDeleteInstallDirectoryWriteProbe(string probePath)

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -2399,16 +2399,22 @@ public static partial class QueryCommandRunner
     private static bool TryParseSearchCursor(string value, out SearchCursor cursor)
     {
         cursor = default;
-        var parts = value.Split(':');
-        if (parts.Length != 3)
+        var lastSeparator = value.LastIndexOf(':');
+        if (lastSeparator <= 0 || lastSeparator == value.Length - 1)
             return false;
-        if (!double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var score) ||
-            !long.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var chunkId) ||
-            !int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var offset) ||
-            offset < 0)
-        {
+
+        var firstSeparator = value.LastIndexOf(':', lastSeparator - 1);
+        if (firstSeparator <= 0 || firstSeparator == lastSeparator - 1)
             return false;
-        }
+
+        if (!double.TryParse(value.AsSpan(0, firstSeparator), NumberStyles.Float, CultureInfo.InvariantCulture, out var score)
+            || !double.IsFinite(score))
+            return false;
+        if (!long.TryParse(value.AsSpan(firstSeparator + 1, lastSeparator - firstSeparator - 1), NumberStyles.None, CultureInfo.InvariantCulture, out var chunkId)
+            || chunkId < 0)
+            return false;
+        if (!int.TryParse(value.AsSpan(lastSeparator + 1), NumberStyles.None, CultureInfo.InvariantCulture, out var offset) || offset < 0)
+            return false;
 
         cursor = new SearchCursor(score, chunkId, offset);
         return true;

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -975,6 +975,43 @@ public static partial class QueryCommandRunner
 
     private static int RunGroupedSearchCount(DbReader reader, QueryCommandOptions options, JsonSerializerOptions jsonOptions, bool exact, SearchQueryHint? exactSubstringHint)
     {
+        if (options.GroupBy == "file" && !HasSearchOriginFilters(options))
+        {
+            var fileGroups = reader.CountSearchResultsByFile(options.Query!, options.Lang, options.RawFts, options.PathPatterns, options.ExcludePaths, options.ExcludeTests, !options.NoDedup, options.Since, exact, options.Prefix, !options.NoVisibilityRank, options.GuardFilters, options.GuardWindow, options.GuardScope);
+            var totalCount = fileGroups.Sum(group => group.Count);
+            var fileCountGroups = fileGroups
+                .Select(group => new SearchGroupedCountItemJsonResult(
+                    group.Path,
+                    group.Count,
+                    group.Path,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null))
+                .ToList();
+
+            if (options.Json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(
+                    new SearchGroupedCountJsonResult(
+                        JsonOutputContract.ApiVersion,
+                        options.Query!,
+                        options.GroupBy!,
+                        totalCount,
+                        fileGroups.Count,
+                        fileCountGroups),
+                    CliJsonSerializerContextFactory.Create(jsonOptions).SearchGroupedCountJsonResult));
+            }
+            else
+            {
+                WriteSearchGroupedCounts(options.GroupBy!, fileCountGroups, totalCount, fileGroups.Count);
+                WriteExactSubstringHintIfNeeded(exactSubstringHint);
+            }
+
+            return CommandExitCodes.Success;
+        }
+
         var results = reader.Search(options.Query!, int.MaxValue, options.Lang, options.RawFts, options.PathPatterns, options.ExcludePaths, options.ExcludeTests, !options.NoDedup, options.Since, exact, options.Prefix, !options.NoVisibilityRank, guardFilters: options.GuardFilters, guardWindow: options.GuardWindow, guardScope: options.GuardScope);
         var displayRows = BuildSearchDisplayRows(results, options, exact);
         var groups = BuildSearchGroupedCounts(options.GroupBy!, displayRows);

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -6003,7 +6003,7 @@ public static partial class QueryCommandRunner
                 status.MacProfileDiagnostics = macProfile.Diagnostics.ToList();
             if (options.CheckWorkspace)
             {
-                status.WorkspaceCheck = IndexFreshnessChecker.Check(reader, status.ProjectRoot, cancellationToken);
+                status.WorkspaceCheck = IndexFreshnessChecker.Check(reader, status.ProjectRoot, cancellationToken, status.PathCaseSensitive);
                 status.IndexMatchesWorkspace = status.WorkspaceCheck.Checked
                     ? status.WorkspaceCheck.MatchesWorkspace
                     : null;

--- a/src/CodeIndex/Cli/SearchAuditRecipes.cs
+++ b/src/CodeIndex/Cli/SearchAuditRecipes.cs
@@ -716,10 +716,16 @@ internal static class SearchAuditRecipes
         for (var i = 0; i < labelArray.Count && i < MaxExternalLabelCount; i++)
         {
             if (!TryReadString(labelArray[i], out var label) || string.IsNullOrWhiteSpace(label))
+            {
+                AddDiagnostic(diagnostics, $"{sourceLabel} recipe '{recipeName}' query '{queryName}' label #{i + 1} must be a non-empty string.");
                 continue;
+            }
             label = label.Trim();
             if (label.Length > MaxExternalLabelLength)
+            {
+                AddDiagnostic(diagnostics, $"{sourceLabel} recipe '{recipeName}' query '{queryName}' label #{i + 1} exceeds {MaxExternalLabelLength} characters.");
                 continue;
+            }
             if (seen.Add(label))
                 labels.Add(label);
         }

--- a/src/CodeIndex/Cli/SearchSnippetFormatter.cs
+++ b/src/CodeIndex/Cli/SearchSnippetFormatter.cs
@@ -11,6 +11,8 @@ public static class SearchSnippetFormatter
 {
     public const int DefaultSnippetLines = 8;
     public const int MaxSnippetLines = 20;
+    internal const int MaxPreferredMatchScanLines = 4096;
+    internal const int MaxPreferredMatchScanChars = 1024 * 1024;
 
     public static SearchSnippetQueryContext PrepareQueryContext(string query)
     {
@@ -251,8 +253,10 @@ public static class SearchSnippetFormatter
         var tokens = queryForLanguage.Tokens;
         var normalizeCSharpVerbatimNames = queryForLanguage.NormalizeCSharpVerbatimNames;
 
-        var maxTrackedWindowLines = preferredMatchLine.HasValue ? int.MaxValue : maxLines;
-        var matchScan = FindMatchingLineIndexes(content, normalizedQuery, tokens, caseSensitive, normalizeCSharpVerbatimNames, maxTrackedWindowLines);
+        var maxTrackedWindowLines = preferredMatchLine.HasValue ? MaxPreferredMatchScanLines : maxLines;
+        var maxScannedLines = preferredMatchLine.HasValue ? MaxPreferredMatchScanLines : int.MaxValue;
+        var maxScannedChars = preferredMatchLine.HasValue ? MaxPreferredMatchScanChars : int.MaxValue;
+        var matchScan = FindMatchingLineIndexes(content, normalizedQuery, tokens, caseSensitive, normalizeCSharpVerbatimNames, maxTrackedWindowLines, maxScannedLines, maxScannedChars);
         var lineCount = matchScan.LineCount;
         if (lineCount == 0)
         {
@@ -618,11 +622,12 @@ public static class SearchSnippetFormatter
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
-    private static SearchSnippetLineMatchScan FindMatchingLineIndexes(string content, string query, string[] tokens, bool caseSensitive, bool normalizeCSharpVerbatimNames, int maxTrackedWindowLines)
+    private static SearchSnippetLineMatchScan FindMatchingLineIndexes(string content, string query, string[] tokens, bool caseSensitive, bool normalizeCSharpVerbatimNames, int maxTrackedWindowLines, int maxScannedLines = int.MaxValue, int maxScannedChars = int.MaxValue)
     {
         var comparison = caseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
         var matches = new List<int>();
         var lineCount = 0;
+        var scannedChars = 0;
         var totalMatchCount = 0;
         int? focusStart = null;
         int? firstDroppedMatchIndex = null;
@@ -631,7 +636,10 @@ public static class SearchSnippetFormatter
         {
             foreach (var (i, rawLine) in EnumerateContentLines(content))
             {
+                if (ShouldStopPreferredMatchScan(lineCount, scannedChars, maxScannedLines, maxScannedChars))
+                    break;
                 lineCount++;
+                scannedChars += rawLine.Length + 1;
                 var line = normalizeCSharpVerbatimNames ? CSharpVerbatimNameNormalizer.Normalize(rawLine) : rawLine;
                 if (line.Contains(query, comparison))
                     AddTrackedMatchIndex(matches, i, maxTrackedWindowLines, ref focusStart, ref totalMatchCount, ref firstDroppedMatchIndex);
@@ -647,12 +655,16 @@ public static class SearchSnippetFormatter
 
         matches.Clear();
         lineCount = 0;
+        scannedChars = 0;
         totalMatchCount = 0;
         focusStart = null;
         firstDroppedMatchIndex = null;
         foreach (var (i, rawLine) in EnumerateContentLines(content))
         {
+            if (ShouldStopPreferredMatchScan(lineCount, scannedChars, maxScannedLines, maxScannedChars))
+                break;
             lineCount++;
+            scannedChars += rawLine.Length + 1;
             var line = normalizeCSharpVerbatimNames ? CSharpVerbatimNameNormalizer.Normalize(rawLine) : rawLine;
             if (tokens.Any(token => line.Contains(token, comparison)))
                 AddTrackedMatchIndex(matches, i, maxTrackedWindowLines, ref focusStart, ref totalMatchCount, ref firstDroppedMatchIndex);
@@ -660,6 +672,9 @@ public static class SearchSnippetFormatter
 
         return new SearchSnippetLineMatchScan(matches, lineCount, totalMatchCount, firstDroppedMatchIndex);
     }
+
+    private static bool ShouldStopPreferredMatchScan(int lineCount, int scannedChars, int maxScannedLines, int maxScannedChars)
+        => lineCount >= maxScannedLines || scannedChars >= maxScannedChars;
 
     private static void AddTrackedMatchIndex(List<int> matches, int lineIndex, int maxTrackedWindowLines, ref int? focusStart, ref int totalMatchCount, ref int? firstDroppedMatchIndex)
     {

--- a/src/CodeIndex/Cli/SolutionProjectResolver.cs
+++ b/src/CodeIndex/Cli/SolutionProjectResolver.cs
@@ -49,6 +49,8 @@ internal static class SolutionProjectResolver
     internal const long MaxSolutionFileBytes = 8L * 1024 * 1024;
     internal const int MaxSolutionLineChars = 16 * 1024;
     internal const int MaxSolutionProjectReferences = 4096;
+    internal static Func<string, IEnumerable<string>>? EnumerateDirectoriesForTesting { get; set; }
+    internal static Func<string, IEnumerable<string>>? EnumerateFilesForTesting { get; set; }
 
     public static IReadOnlyList<DotNetProjectInfo> ResolveProjects(string workspaceRoot, string? solutionPath = null)
         => ResolveProjects(workspaceRoot, solutionPath, SolutionProjectResolverLimits.Default);
@@ -258,7 +260,7 @@ internal static class SolutionProjectResolver
     }
 
     private static bool IsExpectedFilesystemDiscoveryException(Exception ex)
-        => ex is IOException or UnauthorizedAccessException or NotSupportedException;
+        => FileSystemTraversalFailure.IsExpected(ex);
 
     private static void AddAutomaticSolutionDiscoveryDiagnostic(
         string workspaceRoot,
@@ -267,12 +269,7 @@ internal static class SolutionProjectResolver
         SolutionProjectResolverLimits limits,
         IList<string>? traversalDiagnostics)
     {
-        var reason = ex switch
-        {
-            UnauthorizedAccessException => "permissions",
-            NotSupportedException => "an unsupported path",
-            _ => "an I/O error",
-        };
+        var reason = FileSystemTraversalFailure.DescribeReason(ex);
         AddTraversalDiagnostic(
             workspaceRoot,
             directory,
@@ -400,13 +397,15 @@ internal static class SolutionProjectResolver
 
             return indexer.EvaluatePathFilter(directory, isDirectory: true).ShouldSkip;
         }
-        catch (UnauthorizedAccessException)
+        catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
         {
-            AddTraversalDiagnostic(workspaceRoot, directory, "directory filters", "permissions", limits, traversalDiagnostics);
-        }
-        catch (IOException)
-        {
-            AddTraversalDiagnostic(workspaceRoot, directory, "directory filters", "an I/O error", limits, traversalDiagnostics);
+            AddTraversalDiagnostic(
+                workspaceRoot,
+                directory,
+                "directory filters",
+                FileSystemTraversalFailure.DescribeReason(ex),
+                limits,
+                traversalDiagnostics);
         }
 
         return true;
@@ -423,13 +422,15 @@ internal static class SolutionProjectResolver
         {
             return !indexer.EvaluatePathFilter(file).ShouldSkip;
         }
-        catch (UnauthorizedAccessException)
+        catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
         {
-            AddTraversalDiagnostic(workspaceRoot, file, "file filters", "permissions", limits, traversalDiagnostics);
-        }
-        catch (IOException)
-        {
-            AddTraversalDiagnostic(workspaceRoot, file, "file filters", "an I/O error", limits, traversalDiagnostics);
+            AddTraversalDiagnostic(
+                workspaceRoot,
+                file,
+                "file filters",
+                FileSystemTraversalFailure.DescribeReason(ex),
+                limits,
+                traversalDiagnostics);
         }
 
         return false;
@@ -446,7 +447,7 @@ internal static class SolutionProjectResolver
             directory,
             "subdirectories",
             ProjectTraversalEntryKind.Directory,
-            Directory.EnumerateDirectories,
+            EnumerateDirectoriesForTesting ?? Directory.EnumerateDirectories,
             limits,
             budget,
             traversalDiagnostics);
@@ -462,7 +463,7 @@ internal static class SolutionProjectResolver
             directory,
             "files",
             ProjectTraversalEntryKind.File,
-            Directory.EnumerateFiles,
+            EnumerateFilesForTesting ?? Directory.EnumerateFiles,
             limits,
             budget,
             traversalDiagnostics);
@@ -482,14 +483,15 @@ internal static class SolutionProjectResolver
         {
             entries = enumerate(LongPath.EnsureWindowsPrefix(directory));
         }
-        catch (UnauthorizedAccessException)
+        catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
         {
-            AddTraversalDiagnostic(workspaceRoot, directory, entryKind, "permissions", limits, traversalDiagnostics);
-            yield break;
-        }
-        catch (IOException)
-        {
-            AddTraversalDiagnostic(workspaceRoot, directory, entryKind, "an I/O error", limits, traversalDiagnostics);
+            AddTraversalDiagnostic(
+                workspaceRoot,
+                directory,
+                entryKind,
+                FileSystemTraversalFailure.DescribeReason(ex),
+                limits,
+                traversalDiagnostics);
             yield break;
         }
 
@@ -503,14 +505,15 @@ internal static class SolutionProjectResolver
                     yield break;
                 entry = LongPath.RemoveWindowsPrefix(enumerator.Current);
             }
-            catch (UnauthorizedAccessException)
+            catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
             {
-                AddTraversalDiagnostic(workspaceRoot, directory, entryKind, "permissions", limits, traversalDiagnostics);
-                yield break;
-            }
-            catch (IOException)
-            {
-                AddTraversalDiagnostic(workspaceRoot, directory, entryKind, "an I/O error", limits, traversalDiagnostics);
+                AddTraversalDiagnostic(
+                    workspaceRoot,
+                    directory,
+                    entryKind,
+                    FileSystemTraversalFailure.DescribeReason(ex),
+                    limits,
+                    traversalDiagnostics);
                 yield break;
             }
 

--- a/src/CodeIndex/Cli/SolutionProjectResolver.cs
+++ b/src/CodeIndex/Cli/SolutionProjectResolver.cs
@@ -47,6 +47,7 @@ internal readonly record struct SolutionProjectResolverLimits(
 internal static class SolutionProjectResolver
 {
     internal const long MaxSolutionFileBytes = 8L * 1024 * 1024;
+    internal const int MaxSolutionFileLines = 65536;
     internal const int MaxSolutionLineChars = 16 * 1024;
     internal const int MaxSolutionProjectReferences = 4096;
     internal static Func<string, IEnumerable<string>>? EnumerateDirectoriesForTesting { get; set; }
@@ -284,20 +285,26 @@ internal static class SolutionProjectResolver
         string workspaceRoot,
         FileIndexer indexer)
     {
-        RejectOversizedSolutionFile(solutionPath);
+        var prefixedSolutionPath = LongPath.EnsureWindowsPrefix(solutionPath);
+        if (!BoundedLineReader.TryReadUtf8File(
+                prefixedSolutionPath,
+                checked((int)MaxSolutionFileBytes),
+                MaxSolutionFileLines,
+                MaxSolutionLineChars,
+                out var solutionLines,
+                out var readFailure))
+        {
+            ThrowSolutionReadFailure(solutionPath, readFailure);
+        }
+
         var root = Path.GetFullPath(workspaceRoot);
         var solutionDir = Path.GetDirectoryName(solutionPath) ?? workspaceRoot;
         var projects = new List<DotNetProjectInfo>();
         var lineNumber = 0;
         var projectReferenceCount = 0;
-        foreach (var line in File.ReadLines(LongPath.EnsureWindowsPrefix(solutionPath)))
+        foreach (var line in solutionLines)
         {
             lineNumber++;
-            if (line.Length > MaxSolutionLineChars)
-            {
-                throw new InvalidOperationException(
-                    $"solution line is too long at {solutionPath}:{lineNumber}: {line.Length} characters exceeds limit {MaxSolutionLineChars}.");
-            }
 
             if (!TryParseSolutionProjectLine(line, out var name, out var projectPath))
                 continue;
@@ -325,6 +332,30 @@ internal static class SolutionProjectResolver
             .OrderBy(project => project.Name, StringComparer.OrdinalIgnoreCase)
             .ThenBy(project => project.ProjectPath, StringComparer.OrdinalIgnoreCase)
             .ToList();
+    }
+
+    private static void ThrowSolutionReadFailure(string solutionPath, BoundedTextFileReadFailure failure)
+    {
+        if (failure.Kind == BoundedTextFileReadFailureKind.BytesExceeded)
+        {
+            throw new InvalidOperationException(
+                $"solution file is too large: {solutionPath} exceeds limit {MaxSolutionFileBytes} bytes.");
+        }
+
+        if (failure.Kind == BoundedTextFileReadFailureKind.LinesExceeded)
+        {
+            throw new InvalidOperationException(
+                $"solution file contains too many lines at {solutionPath}: limit {MaxSolutionFileLines} exceeded.");
+        }
+
+        if (failure.Kind == BoundedTextFileReadFailureKind.LineLengthExceeded)
+        {
+            throw new InvalidOperationException(
+                $"solution line is too long at {solutionPath}:{failure.LineNumber}: {failure.CharactersRead} characters exceeds limit {MaxSolutionLineChars}.");
+        }
+
+        throw new InvalidOperationException(
+            $"solution file could not be read at {solutionPath}: {failure.Reason}.");
     }
 
     private static DotNetProjectInfo BuildProjectInfo(string fullProjectPath, string workspaceRoot, string? solutionName = null)
@@ -633,16 +664,6 @@ internal static class SolutionProjectResolver
         return extension.Equals(".csproj", StringComparison.OrdinalIgnoreCase)
             || extension.Equals(".fsproj", StringComparison.OrdinalIgnoreCase)
             || extension.Equals(".vbproj", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static void RejectOversizedSolutionFile(string solutionPath)
-    {
-        var length = new FileInfo(LongPath.EnsureWindowsPrefix(solutionPath)).Length;
-        if (length > MaxSolutionFileBytes)
-        {
-            throw new InvalidOperationException(
-                $"solution file is too large: {solutionPath} is {length} bytes; limit is {MaxSolutionFileBytes} bytes.");
-        }
     }
 
     private static bool TryParseSolutionProjectLine(string line, out string name, out string projectPath)

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -4,6 +4,7 @@ using CodeIndex.Indexer;
 using CodeIndex.Models;
 using Microsoft.Data.Sqlite;
 using System.Globalization;
+using System.Runtime.ExceptionServices;
 
 namespace CodeIndex.Database;
 
@@ -111,6 +112,8 @@ public class DbContext : IDisposable
     private static readonly AsyncLocal<Action<SqliteCommand>?> ScopedPlannerStatisticsCommandCreatedForTesting = new();
     private static readonly AsyncLocal<Action<string, string>?> ScopedPlannerStatisticsCommandExecutedForTesting = new();
     private static readonly AsyncLocal<Action<string>?> ScopedWalCheckpointTruncateExecutedForTesting = new();
+    private static readonly AsyncLocal<Action<string>?> ScopedForeignKeysDisabledForTesting = new();
+    private static readonly AsyncLocal<Action<string, long>?> ScopedForeignKeysRestoringForTesting = new();
     private static readonly AsyncLocal<Action<SqliteConnection, string>?> ScopedForeignKeyValidationBeforeCheckForTesting = new();
 
     internal static Action<string>? OptimizePragmaExecutedForTesting
@@ -135,6 +138,18 @@ public class DbContext : IDisposable
     {
         get => ScopedWalCheckpointTruncateExecutedForTesting.Value;
         set => ScopedWalCheckpointTruncateExecutedForTesting.Value = value;
+    }
+
+    internal static Action<string>? ForeignKeysDisabledForTesting
+    {
+        get => ScopedForeignKeysDisabledForTesting.Value;
+        set => ScopedForeignKeysDisabledForTesting.Value = value;
+    }
+
+    internal static Action<string, long>? ForeignKeysRestoringForTesting
+    {
+        get => ScopedForeignKeysRestoringForTesting.Value;
+        set => ScopedForeignKeysRestoringForTesting.Value = value;
     }
 
     internal static Action<SqliteConnection, string>? ForeignKeyValidationBeforeCheckForTesting
@@ -2161,9 +2176,7 @@ public class DbContext : IDisposable
         const string oldSymbolReferences = "_symbol_references_file_line_key";
         var quotedOldReferenceLines = SqliteIdentifier.Quote(oldReferenceLines);
         var quotedOldSymbolReferences = SqliteIdentifier.Quote(oldSymbolReferences);
-        var foreignKeys = ReadPragmaLong("foreign_keys");
-        Execute("PRAGMA foreign_keys=OFF");
-        try
+        RunWithForeignKeysDisabledForMigration("EnsureReferenceLinesContextKey", () =>
         {
             Execute($"DROP TABLE IF EXISTS {quotedOldSymbolReferences}");
             Execute($"DROP TABLE IF EXISTS {quotedOldReferenceLines}");
@@ -2176,11 +2189,7 @@ public class DbContext : IDisposable
             Execute($"DROP TABLE {quotedOldSymbolReferences}");
             Execute($"DROP TABLE {quotedOldReferenceLines}");
             InvokeForeignKeyValidationBeforeCheckForTesting("reference_lines_context_key");
-        }
-        finally
-        {
-            Execute($"PRAGMA foreign_keys={foreignKeys}");
-        }
+        });
 
         ValidateForeignKeysAfterMigration("reference_lines_context_key");
         _schemaCache?.Refresh();
@@ -2267,10 +2276,8 @@ public class DbContext : IDisposable
             """;
         const string symbolReferencesColumns = "id, file_id, symbol_name, reference_kind, line, column_number, context, reference_line_id, container_kind, container_name, symbol_name_folded, container_name_folded, is_self_reference, is_mutual_recursion";
 
-        var foreignKeys = ReadPragmaLong("foreign_keys");
         var rebuilt = false;
-        Execute("PRAGMA foreign_keys=OFF");
-        try
+        RunWithForeignKeysDisabledForMigration("EnsureKindCheckConstraintsCurrent", () =>
         {
             if (!TableCheckContainsAll("symbols", SymbolKindCatalog.SymbolKinds))
             {
@@ -2286,14 +2293,44 @@ public class DbContext : IDisposable
 
             if (rebuilt)
                 InvokeForeignKeyValidationBeforeCheckForTesting("kind_check_constraints");
-        }
-        finally
-        {
-            Execute($"PRAGMA foreign_keys={foreignKeys}");
-        }
+        });
 
         if (rebuilt)
             ValidateForeignKeysAfterMigration("kind_check_constraints");
+    }
+
+    private void RunWithForeignKeysDisabledForMigration(string operation, Action action)
+    {
+        var foreignKeys = ReadPragmaLong("foreign_keys");
+        Execute("PRAGMA foreign_keys=OFF");
+        ExceptionDispatchInfo? operationFailure = null;
+        try
+        {
+            ForeignKeysDisabledForTesting?.Invoke(operation);
+            action();
+        }
+        catch (Exception ex)
+        {
+            operationFailure = ExceptionDispatchInfo.Capture(ex);
+        }
+
+        try
+        {
+            ForeignKeysRestoringForTesting?.Invoke(operation, foreignKeys);
+            Execute($"PRAGMA foreign_keys={foreignKeys}");
+        }
+        catch (Exception ex)
+        {
+            throw new CodeIndexException(
+                code: CommandErrorCodes.DbError,
+                category: CodeIndexExceptionCategory.Database,
+                message: $"Failed to restore PRAGMA foreign_keys after {operation}.",
+                path: _connection.DataSource,
+                hint: "Close other database connections, restore write access if needed, and rerun the command before trusting further migration work.",
+                innerException: ex);
+        }
+
+        operationFailure?.Throw();
     }
 
     private void InvokeForeignKeyValidationBeforeCheckForTesting(string phase)

--- a/src/CodeIndex/Database/DbReader.GraphQueries.cs
+++ b/src/CodeIndex/Database/DbReader.GraphQueries.cs
@@ -1090,6 +1090,9 @@ public partial class DbReader
     // impact --with-paths が 1 caller につき保持する経路数の上限。ダイヤモンド型で多経路が
     // 収束する場合に JSON 膨張を抑える役割があり、超過時は PathsTruncated で通知する。
     private const int DefaultImpactPathsPerResult = 10;
+    internal const int DefaultImpactGraphStateEntryBudget = 10_000;
+    internal const int ImpactBoundaryCallerProbeBudget = 512;
+    private const int ImpactBoundaryCallerProbePageSize = 64;
 
     /// <summary>
     /// Compute transitive callers of a symbol using BFS with exact matching.
@@ -1139,6 +1142,9 @@ public partial class DbReader
         string? truncatedReason = null;
         // Safety cap to prevent infinite loops on pathological graphs / 病的グラフでの無限ループ防止
         const int maxFetchIterations = 1000;
+        var graphStateEntryBudget = GetImpactGraphStateEntryBudget(limit);
+        var graphStateBudgetHit = false;
+        var boundaryProbeBudgetHit = false;
 
         // Path tracking state is allocated only when callers opt in. We collapse parent edges by
         // caller name (rather than path:name) so that diamond chains converging on the same name
@@ -1156,7 +1162,7 @@ public partial class DbReader
             ? new Dictionary<string, List<int>>(StringComparer.OrdinalIgnoreCase)
             : null;
 
-        while (queue.Count > 0 && results.Count < limit)
+        while (queue.Count > 0 && results.Count < limit && !graphStateBudgetHit && !boundaryProbeBudgetHit)
         {
             var (currentSymbol, depth) = queue.Dequeue();
 
@@ -1169,7 +1175,7 @@ public partial class DbReader
             var pageSize = Math.Max(1, needed + 1);
             var fetchIterations = 0;
 
-            while (results.Count < limit && fetchIterations < maxFetchIterations)
+            while (results.Count < limit && fetchIterations < maxFetchIterations && !graphStateBudgetHit && !boundaryProbeBudgetHit)
             {
                 fetchIterations++;
                 var page = GetCallersExact(currentSymbol, pageSize, offset, lang, pathPatterns, excludePathPatterns, excludeTests);
@@ -1199,6 +1205,13 @@ public partial class DbReader
                         cycleParentsByName[callerName] = cycleParentSet;
                     }
                     cycleParentSet.Add(currentSymbol);
+                    if (ImpactGraphStateEntryCount(parentsByName, cycleParentsByName, depthByName, resultIndicesByName) > graphStateEntryBudget)
+                    {
+                        graphStateBudgetHit = true;
+                        truncated = true;
+                        truncatedReason = ImpactTruncatedReasons.GraphStateBudget;
+                        break;
+                    }
 
                     if (!visited.Add(key))
                     {
@@ -1212,6 +1225,13 @@ public partial class DbReader
                             && existingDepth == depth + 1)
                         {
                             parentsByName[callerName].Add(currentSymbol);
+                            if (ImpactGraphStateEntryCount(parentsByName, cycleParentsByName, depthByName, resultIndicesByName) > graphStateEntryBudget)
+                            {
+                                graphStateBudgetHit = true;
+                                truncated = true;
+                                truncatedReason = ImpactTruncatedReasons.GraphStateBudget;
+                                break;
+                            }
                         }
                         continue;
                     }
@@ -1252,6 +1272,13 @@ public partial class DbReader
                         parentsByName[callerName] = parentSet;
                     }
                     parentSet.Add(currentSymbol);
+                    if (ImpactGraphStateEntryCount(parentsByName, cycleParentsByName, depthByName, resultIndicesByName) > graphStateEntryBudget)
+                    {
+                        graphStateBudgetHit = true;
+                        truncated = true;
+                        truncatedReason = ImpactTruncatedReasons.GraphStateBudget;
+                        break;
+                    }
 
                     // Only recurse if the just-added caller (at depth + 1) is strictly below
                     // maxDepth, so that the next BFS step can reach depth + 2 ≤ maxDepth.
@@ -1269,7 +1296,7 @@ public partial class DbReader
                              && caller.CallerName != SyntheticTopLevelCallerName
                              && depth + 1 == maxDepth)
                     {
-                        maxDepthReached |= InspectBoundaryCallers(
+                        var boundaryInspection = InspectBoundaryCallers(
                             caller.CallerName,
                             resolvedName,
                             rootDefinitionPaths,
@@ -1281,6 +1308,14 @@ public partial class DbReader
                             pathPatterns,
                             excludePathPatterns,
                             excludeTests);
+                        maxDepthReached |= boundaryInspection.HasUnvisitedCaller;
+                        if (boundaryInspection.ProbeBudgetHit)
+                        {
+                            boundaryProbeBudgetHit = true;
+                            truncated = true;
+                            truncatedReason = ImpactTruncatedReasons.BoundaryProbeBudget;
+                            break;
+                        }
                     }
                 }
 
@@ -1322,6 +1357,8 @@ public partial class DbReader
 
         var terminationReason = truncatedReason switch
         {
+            ImpactTruncatedReasons.GraphStateBudget => ImpactTerminationReasons.GraphStateBudget,
+            ImpactTruncatedReasons.BoundaryProbeBudget => ImpactTerminationReasons.BoundaryProbeBudget,
             ImpactTruncatedReasons.SafetyCap => ImpactTerminationReasons.SafetyCap,
             ImpactTruncatedReasons.UserLimit => ImpactTerminationReasons.RowLimitTruncated,
             _ when cycles.Count > 0 => ImpactTerminationReasons.CycleDetected,
@@ -1332,7 +1369,32 @@ public partial class DbReader
         return (results, truncated, truncatedReason, terminationReason, cycles);
     }
 
-    private bool InspectBoundaryCallers(
+    private static int GetImpactGraphStateEntryBudget(int limit)
+    {
+        var limitScaled = Math.Max(1, limit) * 200;
+        return Math.Max(1024, Math.Min(DefaultImpactGraphStateEntryBudget, limitScaled));
+    }
+
+    private static int ImpactGraphStateEntryCount(
+        Dictionary<string, HashSet<string>> parentsByName,
+        Dictionary<string, HashSet<string>> cycleParentsByName,
+        Dictionary<string, int> depthByName,
+        Dictionary<string, List<int>>? resultIndicesByName)
+    {
+        var count = depthByName.Count + parentsByName.Count + cycleParentsByName.Count + (resultIndicesByName?.Count ?? 0);
+        foreach (var parents in parentsByName.Values)
+            count += parents.Count;
+        foreach (var parents in cycleParentsByName.Values)
+            count += parents.Count;
+        if (resultIndicesByName != null)
+            foreach (var indices in resultIndicesByName.Values)
+                count += indices.Count;
+        return count;
+    }
+
+    private readonly record struct ImpactBoundaryInspection(bool HasUnvisitedCaller, bool ProbeBudgetHit);
+
+    private ImpactBoundaryInspection InspectBoundaryCallers(
         string symbolName,
         string resolvedName,
         HashSet<string> rootDefinitionPaths,
@@ -1345,13 +1407,18 @@ public partial class DbReader
         IReadOnlyList<string>? excludePathPatterns,
         bool excludeTests)
     {
-        const int pageSize = 1;
         var offset = 0;
+        var probes = 0;
         while (true)
         {
+            if (probes >= ImpactBoundaryCallerProbeBudget)
+                return new ImpactBoundaryInspection(HasUnvisitedCaller: true, ProbeBudgetHit: true);
+
+            var pageSize = Math.Min(ImpactBoundaryCallerProbePageSize, ImpactBoundaryCallerProbeBudget - probes);
             var page = GetCallersExact(symbolName, pageSize, offset, lang, pathPatterns, excludePathPatterns, excludeTests);
             if (page.Count == 0)
-                return false;
+                return new ImpactBoundaryInspection(HasUnvisitedCaller: false, ProbeBudgetHit: false);
+            probes += page.Count;
 
             foreach (var caller in page)
             {
@@ -1372,11 +1439,11 @@ public partial class DbReader
 
                 var key = BuildImpactVisitedKey(caller, callerName);
                 if (!visited.Contains(key))
-                    return true;
+                    return new ImpactBoundaryInspection(HasUnvisitedCaller: true, ProbeBudgetHit: false);
             }
 
             if (page.Count < pageSize)
-                return false;
+                return new ImpactBoundaryInspection(HasUnvisitedCaller: false, ProbeBudgetHit: false);
             offset += page.Count;
         }
     }

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -1292,8 +1292,12 @@ public partial class DbReader : IDisposable
         return input.Replace("\\", "\\\\").Replace("%", "\\%").Replace("_", "\\_");
     }
 
+    internal const int MaxPathLikePatternLength = 1024;
+    internal const int MaxPathLikePatternWildcards = 128;
+
     internal static string BuildPathLikePattern(string input)
     {
+        ValidatePathLikePattern(input);
         var hasWildcard = false;
         var builder = new StringBuilder(input.Length + 2);
         var escaped = false;
@@ -1344,6 +1348,37 @@ public partial class DbReader : IDisposable
 
         var pattern = builder.ToString();
         return hasWildcard ? pattern : $"%{pattern}%";
+    }
+
+    private static void ValidatePathLikePattern(string input)
+    {
+        if (input.Length > MaxPathLikePatternLength)
+            throw new SearchQueryLimitException(
+                $"path pattern is too long ({input.Length} characters); maximum is {MaxPathLikePatternLength}. Split path filters or narrow the query.");
+
+        var wildcardCount = 0;
+        var escaped = false;
+        foreach (var ch in input)
+        {
+            if (escaped)
+            {
+                escaped = false;
+                continue;
+            }
+
+            if (ch == '\\')
+            {
+                escaped = true;
+                continue;
+            }
+
+            if (ch is '*' or '?')
+                wildcardCount++;
+        }
+
+        if (wildcardCount > MaxPathLikePatternWildcards)
+            throw new SearchQueryLimitException(
+                $"path pattern has too many wildcards ({wildcardCount}); maximum is {MaxPathLikePatternWildcards}. Split path filters or use a narrower path prefix.");
     }
 
     private static void AppendLikeLiteral(StringBuilder builder, char ch)

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -13,11 +13,14 @@ public partial class DbReader
     internal const string AllTokensFilteredByLengthReason = "all_tokens_filtered_by_length";
     internal const int MaxLiteralSearchQueryLength = 1000;
     internal const int MaxLiteralSearchTokenCount = 128;
+    internal const int MaxLiteralSearchTokenLength = 1000;
     internal const int MaxRawFtsQueryLength = 2000;
     internal const int MaxRawFtsBooleanOperators = 64;
     internal const int MaxRawFtsNearOperators = 16;
     internal const int MaxRawFtsParenthesisDepth = 16;
     internal const int MaxRawFtsNearDistance = 100;
+    internal const int MaxRawFtsColumnListCount = 16;
+    internal const int MaxRawFtsColumnTokenLength = 64;
     internal const int DefaultSearchGuardWindow = 8;
     internal const int MaxSearchGuardWindow = 200;
     internal const int MaxSearchGuardFilters = 8;
@@ -1047,7 +1050,9 @@ public partial class DbReader
                 var start = i;
                 while (i < query.Length && !char.IsWhiteSpace(query[i]))
                     i++;
-                tokens.Add(query[start..i]);
+                var token = query[start..i];
+                ValidateLiteralSearchTokenLength(token);
+                tokens.Add(token);
             }
             else
             {
@@ -1069,10 +1074,15 @@ public partial class DbReader
                     }
 
                     phrase.Append(query[i]);
+                    if (phrase.Length > MaxLiteralSearchTokenLength)
+                        throw new SearchQueryLimitException(
+                            $"literal search phrase is too long ({phrase.Length} characters); maximum is {MaxLiteralSearchTokenLength}. Split generated input into smaller queries.");
                     i++;
                 }
 
-                tokens.Add(phrase.Length == 0 ? "\"" : phrase.ToString());
+                var token = phrase.Length == 0 ? "\"" : phrase.ToString();
+                ValidateLiteralSearchTokenLength(token);
+                tokens.Add(token);
             }
 
             if (tokens.Count > MaxLiteralSearchTokenCount)
@@ -1081,6 +1091,15 @@ public partial class DbReader
         }
 
         return tokens.ToArray();
+    }
+
+    private static void ValidateLiteralSearchTokenLength(string token)
+    {
+        if (token.Length <= MaxLiteralSearchTokenLength)
+            return;
+
+        throw new SearchQueryLimitException(
+            $"literal search token is too long ({token.Length} characters); maximum is {MaxLiteralSearchTokenLength}. Split generated input into smaller queries.");
     }
 
     internal static string ValidateRawFtsQuery(string query)
@@ -1221,6 +1240,9 @@ public partial class DbReader
 
         var columns = query[(start + 1)..(colonIndex - 1)]
             .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
+        if (columns.Length > MaxRawFtsColumnListCount)
+            throw new FtsQuerySyntaxException(
+                $"raw FTS5 column list has too many columns ({columns.Length}); maximum is {MaxRawFtsColumnListCount}. The fts_chunks index only exposes the 'content' column.");
         foreach (var column in columns)
             ValidateRawFtsColumn(column);
     }
@@ -1228,6 +1250,9 @@ public partial class DbReader
     private static void ValidateRawFtsColumn(string column)
     {
         const string validColumn = "content";
+        if (column.Length > MaxRawFtsColumnTokenLength)
+            throw new FtsQuerySyntaxException(
+                $"raw FTS5 column qualifier is too long ({column.Length} characters); maximum is {MaxRawFtsColumnTokenLength}. The fts_chunks index only exposes the '{validColumn}' column.");
         if (string.Equals(column, validColumn, StringComparison.OrdinalIgnoreCase))
             return;
 

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -67,7 +67,7 @@ public partial class DbReader
             return FtsQueryDiagnostics.None;
 
         var normalizedQuery = NormalizeLiteralSearchQuery(query, NormalizeQueryLanguage(lang));
-        var tokens = SplitLiteralSearchTokens(normalizedQuery)
+        var tokens = SplitLiteralSearchTokens(normalizedQuery, validateLimits: false)
             .Select(token => token.Length > 1 && token.EndsWith('*') ? token[..^1] : token)
             .Where(token => token.Length > 0)
             .ToArray();
@@ -1146,7 +1146,7 @@ public partial class DbReader
             $"literal search query is too long ({query.Length} characters); maximum is {MaxLiteralSearchQueryLength}. Split generated input into smaller queries.");
     }
 
-    internal static string[] SplitLiteralSearchTokens(string query)
+    internal static string[] SplitLiteralSearchTokens(string query, bool validateLimits = true)
     {
         var tokens = new List<string>();
         for (var i = 0; i < query.Length;)
@@ -1162,7 +1162,8 @@ public partial class DbReader
                 while (i < query.Length && !char.IsWhiteSpace(query[i]))
                     i++;
                 var token = query[start..i];
-                ValidateLiteralSearchTokenLength(token);
+                if (validateLimits)
+                    ValidateLiteralSearchTokenLength(token);
                 tokens.Add(token);
             }
             else
@@ -1185,18 +1186,19 @@ public partial class DbReader
                     }
 
                     phrase.Append(query[i]);
-                    if (phrase.Length > MaxLiteralSearchTokenLength)
+                    if (validateLimits && phrase.Length > MaxLiteralSearchTokenLength)
                         throw new SearchQueryLimitException(
                             $"literal search phrase is too long ({phrase.Length} characters); maximum is {MaxLiteralSearchTokenLength}. Split generated input into smaller queries.");
                     i++;
                 }
 
                 var token = phrase.Length == 0 ? "\"" : phrase.ToString();
-                ValidateLiteralSearchTokenLength(token);
+                if (validateLimits)
+                    ValidateLiteralSearchTokenLength(token);
                 tokens.Add(token);
             }
 
-            if (tokens.Count > MaxLiteralSearchTokenCount)
+            if (validateLimits && tokens.Count > MaxLiteralSearchTokenCount)
                 throw new SearchQueryLimitException(
                     $"literal search query has too many terms ({tokens.Count}); maximum is {MaxLiteralSearchTokenCount}. Split generated input into smaller queries.");
         }

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -545,6 +545,117 @@ public partial class DbReader
         return new QueryCountResult(count, keptFiles.Count);
     }
 
+    public List<SearchFileCountResult> CountSearchResultsByFile(string query, string? lang = null, bool rawQuery = false, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, bool deduplicate = true, DateTime? since = null, bool exact = false, bool prefix = false, bool visibilityRank = true, IReadOnlyList<SearchGuardFilter>? guardFilters = null, int guardWindow = DefaultSearchGuardWindow, SearchGuardScope guardScope = SearchGuardScope.Window)
+    {
+        if (string.IsNullOrWhiteSpace(query))
+            return [];
+
+        if (guardFilters is { Count: > 0 })
+        {
+            var guardedResults = Search(query, int.MaxValue, lang, rawQuery, pathPatterns, excludePathPatterns, excludeTests, deduplicate, since, exact, prefix, visibilityRank, guardFilters: guardFilters, guardWindow: guardWindow, guardScope: guardScope);
+            return guardedResults
+                .GroupBy(result => result.Path, StringComparer.Ordinal)
+                .Select(group => new SearchFileCountResult(group.Key, group.Count()))
+                .OrderByDescending(group => group.Count)
+                .ThenBy(group => group.Path, StringComparer.Ordinal)
+                .ToList();
+        }
+
+        if (!rawQuery)
+            ValidateLiteralSearchQueryLength(query);
+
+        lang = NormalizeQueryLanguage(lang);
+        var normalizedQuery = rawQuery ? query : NormalizeLiteralSearchQuery(query, lang);
+        var coverageTokens = exact ? new List<string>() : GetSearchCoverageTokens(normalizedQuery, rawQuery);
+        using var cmd = _conn.CreateCommand();
+        string sql;
+
+        if (exact)
+        {
+            sql = $@"
+                SELECT f.path, f.lang, c.start_line, c.end_line, c.content,
+                       0.0 AS rank
+                FROM chunks c
+                JOIN files f ON c.file_id = f.id{SearchSymbolMatchJoinsSql}
+                WHERE instr(
+                    {GetExactSearchTextSql("c.content", "f.lang")},
+                    {GetExactSearchTextSql("@exactQuery", "f.lang")}
+                ) > 0";
+        }
+        else
+        {
+            var sanitizedQuery = rawQuery ? ValidateRawFtsQuery(query) : SanitizeFtsQuery(normalizedQuery, prefix);
+            if (rawQuery)
+                ValidateRawFtsNearDistance(sanitizedQuery);
+            sql = $@"
+                SELECT f.path, f.lang, c.start_line, c.end_line, c.content,
+                       rank
+                FROM fts_chunks
+                JOIN chunks c ON fts_chunks.rowid = c.id
+                JOIN files f ON c.file_id = f.id{SearchSymbolMatchJoinsSql}";
+            sql += " WHERE fts_chunks MATCH @query";
+            cmd.Parameters.AddWithValue("@query", sanitizedQuery);
+        }
+        if (lang != null)
+            sql += " AND f.lang = @lang";
+        if (since != null && _fileColumns.Contains("modified"))
+            sql += " AND f.modified >= @since";
+
+        AppendPathFilters(ref sql, pathPatterns, excludePathPatterns, excludeTests);
+        sql += $" ORDER BY {GetSearchOrderSql(coverageTokens.Count, exactLiteralBoost: false)}";
+
+        cmd.CommandText = sql;
+        if (exact)
+            cmd.Parameters.AddWithValue("@exactQuery", query);
+        cmd.Parameters.AddWithValue("@rankingQuery", normalizedQuery.Trim());
+        cmd.Parameters.AddWithValue("@rankingQueryPrefix", $"{EscapeLikeQuery(normalizedQuery.Trim())}%");
+        cmd.Parameters.AddWithValue("@visibilityRank", visibilityRank ? 1 : 0);
+        AddSearchCoverageParameters(cmd, coverageTokens);
+        if (lang != null)
+            cmd.Parameters.AddWithValue("@lang", lang);
+        if (since != null && _fileColumns.Contains("modified"))
+            cmd.Parameters.AddWithValue("@since", since.Value);
+        AddPathFilterParameters(cmd, pathPatterns, excludePathPatterns);
+
+        var keptMatchLines = new Dictionary<string, HashSet<int>>(StringComparer.Ordinal);
+        var keptIntervals = new Dictionary<string, IntervalSet>(StringComparer.Ordinal);
+        var matchContext = deduplicate ? SearchPrimaryMatchContext.Create(query, normalizedQuery, rawQuery, exact, lang) : null;
+        var countsByPath = new Dictionary<string, int>(StringComparer.Ordinal);
+        try
+        {
+            using var reader = cmd.ExecuteTrackedReader();
+            while (reader.TrackedRead())
+            {
+                var path = reader.GetString(0);
+                if (deduplicate)
+                {
+                    var result = new SearchResult
+                    {
+                        Path = path,
+                        Lang = GetNullableString(reader, 1),
+                        StartLine = reader.GetInt32(2),
+                        EndLine = reader.GetInt32(3),
+                        Content = reader.GetString(4),
+                    };
+                    if (!AddSearchResultDedupCoverage(result, matchContext!, keptMatchLines, keptIntervals))
+                        continue;
+                }
+
+                countsByPath[path] = countsByPath.TryGetValue(path, out var count) ? count + 1 : 1;
+            }
+        }
+        catch (SqliteException ex) when (rawQuery && IsFtsQuerySyntaxError(ex))
+        {
+            throw new FtsQuerySyntaxException(ex.Message, ex);
+        }
+
+        return countsByPath
+            .Select(kv => new SearchFileCountResult(kv.Key, kv.Value))
+            .OrderByDescending(group => group.Count)
+            .ThenBy(group => group.Path, StringComparer.Ordinal)
+            .ToList();
+    }
+
     private List<SearchResult> FilterBySearchGuards(
         List<SearchResult> results,
         SearchPrimaryMatchContext primaryMatchContext,

--- a/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
+++ b/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
@@ -121,6 +121,8 @@ internal sealed class PostExtractionHookCallbackWorkerClient : IDisposable
             }
 
             stopwatch.Stop();
+            // WaitForTask already proved the async read completed within the callback budget;
+            // GetResult only observes that completed protocol response on this sync API.
             var responseJson = responseTask.GetAwaiter().GetResult();
             if (responseJson == null)
             {

--- a/src/CodeIndex/Indexer/Scanning/CaseSensitivityProbeDirectory.cs
+++ b/src/CodeIndex/Indexer/Scanning/CaseSensitivityProbeDirectory.cs
@@ -11,6 +11,7 @@ internal static class CaseSensitivityProbeDirectory
         UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
 
     internal static Action<string>? DeleteCreatedEmptyDirectoryForTesting { get; set; }
+    internal static Action<CaseSensitivityProbeCleanupDiagnostic>? CleanupDiagnosticSinkForTesting { get; set; }
 
     internal static ProbePathScope CreateProbePathScope(string projectRoot, string prefix)
     {
@@ -44,6 +45,7 @@ internal static class CaseSensitivityProbeDirectory
         private readonly string _dataDirectory;
         private readonly bool _createdProbeDirectory;
         private readonly bool _createdDataDirectory;
+        private readonly List<CaseSensitivityProbeCleanupDiagnostic> _cleanupDiagnostics = [];
         private bool _disposed;
 
         internal ProbePathScope(
@@ -64,6 +66,7 @@ internal static class CaseSensitivityProbeDirectory
 
         internal string ProjectRoot { get; }
         internal string Path { get; }
+        internal IReadOnlyList<CaseSensitivityProbeCleanupDiagnostic> CleanupDiagnostics => _cleanupDiagnostics;
 
         public void Dispose()
         {
@@ -92,13 +95,47 @@ internal static class CaseSensitivityProbeDirectory
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                throw new CaseSensitivityProbeException(
-                    "Failed to clean up filesystem case-sensitivity probe directory.",
-                    ProjectRoot,
-                    ex,
-                    cleanupPath: path);
+                RecordCleanupDiagnostic(path, ex);
             }
         }
+
+        private void RecordCleanupDiagnostic(string path, Exception ex)
+        {
+            var diagnostic = new CaseSensitivityProbeCleanupDiagnostic(
+                RelativePath: FormatCleanupRelativePath(path),
+                ExceptionType: ex.GetType().Name,
+                Message: "Failed to clean up filesystem case-sensitivity probe directory.");
+            _cleanupDiagnostics.Add(diagnostic);
+
+            if (CleanupDiagnosticSinkForTesting is { } sink)
+            {
+                sink(diagnostic);
+                return;
+            }
+
+            Console.Error.WriteLine(
+                $"Warning: {diagnostic.Message} path={diagnostic.RelativePath} exception={diagnostic.ExceptionType}. " +
+                $"Remove stale {DataDirectoryName}/{ProbeDirectoryName} entries when no cdidx process is running.");
+        }
+
+        private string FormatCleanupRelativePath(string path)
+        {
+            try
+            {
+                var relative = System.IO.Path.GetRelativePath(ProjectRoot, path);
+                if (!relative.StartsWith("..", StringComparison.Ordinal) && !System.IO.Path.IsPathRooted(relative))
+                    return NormalizeRelativePath(relative);
+            }
+            catch
+            {
+            }
+
+            return DataDirectoryName + "/" + ProbeDirectoryName;
+        }
+
+        private static string NormalizeRelativePath(string path)
+            => path.Replace(System.IO.Path.DirectorySeparatorChar, '/')
+                .Replace(System.IO.Path.AltDirectorySeparatorChar, '/');
     }
 
     internal readonly record struct ProbeDirectoryScope(
@@ -122,3 +159,8 @@ internal static class CaseSensitivityProbeDirectory
     }
 
 }
+
+internal readonly record struct CaseSensitivityProbeCleanupDiagnostic(
+    string RelativePath,
+    string ExceptionType,
+    string Message);

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -112,6 +112,8 @@ public class FileIndexer
     private const int GitLfsPointerMaxBytes = 1024;
     private const int MaxGitmodulesBytes = 256 * 1024;
     private const int MaxGitmodulesLines = 4096;
+    private const int MaxGitmodulesLineChars = 16 * 1024;
+    internal const int MaxGitmodulesSubmodulePaths = 1024;
     private const int MaxProjectMarkerTraversalWarnings = 32;
     private static readonly string[] IgnoreFileNames = [".gitignore", ".cdidxignore"];
     private const int MaxIgnoreFileBytes = 256 * 1024;
@@ -3072,8 +3074,21 @@ public class FileIndexer
                     MaxIgnoreFileBytes,
                     MaxIgnoreFileLines,
                     out var lines,
-                    out var skippedReason))
+                    out var skippedReason,
+                    out var readFailure))
             {
+                if (readFailure.ExceptionType is nameof(FileNotFoundException) or nameof(DirectoryNotFoundException))
+                    return true;
+
+                if (readFailure.ExceptionType == nameof(UnauthorizedAccessException))
+                {
+                    if (!File.Exists(prefixedIgnorePath))
+                        throw new UnauthorizedAccessException(readFailure.Reason);
+
+                    errors.Add(new ScanError(ToRelativePath(ignorePath), $"Could not read {ignoreFileName} due to permissions.", ScanIssueSeverity.Warning));
+                    return true;
+                }
+
                 errors.Add(new ScanError(
                     ToRelativePath(ignorePath),
                     $"Could not safely read {ignoreFileName} because {skippedReason}."));
@@ -3226,7 +3241,8 @@ public class FileIndexer
                         MaxGitmodulesBytes,
                         MaxGitmodulesLines,
                         out lines,
-                        out var skippedReason))
+                        out var skippedReason,
+                        out _))
                 {
                     warnings.Add(new ScanError(
                         NormalizeIgnorePath(Path.GetRelativePath(projectRoot, gitmodulesPath)),
@@ -3236,6 +3252,7 @@ public class FileIndexer
                 }
             }
 
+            var submodulePathCount = 0;
             foreach (var rawSubmodulePath in ParseSubmodulePathsFromGitmodules(lines))
             {
                 string absolute;
@@ -3256,10 +3273,22 @@ public class FileIndexer
                     continue;
                 }
 
-                submodulePaths.Add(relativeToProject);
-                var segments = relativeToProject.Split('/', StringSplitOptions.RemoveEmptyEntries);
-                for (var i = 1; i < segments.Length; i++)
-                    ancestorPaths.Add(string.Join('/', segments, 0, i));
+                if (submodulePathCount >= MaxGitmodulesSubmodulePaths)
+                {
+                    warnings.Add(new ScanError(
+                        NormalizeIgnorePath(Path.GetRelativePath(projectRoot, gitmodulesPath)),
+                        $"Stopped parsing .gitmodules submodule paths after {MaxGitmodulesSubmodulePaths} entries.",
+                        ScanIssueSeverity.Warning));
+                    break;
+                }
+
+                submodulePathCount++;
+                if (submodulePaths.Add(relativeToProject))
+                {
+                    var segments = relativeToProject.Split('/', StringSplitOptions.RemoveEmptyEntries);
+                    for (var i = 1; i < segments.Length; i++)
+                        ancestorPaths.Add(string.Join('/', segments, 0, i));
+                }
             }
         }
         catch (IOException ex)
@@ -3291,61 +3320,18 @@ public class FileIndexer
         int maxBytes,
         int maxLines,
         out IReadOnlyList<string> lines,
-        out string skippedReason)
+        out string skippedReason,
+        out BoundedTextFileReadFailure failure)
     {
-        lines = [];
-        skippedReason = string.Empty;
-
-        using var stream = new FileStream(
+        var success = BoundedLineReader.TryReadUtf8File(
             path,
-            FileMode.Open,
-            FileAccess.Read,
-            FileShare.ReadWrite | FileShare.Delete,
-            bufferSize: 8192,
-            useAsync: false);
-
-        if (stream.Length > maxBytes)
-        {
-            skippedReason = $"it exceeds {maxBytes} bytes";
-            return false;
-        }
-
-        using var accumulator = new MemoryStream((int)Math.Min(stream.Length, maxBytes));
-        var buffer = new byte[8192];
-        long total = 0;
-        int read;
-        while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
-        {
-            total += read;
-            if (total > maxBytes)
-            {
-                skippedReason = $"it exceeds {maxBytes} bytes";
-                return false;
-            }
-
-            accumulator.Write(buffer, 0, read);
-        }
-
-        var text = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(accumulator.ToArray());
-        var result = new List<string>();
-        using var reader = new StringReader(text);
-        string? line;
-        while ((line = reader.ReadLine()) != null)
-        {
-            if (result.Count == 0 && line.Length > 0 && line[0] == '\uFEFF')
-                line = line[1..];
-
-            if (result.Count >= maxLines)
-            {
-                skippedReason = $"it exceeds {maxLines} lines";
-                return false;
-            }
-
-            result.Add(line);
-        }
-
-        lines = result;
-        return true;
+            maxBytes,
+            maxLines,
+            MaxGitmodulesLineChars,
+            out lines,
+            out failure);
+        skippedReason = success ? string.Empty : failure.Reason;
+        return success;
     }
 
     // Tolerant .gitmodules reader: yields each declared submodule's "path = ..." value.
@@ -3392,10 +3378,7 @@ public class FileIndexer
             if (!string.Equals(key, "path", StringComparison.OrdinalIgnoreCase))
                 continue;
 
-            var value = line[(equalsIndex + 1)..].Trim();
-            var commentIndex = value.IndexOfAny(['#', ';']);
-            if (commentIndex >= 0)
-                value = value[..commentIndex].Trim();
+            var value = StripGitmodulesInlineComment(line[(equalsIndex + 1)..]);
             if (value.Length >= 2 && value[0] == '"' && value[^1] == '"')
                 value = value[1..^1];
             if (value.Length == 0)
@@ -3405,6 +3388,38 @@ public class FileIndexer
 
             yield return value;
         }
+    }
+
+    private static string StripGitmodulesInlineComment(string value)
+    {
+        var inQuotes = false;
+        var escaping = false;
+        for (var i = 0; i < value.Length; i++)
+        {
+            var ch = value[i];
+            if (escaping)
+            {
+                escaping = false;
+                continue;
+            }
+
+            if (inQuotes && ch == '\\')
+            {
+                escaping = true;
+                continue;
+            }
+
+            if (ch == '"')
+            {
+                inQuotes = !inQuotes;
+                continue;
+            }
+
+            if (!inQuotes && ch is '#' or ';')
+                return value[..i].Trim();
+        }
+
+        return value.Trim();
     }
 
     internal static string NormalizeIgnorePath(string path)

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -1981,19 +1981,13 @@ public class FileIndexer
                     pendingDirectories.Push(new ProjectMarkerFingerprintDirectory(subDir, activeIgnoreRules, IsProjectRoot: false));
                 }
             }
-            catch (UnauthorizedAccessException)
+            catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
             {
-                AddProjectMarkerTraversalWarning(errors, currentDirectory, nameof(UnauthorizedAccessException));
+                var exceptionType = FileSystemTraversalFailure.ExceptionTypeName(ex);
+                AddProjectMarkerTraversalWarning(errors, currentDirectory, exceptionType);
                 MarkProjectMarkerTraversalTruncated(
                     traversalState,
-                    $"traversal failed with {nameof(UnauthorizedAccessException)}");
-            }
-            catch (IOException)
-            {
-                AddProjectMarkerTraversalWarning(errors, currentDirectory, nameof(IOException));
-                MarkProjectMarkerTraversalTruncated(
-                    traversalState,
-                    $"traversal failed with {nameof(IOException)}");
+                    $"traversal failed with {exceptionType}");
             }
         }
     }
@@ -2446,16 +2440,11 @@ public class FileIndexer
             RecordDanglingFileSystemEntries(dir, scanState, cancellationToken);
             fullyScanned &= EnumerateSubdirectories(dir, scanState, activeIgnoreRules, passthrough, continueOnError, cancellationToken, depth);
         }
-        catch (UnauthorizedAccessException)
+        catch (Exception ex) when (FileSystemTraversalFailure.IsExpected(ex))
         {
-            // Skip inaccessible directories / アクセス不可ディレクトリはスキップ
-            scanState.Errors.Add(new ScanError(ToRelativePath(dir), "Could not scan directory due to permissions."));
-            fullyScanned = false;
-        }
-        catch (IOException)
-        {
-            // Skip on I/O errors / I/Oエラー時はスキップ
-            scanState.Errors.Add(new ScanError(ToRelativePath(dir), "Could not scan directory due to an I/O error."));
+            scanState.Errors.Add(new ScanError(
+                ToRelativePath(dir),
+                $"Could not scan directory due to {FileSystemTraversalFailure.DescribeReason(ex)}."));
             fullyScanned = false;
         }
 

--- a/src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
+++ b/src/CodeIndex/Indexer/Scanning/LanguageMapOverrides.cs
@@ -1,5 +1,5 @@
-using System.Text;
 using CodeIndex.Cli;
+using CodeIndex.Diagnostics;
 
 namespace CodeIndex.Indexer;
 
@@ -8,6 +8,7 @@ internal static class LanguageMapOverrides
     internal const string WorkspaceFileName = ".cdidx-langmap.yaml";
     private const int MaxOverrideFileBytes = 128 * 1024;
     private const int MaxOverrideFileLines = 16384;
+    private const int MaxOverrideLineChars = 16 * 1024;
     private const int MaxOverrideEntries = 4096;
     private static readonly object WarningLock = new();
     private static readonly HashSet<string> ReportedWarnings = new(StringComparer.Ordinal);
@@ -20,11 +21,13 @@ internal static class LanguageMapOverrides
     internal static IReadOnlyDictionary<string, string> LoadEffectiveMapFromPathsForTesting(
         IEnumerable<string> configPaths,
         Action<string>? reportWarning = null)
-        => LoadEffectiveMapFromPaths(configPaths, reportWarning);
+        => LoadEffectiveMapFromPaths(
+            configPaths,
+            reportWarning == null ? null : (message, _) => reportWarning(message));
 
     private static IReadOnlyDictionary<string, string> LoadEffectiveMapFromPaths(
         IEnumerable<string> configPaths,
-        Action<string>? reportWarning)
+        Action<string, string?>? reportWarning)
     {
         var map = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var path in configPaths)
@@ -66,14 +69,16 @@ internal static class LanguageMapOverrides
     private static void LoadInto(
         string path,
         Dictionary<string, string> target,
-        Action<string>? reportWarning)
+        Action<string, string?>? reportWarning)
     {
         if (!File.Exists(path))
             return;
 
         if (!TryReadBoundedUtf8Lines(path, out var lines, out var skippedReason))
         {
-            reportWarning?.Invoke($"Skipped language-map override file {path} because {skippedReason}.");
+            reportWarning?.Invoke(
+                $"Skipped language-map override file {DiagnosticSanitizer.ForPath(path)} because {DiagnosticSanitizer.ForMessage(skippedReason)}.",
+                $"{path}\n{skippedReason}");
             return;
         }
 
@@ -95,7 +100,9 @@ internal static class LanguageMapOverrides
             {
                 if (entryCount >= MaxOverrideEntries)
                 {
-                    reportWarning?.Invoke($"Ignored remaining language-map override entries in {path} because the loaded entry count exceeds {MaxOverrideEntries}.");
+                    reportWarning?.Invoke(
+                        $"Ignored remaining language-map override entries in {DiagnosticSanitizer.ForPath(path)} because the loaded entry count exceeds {MaxOverrideEntries}.",
+                        $"{path}\nentry-count");
                     return;
                 }
 
@@ -108,83 +115,23 @@ internal static class LanguageMapOverrides
 
     private static bool TryReadBoundedUtf8Lines(string path, out IReadOnlyList<string> lines, out string skippedReason)
     {
-        lines = [];
-        skippedReason = string.Empty;
-
-        try
-        {
-            using var stream = OpenOverrideFileForTesting?.Invoke(path)
-                ?? new FileStream(
-                    path,
-                    FileMode.Open,
-                    FileAccess.Read,
-                    FileShare.ReadWrite | FileShare.Delete,
-                    bufferSize: 8192,
-                    useAsync: false);
-
-            if (stream.Length > MaxOverrideFileBytes)
-            {
-                skippedReason = $"it exceeds {MaxOverrideFileBytes} bytes";
-                return false;
-            }
-
-            using var accumulator = new MemoryStream((int)Math.Min(stream.Length, MaxOverrideFileBytes));
-            var buffer = new byte[8192];
-            long total = 0;
-            int read;
-            while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
-            {
-                total += read;
-                if (total > MaxOverrideFileBytes)
-                {
-                    skippedReason = $"it exceeds {MaxOverrideFileBytes} bytes";
-                    return false;
-                }
-
-                accumulator.Write(buffer, 0, read);
-            }
-
-            var text = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(accumulator.ToArray());
-            if (text.Length > 0 && text[0] == '\uFEFF')
-                text = text[1..];
-
-            var result = new List<string>();
-            using var reader = new StringReader(text);
-            string? line;
-            while ((line = reader.ReadLine()) != null)
-            {
-                if (result.Count >= MaxOverrideFileLines)
-                {
-                    skippedReason = $"it exceeds {MaxOverrideFileLines} lines";
-                    return false;
-                }
-
-                result.Add(line);
-            }
-
-            lines = result;
-            return true;
-        }
-        catch (IOException ex)
-        {
-            skippedReason = $"it could not be read ({ex.GetType().Name}: {CollapseLineBreaks(ex.Message)})";
-            return false;
-        }
-        catch (UnauthorizedAccessException ex)
-        {
-            skippedReason = $"it could not be read ({ex.GetType().Name}: {CollapseLineBreaks(ex.Message)})";
-            return false;
-        }
+        var success = BoundedLineReader.TryReadUtf8File(
+            path,
+            MaxOverrideFileBytes,
+            MaxOverrideFileLines,
+            MaxOverrideLineChars,
+            out lines,
+            out var failure,
+            OpenOverrideFileForTesting);
+        skippedReason = success ? string.Empty : failure.Reason;
+        return success;
     }
 
-    private static string CollapseLineBreaks(string value)
-        => value.Replace('\r', ' ').Replace('\n', ' ');
-
-    private static void ReportWarningOnce(string message)
+    private static void ReportWarningOnce(string message, string? dedupeKey)
     {
         lock (WarningLock)
         {
-            if (!ReportedWarnings.Add(message))
+            if (!ReportedWarnings.Add(dedupeKey ?? message))
                 return;
         }
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
@@ -106,6 +106,8 @@ internal sealed class SymbolExtractionWorkerClient : IDisposable
             }
 
             stopwatch.Stop();
+            // WaitForTask already proved the async read completed within the worker budget;
+            // GetResult only observes that completed protocol response on this sync API.
             var responseJson = responseTask.GetAwaiter().GetResult();
             if (responseJson == null)
             {

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.TypeScriptPathAliases.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.TypeScriptPathAliases.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using CodeIndex.Cli;
+using CodeIndex.Diagnostics;
 
 namespace CodeIndex.Indexer;
 
@@ -56,8 +57,9 @@ public static partial class SymbolExtractor
 
         if (moduleName.Length > MaxTypeScriptPathAliasModuleSpecifierLength)
         {
-            ReportTypeScriptPathAliasWarningOnce(
-                $"Skipped TypeScript path alias resolution in config {config.ConfigPath} for module specifiers longer than {MaxTypeScriptPathAliasModuleSpecifierLength} characters.");
+            ReportTypeScriptPathAliasConfigWarningOnce(
+                config.ConfigPath,
+                $"Skipped TypeScript path alias resolution in config {DiagnosticSanitizer.ForPath(config.ConfigPath)} for module specifiers longer than {MaxTypeScriptPathAliasModuleSpecifierLength} characters.");
             return moduleName;
         }
 
@@ -70,8 +72,9 @@ public static partial class SymbolExtractor
             {
                 if (!TrySubstituteTypeScriptPathAliasTarget(target, wildcard, out var substituted))
                 {
-                    ReportTypeScriptPathAliasWarningOnce(
-                        $"Skipped TypeScript path alias target substitution in config {config.ConfigPath} longer than {MaxTypeScriptPathAliasSubstitutedTargetLength} characters.");
+                    ReportTypeScriptPathAliasConfigWarningOnce(
+                        config.ConfigPath,
+                        $"Skipped TypeScript path alias target substitution in config {DiagnosticSanitizer.ForPath(config.ConfigPath)} longer than {MaxTypeScriptPathAliasSubstitutedTargetLength} characters.");
                     continue;
                 }
 
@@ -136,11 +139,10 @@ public static partial class SymbolExtractor
 
         if (depth > MaxTypeScriptPathAliasExtendsDepth)
         {
-            ReportTypeScriptPathAliasWarningOnce(
-                FormatTypeScriptPathAliasConfigSkippedMessage(
-                    configPath,
-                    TypeScriptPathAliasDiagnosticDepthLimit,
-                    $"the extends depth exceeds {MaxTypeScriptPathAliasExtendsDepth}"));
+            ReportTypeScriptPathAliasConfigSkippedWarning(
+                configPath,
+                TypeScriptPathAliasDiagnosticDepthLimit,
+                $"the extends depth exceeds {MaxTypeScriptPathAliasExtendsDepth}");
             return null;
         }
 
@@ -153,8 +155,7 @@ public static partial class SymbolExtractor
                     out var configText,
                     out var skippedReason))
             {
-                ReportTypeScriptPathAliasWarningOnce(
-                    FormatTypeScriptPathAliasConfigSkippedMessage(configPath, skippedReason));
+                ReportTypeScriptPathAliasConfigSkippedWarning(configPath, skippedReason);
                 return null;
             }
 
@@ -164,20 +165,18 @@ public static partial class SymbolExtractor
         }
         catch (JsonException)
         {
-            ReportTypeScriptPathAliasWarningOnce(
-                FormatTypeScriptPathAliasConfigSkippedMessage(
-                    configPath,
-                    TypeScriptPathAliasDiagnosticJsonInvalid,
-                    $"it could not be parsed as JSON within the {MaxTypeScriptPathAliasConfigJsonDepth}-level depth limit"));
+            ReportTypeScriptPathAliasConfigSkippedWarning(
+                configPath,
+                TypeScriptPathAliasDiagnosticJsonInvalid,
+                $"it could not be parsed as JSON within the {MaxTypeScriptPathAliasConfigJsonDepth}-level depth limit");
             return null;
         }
         catch
         {
-            ReportTypeScriptPathAliasWarningOnce(
-                FormatTypeScriptPathAliasConfigSkippedMessage(
-                    configPath,
-                    TypeScriptPathAliasDiagnosticReadFailed,
-                    "it could not be read"));
+            ReportTypeScriptPathAliasConfigSkippedWarning(
+                configPath,
+                TypeScriptPathAliasDiagnosticReadFailed,
+                "it could not be read");
             return null;
         }
 
@@ -268,26 +267,30 @@ public static partial class SymbolExtractor
 
                     if (rulesTruncated)
                     {
-                        ReportTypeScriptPathAliasWarningOnce(
-                            $"Truncated TypeScript path alias rules in config {configPath} to {MaxTypeScriptPathAliasRules} entries.");
+                        ReportTypeScriptPathAliasConfigWarningOnce(
+                            configPath,
+                            $"Truncated TypeScript path alias rules in config {DiagnosticSanitizer.ForPath(configPath)} to {MaxTypeScriptPathAliasRules} entries.");
                     }
 
                     if (targetsTruncated)
                     {
-                        ReportTypeScriptPathAliasWarningOnce(
-                            $"Truncated TypeScript path alias targets in config {configPath} to {MaxTypeScriptPathAliasTotalTargets} total entries and {MaxTypeScriptPathAliasTargetsPerRule} entries per rule.");
+                        ReportTypeScriptPathAliasConfigWarningOnce(
+                            configPath,
+                            $"Truncated TypeScript path alias targets in config {DiagnosticSanitizer.ForPath(configPath)} to {MaxTypeScriptPathAliasTotalTargets} total entries and {MaxTypeScriptPathAliasTargetsPerRule} entries per rule.");
                     }
 
                     if (ignoredLongPattern)
                     {
-                        ReportTypeScriptPathAliasWarningOnce(
-                            $"Ignored TypeScript path alias rules in config {configPath} with patterns longer than {MaxTypeScriptPathAliasPatternLength} characters.");
+                        ReportTypeScriptPathAliasConfigWarningOnce(
+                            configPath,
+                            $"Ignored TypeScript path alias rules in config {DiagnosticSanitizer.ForPath(configPath)} with patterns longer than {MaxTypeScriptPathAliasPatternLength} characters.");
                     }
 
                     if (ignoredLongTarget)
                     {
-                        ReportTypeScriptPathAliasWarningOnce(
-                            $"Ignored TypeScript path alias targets in config {configPath} longer than {MaxTypeScriptPathAliasTargetLength} characters.");
+                        ReportTypeScriptPathAliasConfigWarningOnce(
+                            configPath,
+                            $"Ignored TypeScript path alias targets in config {DiagnosticSanitizer.ForPath(configPath)} longer than {MaxTypeScriptPathAliasTargetLength} characters.");
                     }
                 }
             }
@@ -370,16 +373,29 @@ public static partial class SymbolExtractor
         FormatTypeScriptPathAliasConfigSkippedMessage(configPath, reason.Code, reason.Reason);
 
     private static string FormatTypeScriptPathAliasConfigSkippedMessage(string configPath, string code, string reason) =>
-        $"Skipped TypeScript path alias config {configPath} [{code}] because {reason}.";
+        $"Skipped TypeScript path alias config {DiagnosticSanitizer.ForPath(configPath)} [{DiagnosticSanitizer.ForMessage(code)}] because {DiagnosticSanitizer.ForMessage(reason)}.";
+
+    private static void ReportTypeScriptPathAliasConfigSkippedWarning(
+        string configPath,
+        TypeScriptPathAliasConfigSkippedReason reason) =>
+        ReportTypeScriptPathAliasConfigSkippedWarning(configPath, reason.Code, reason.Reason);
+
+    private static void ReportTypeScriptPathAliasConfigSkippedWarning(string configPath, string code, string reason)
+        => ReportTypeScriptPathAliasWarningOnce(
+            FormatTypeScriptPathAliasConfigSkippedMessage(configPath, code, reason),
+            $"{configPath}\n{code}\n{reason}");
 
     private static bool IsTypeScriptPathAliasConfigReadException(Exception exception) =>
         exception is IOException or UnauthorizedAccessException or NotSupportedException;
 
-    private static void ReportTypeScriptPathAliasWarningOnce(string message)
+    private static void ReportTypeScriptPathAliasConfigWarningOnce(string configPath, string message)
+        => ReportTypeScriptPathAliasWarningOnce(message, $"{configPath}\n{message}");
+
+    private static void ReportTypeScriptPathAliasWarningOnce(string message, string? dedupeKey = null)
     {
         lock (TypeScriptPathAliasWarningLock)
         {
-            if (!TypeScriptPathAliasReportedWarnings.Add(message))
+            if (!TypeScriptPathAliasReportedWarnings.Add(dedupeKey ?? message))
                 return;
         }
 

--- a/src/CodeIndex/Mcp/AuditLogSink.cs
+++ b/src/CodeIndex/Mcp/AuditLogSink.cs
@@ -5,6 +5,7 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
+using System.Threading.Channels;
 using CodeIndex.Cli;
 using CodeIndex.Diagnostics;
 using CodeIndex.Indexer;
@@ -43,6 +44,9 @@ internal sealed class AuditLogSink : IDisposable
     internal const int MaxAuditArgumentKeyChars = McpBoundedText.MaxDiagnosticDisplayChars;
     internal const int MaxRequestIdChars = 256;
     internal const int MaxSerializedEventBytes = 64 * 1024;
+    internal const int DefaultQueueCapacity = 1024;
+    internal const int MaxConfiguredQueueCapacity = 16 * 1024;
+    private static readonly TimeSpan DisposeWriterTimeout = TimeSpan.FromSeconds(5);
 
     private static readonly Regex SecretValuePattern = new(
         "(?i)(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|sk-(?:proj-)?[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16}|://[^/\\s:@]+:[^/\\s:@]+@|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|authorization)=[^&\\s]+)",
@@ -52,20 +56,26 @@ internal sealed class AuditLogSink : IDisposable
         MaxDepth = MaxArgValueDepth + 1,
     };
 
-    private readonly object _gate = new();
     private readonly string _path;
     private readonly long _maxBytes;
     private readonly bool _includeValues;
+    private readonly int _queueCapacity;
+    private readonly Channel<byte[]> _recordQueue;
+    private readonly Task _writerTask;
     private readonly Encoding _utf8NoBom = new UTF8Encoding(false);
     private long _bytesWritten;
+    private long _pendingRecordCount;
     private long _droppedRecordCount;
+    private long _queueFullDropCount;
     private long _serializationFailureCount;
     private long _writeFailureCount;
     private long _rotationFailureCount;
     private long _rotationCleanupFailureCount;
     private string? _lastDropReason;
     private string? _lastRotationFailure;
-    private bool _disposed;
+    private int _disposed;
+
+    internal Action? BeforeWriteForTests { get; set; }
 
     internal sealed record AuditLogDiagnostics(
         string Path,
@@ -73,7 +83,10 @@ internal sealed class AuditLogSink : IDisposable
         long MaxBytes,
         long BytesWritten,
         bool Disposed,
+        int QueueCapacity,
+        long QueueDepth,
         long DroppedRecordCount,
+        long QueueFullDropCount,
         long SerializationFailureCount,
         long WriteFailureCount,
         long RotationFailureCount,
@@ -82,7 +95,7 @@ internal sealed class AuditLogSink : IDisposable
         string? LastDropReason,
         string? LastRotationFailure);
 
-    internal AuditLogSink(string path, long maxBytes, bool includeValues)
+    internal AuditLogSink(string path, long maxBytes, bool includeValues, int? queueCapacity = null)
     {
         if (string.IsNullOrWhiteSpace(path))
             throw new ArgumentException("Audit log path must be non-empty.", nameof(path));
@@ -94,6 +107,7 @@ internal sealed class AuditLogSink : IDisposable
         _path = System.IO.Path.GetFullPath(path);
         _maxBytes = maxBytes;
         _includeValues = includeValues;
+        _queueCapacity = ResolveQueueCapacity(queueCapacity);
         var directory = System.IO.Path.GetDirectoryName(_path);
         if (!string.IsNullOrEmpty(directory))
             Directory.CreateDirectory(directory);
@@ -110,6 +124,14 @@ internal sealed class AuditLogSink : IDisposable
             _bytesWritten = probe.Length;
         }
         PrivateLogFile.TrySetPrivatePermissions(_path);
+        _recordQueue = Channel.CreateBounded<byte[]>(new BoundedChannelOptions(_queueCapacity)
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            FullMode = BoundedChannelFullMode.Wait,
+            AllowSynchronousContinuations = false,
+        });
+        _writerTask = BackgroundTaskObserver.Run(DrainQueueAsync, "cdidx-mcp-audit", "audit log writer");
     }
 
     /// <summary>Path the sink writes to (absolute, post normalisation).</summary>
@@ -123,36 +145,37 @@ internal sealed class AuditLogSink : IDisposable
 
     internal AuditLogDiagnostics SnapshotDiagnostics()
     {
-        lock (_gate)
-        {
-            var droppedRecordCount = Interlocked.Read(ref _droppedRecordCount);
-            var serializationFailureCount = Interlocked.Read(ref _serializationFailureCount);
-            var writeFailureCount = Interlocked.Read(ref _writeFailureCount);
-            var rotationFailureCount = Interlocked.Read(ref _rotationFailureCount);
-            var rotationCleanupFailureCount = Interlocked.Read(ref _rotationCleanupFailureCount);
-            var rotationDegraded = rotationFailureCount > 0
-                || rotationCleanupFailureCount > 0
-                || _bytesWritten >= _maxBytes;
-            return new AuditLogDiagnostics(
-                _path,
-                _includeValues,
-                _maxBytes,
-                _bytesWritten,
-                _disposed,
-                droppedRecordCount,
-                serializationFailureCount,
-                writeFailureCount,
-                rotationFailureCount,
-                rotationCleanupFailureCount,
-                rotationDegraded,
-                Volatile.Read(ref _lastDropReason),
-                Volatile.Read(ref _lastRotationFailure));
-        }
+        var bytesWritten = Volatile.Read(ref _bytesWritten);
+        var droppedRecordCount = Interlocked.Read(ref _droppedRecordCount);
+        var serializationFailureCount = Interlocked.Read(ref _serializationFailureCount);
+        var writeFailureCount = Interlocked.Read(ref _writeFailureCount);
+        var rotationFailureCount = Interlocked.Read(ref _rotationFailureCount);
+        var rotationCleanupFailureCount = Interlocked.Read(ref _rotationCleanupFailureCount);
+        var rotationDegraded = rotationFailureCount > 0
+            || rotationCleanupFailureCount > 0
+            || bytesWritten >= _maxBytes;
+        return new AuditLogDiagnostics(
+            _path,
+            _includeValues,
+            _maxBytes,
+            bytesWritten,
+            Volatile.Read(ref _disposed) != 0,
+            _queueCapacity,
+            Math.Max(0, Interlocked.Read(ref _pendingRecordCount)),
+            droppedRecordCount,
+            Interlocked.Read(ref _queueFullDropCount),
+            serializationFailureCount,
+            writeFailureCount,
+            rotationFailureCount,
+            rotationCleanupFailureCount,
+            rotationDegraded,
+            Volatile.Read(ref _lastDropReason),
+            Volatile.Read(ref _lastRotationFailure));
     }
 
     internal void Record(AuditEvent evt)
     {
-        if (_disposed)
+        if (Volatile.Read(ref _disposed) != 0)
             return;
 
         string line;
@@ -168,37 +191,58 @@ internal sealed class AuditLogSink : IDisposable
         }
 
         var encoded = _utf8NoBom.GetBytes(line + "\n");
-        lock (_gate)
-        {
-            if (_disposed)
-                return;
+        Interlocked.Increment(ref _pendingRecordCount);
+        if (_recordQueue.Writer.TryWrite(encoded))
+            return;
 
+        Interlocked.Decrement(ref _pendingRecordCount);
+        if (Volatile.Read(ref _disposed) == 0)
+            RecordDropped("queue_full", new AuditLogQueueFullException());
+    }
+
+    private async Task DrainQueueAsync()
+    {
+        await foreach (var encoded in _recordQueue.Reader.ReadAllAsync().ConfigureAwait(false))
+        {
             try
             {
-                // Open + write + close per record so an external `tail -F` keeps following
-                // rotations and so the file is closed during rename. Audit volume is bounded
-                // by tool-call cadence (not loop hot paths), so the per-call open is cheap.
-                // 1 レコードごとに open/write/close する。外部 `tail -F` の rotation 追従と
-                // rename 中のロック回避のため。ツール呼び出し頻度はループのホットパスではない
-                // ので open のコストは許容範囲。
-                using (var stream = PrivateLogFile.OpenAppend(_path, FileShare.ReadWrite))
-                {
-                    stream.Write(encoded, 0, encoded.Length);
-                    stream.Flush();
-                }
-                _bytesWritten += encoded.Length;
-
-                if (_bytesWritten >= _maxBytes)
-                {
-                    RotateLocked();
-                }
+                WriteEncodedRecord(encoded);
             }
-            catch (Exception ex)
+            finally
             {
-                // Best-effort: a failing audit write must not break the tool call.
-                // ベストエフォート: 監査出力失敗で本体呼び出しを壊さない。
-                RecordDropped("write_failure", ex);
+                Interlocked.Decrement(ref _pendingRecordCount);
             }
+        }
+    }
+
+    private void WriteEncodedRecord(byte[] encoded)
+    {
+        try
+        {
+            BeforeWriteForTests?.Invoke();
+            // Open + write + close per record so an external `tail -F` keeps following
+            // rotations and so the file is closed during rename. The queue keeps this
+            // IO off the caller's hot path while preserving serialized file writes.
+            // 1 レコードごとに open/write/close する。queue により呼び出し側の hot path から
+            // IO を外しつつ、ファイル書き込みの直列性は維持する。
+            using (var stream = PrivateLogFile.OpenAppend(_path, FileShare.ReadWrite))
+            {
+                stream.Write(encoded, 0, encoded.Length);
+                stream.Flush();
+            }
+            var bytesWritten = Volatile.Read(ref _bytesWritten) + encoded.Length;
+            Volatile.Write(ref _bytesWritten, bytesWritten);
+
+            if (bytesWritten >= _maxBytes)
+            {
+                RotateLocked();
+            }
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a failing audit write must not break the tool call.
+            // ベストエフォート: 監査出力失敗で本体呼び出しを壊さない。
+            RecordDropped("write_failure", ex);
         }
     }
 
@@ -206,7 +250,7 @@ internal sealed class AuditLogSink : IDisposable
     /// Rotate the current file to `<path>.1`, cascading older files up to `RotationKeep` slots.
     /// `<path>.(RotationKeep-1)` is the oldest retained slot, and the previous oldest is
     /// deleted so a slow drain of the audit log cannot fill the disk.
-    /// Caller must hold `_gate`.
+    /// Caller must be the single audit queue writer.
     /// </summary>
     private void RotateLocked()
     {
@@ -215,7 +259,7 @@ internal sealed class AuditLogSink : IDisposable
             RotationKeep,
             onFailure: ex => RecordRotationFailure("rotation_failure", ex),
             onCleanupFailure: ex => RecordRotationFailure("rotation_cleanup_failure", ex)))
-            _bytesWritten = 0;
+            Volatile.Write(ref _bytesWritten, 0);
     }
 
     private void RecordDropped(string reason, Exception exception)
@@ -225,6 +269,9 @@ internal sealed class AuditLogSink : IDisposable
         {
             case "serialization_failure":
                 Interlocked.Increment(ref _serializationFailureCount);
+                break;
+            case "queue_full":
+                Interlocked.Increment(ref _queueFullDropCount);
                 break;
             case "write_failure":
                 Interlocked.Increment(ref _writeFailureCount);
@@ -256,10 +303,46 @@ internal sealed class AuditLogSink : IDisposable
 
     public void Dispose()
     {
-        lock (_gate)
+        if (Interlocked.Exchange(ref _disposed, 1) != 0)
+            return;
+
+        _recordQueue.Writer.TryComplete();
+        try
         {
-            _disposed = true;
+            _writerTask.Wait(DisposeWriterTimeout);
         }
+        catch
+        {
+            // Disposal is best-effort; audit logging must not block process shutdown.
+            // dispose は best-effort。監査ログでプロセス終了を止めない。
+        }
+    }
+
+    internal bool WaitForIdle(TimeSpan timeout)
+    {
+        var deadline = DateTimeOffset.UtcNow + timeout;
+        while (Interlocked.Read(ref _pendingRecordCount) > 0)
+        {
+            if (DateTimeOffset.UtcNow >= deadline)
+                return false;
+            Thread.Sleep(10);
+        }
+        return true;
+    }
+
+    private static int ResolveQueueCapacity(int? queueCapacity)
+    {
+        var capacity = queueCapacity ?? DefaultQueueCapacity;
+        if (capacity <= 0 || capacity > MaxConfiguredQueueCapacity)
+            throw new ArgumentOutOfRangeException(
+                nameof(queueCapacity),
+                capacity,
+                $"Audit log queue capacity must be between 1 and {MaxConfiguredQueueCapacity.ToString(CultureInfo.InvariantCulture)}.");
+        return capacity;
+    }
+
+    private sealed class AuditLogQueueFullException : Exception
+    {
     }
 
     internal static string SerializeEvent(AuditEvent evt, bool includeValues)

--- a/src/CodeIndex/Mcp/HttpMcpTransport.cs
+++ b/src/CodeIndex/Mcp/HttpMcpTransport.cs
@@ -39,6 +39,8 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     internal const int DefaultMaxEventStreams = 16;
     internal const int MaxConfiguredEventStreams = 1024;
     internal const int MaxRequestLogFieldCharacters = 256;
+    internal const int DefaultRequestLogQueueCapacity = 1024;
+    internal const int MaxConfiguredRequestLogQueueCapacity = 16 * 1024;
     internal const int MaxHealthJsonBytes = 64 * 1024;
     internal const int MaxSseEventFrameBytes = 64 * 1024;
     internal const string RequestLogTruncationMarker = "...<truncated>";
@@ -63,7 +65,9 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     private readonly HttpListener _listener;
     private readonly string _endpoint;
     private readonly Action<HttpRequestLogRecord>? _requestLogger;
-    private readonly object _requestLoggerGate = new();
+    private readonly int _requestLogQueueCapacity;
+    private readonly Channel<HttpRequestLogRecord>? _requestLogQueue;
+    private readonly Task? _requestLogTask;
     private readonly ConcurrentDictionary<Guid, EventStream> _eventStreams = new();
     private readonly CancellationTokenSource _acceptCts = new();
     private readonly Channel<PendingRequest> _requestQueue;
@@ -84,7 +88,11 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     private readonly byte[]? _bearerTokenHash;
     private PendingRequest? _pendingRequest;
     private int _queuedRequestCount;
+    private int _pendingRequestLogCount;
     private int _eventStreamCount;
+    private long _requestLogDroppedCount;
+    private long _requestLogQueueFullDropCount;
+    private long _requestLogCallbackFailureCount;
     private long _responseAbortCleanupFailureCount;
     private long _responseCloseCleanupFailureCount;
     private long _concurrentHandlerLimitRejectionCount;
@@ -92,6 +100,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     private long _eventStreamLimitRejectionCount;
     private string? _lastResponseAbortCleanupFailure;
     private string? _lastResponseCloseCleanupFailure;
+    private string? _lastRequestLogDropReason;
     private bool _disposed;
 
     /// <summary>
@@ -113,7 +122,8 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
         int? maxResponseBodyBytes = null,
         int? maxQueuedRequests = null,
         int? maxConcurrentHandlers = null,
-        int? maxEventStreams = null)
+        int? maxEventStreams = null,
+        int? requestLogQueueCapacity = null)
     {
         _maxRequestBodyBytes = ResolvePositiveIntOption(
             maxRequestBodyBytes,
@@ -150,6 +160,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
             DefaultMaxEventStreams,
             MaxConfiguredEventStreams,
             "HTTP MCP event stream limit");
+        _requestLogQueueCapacity = ResolveRequestLogQueueCapacity(requestLogQueueCapacity);
         _requestQueue = Channel.CreateBounded<PendingRequest>(new BoundedChannelOptions(_maxQueuedRequests)
         {
             SingleReader = true,
@@ -173,6 +184,17 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
         _listener.Prefixes.Add(prefix);
         _listener.Start();
         _requestLogger = requestLogger;
+        if (_requestLogger is not null)
+        {
+            _requestLogQueue = Channel.CreateBounded<HttpRequestLogRecord>(new BoundedChannelOptions(_requestLogQueueCapacity)
+            {
+                SingleReader = true,
+                SingleWriter = false,
+                FullMode = BoundedChannelFullMode.Wait,
+                AllowSynchronousContinuations = false,
+            });
+            _requestLogTask = BackgroundTaskObserver.Run(DrainRequestLogQueueAsync, "cdidx-mcp-http", "request log writer");
+        }
         _endpoint = $"http://{host}:{boundPort}/";
         _acceptLoop = BackgroundTaskObserver.Run(
             token => AcceptLoopAsync(token),
@@ -213,9 +235,19 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
 
     internal int MaxEventStreams => _maxEventStreams;
 
+    internal int RequestLogQueueCapacity => _requestLogQueue is null ? 0 : _requestLogQueueCapacity;
+
     internal int QueuedRequestCount => Volatile.Read(ref _queuedRequestCount);
 
+    internal int RequestLogQueueDepth => _requestLogQueue is null ? 0 : Math.Max(0, Volatile.Read(ref _pendingRequestLogCount));
+
     internal int EventStreamCount => Volatile.Read(ref _eventStreamCount);
+
+    internal long RequestLogDroppedCount => Interlocked.Read(ref _requestLogDroppedCount);
+
+    internal long RequestLogQueueFullDropCount => Interlocked.Read(ref _requestLogQueueFullDropCount);
+
+    internal long RequestLogCallbackFailureCount => Interlocked.Read(ref _requestLogCallbackFailureCount);
 
     internal long ResponseAbortCleanupFailureCount => Interlocked.Read(ref _responseAbortCleanupFailureCount);
 
@@ -228,6 +260,10 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     internal long EventStreamLimitRejectionCount => Interlocked.Read(ref _eventStreamLimitRejectionCount);
 
     internal bool ResponseCleanupDegraded => ResponseAbortCleanupFailureCount > 0 || ResponseCloseCleanupFailureCount > 0;
+
+    internal bool RequestLogDegraded => RequestLogDroppedCount > 0;
+
+    internal string? LastRequestLogDropReason => Volatile.Read(ref _lastRequestLogDropReason);
 
     internal string? LastResponseAbortCleanupFailure => Volatile.Read(ref _lastResponseAbortCleanupFailure);
 
@@ -376,6 +412,17 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
         }
 
         return defaultValue;
+    }
+
+    private static int ResolveRequestLogQueueCapacity(int? explicitValue)
+    {
+        var capacity = explicitValue ?? DefaultRequestLogQueueCapacity;
+        if (capacity <= 0 || capacity > MaxConfiguredRequestLogQueueCapacity)
+            throw new ArgumentOutOfRangeException(
+                nameof(explicitValue),
+                capacity,
+                $"HTTP MCP request log queue depth must be between 1 and {MaxConfiguredRequestLogQueueCapacity.ToString(CultureInfo.InvariantCulture)}.");
+        return capacity;
     }
 
     public async Task<string?> ReadFrameAsync(CancellationToken cancellationToken)
@@ -1150,6 +1197,20 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
 
         if (acceptLoopCompleted)
             _acceptCts.Dispose();
+        if (_requestLogQueue is not null)
+        {
+            _requestLogQueue.Writer.TryComplete();
+            try
+            {
+                if (_requestLogTask is not null)
+                    await _requestLogTask.WaitAsync(DisposeAcceptLoopTimeout).ConfigureAwait(false);
+            }
+            catch
+            {
+                // Request logging is best-effort; shutdown must not wait indefinitely.
+                // request log は best-effort。shutdown を無期限に待たせない。
+            }
+        }
     }
 
     private void MarkRejected(PendingRequest request, string reason)
@@ -1202,32 +1263,70 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
 
     private void LogRequest(PendingRequest request, int statusCode)
     {
-        if (_requestLogger is null || request.Logged)
+        if (_requestLogger is null || _requestLogQueue is null || request.Logged)
             return;
 
         request.Logged = true;
-        try
+        var record = new HttpRequestLogRecord(
+            request.CorrelationId,
+            request.RequestId,
+            request.RemotePeer,
+            request.Method,
+            request.Path,
+            statusCode,
+            request.Elapsed.TotalMilliseconds,
+            request.AuthOutcome,
+            request.RejectionReason,
+            request.Diagnostic);
+        Interlocked.Increment(ref _pendingRequestLogCount);
+        if (_requestLogQueue.Writer.TryWrite(record))
+            return;
+
+        Interlocked.Decrement(ref _pendingRequestLogCount);
+        if (!_disposed)
+            RecordRequestLogDrop("queue_full", null);
+    }
+
+    private async Task DrainRequestLogQueueAsync()
+    {
+        if (_requestLogger is null || _requestLogQueue is null)
+            return;
+
+        await foreach (var record in _requestLogQueue.Reader.ReadAllAsync().ConfigureAwait(false))
         {
-            var record = new HttpRequestLogRecord(
-                    request.CorrelationId,
-                    request.RequestId,
-                    request.RemotePeer,
-                    request.Method,
-                    request.Path,
-                    statusCode,
-                    request.Elapsed.TotalMilliseconds,
-                    request.AuthOutcome,
-                    request.RejectionReason,
-                    request.Diagnostic);
-            lock (_requestLoggerGate)
+            try
             {
                 _requestLogger(record);
             }
+            catch (Exception ex)
+            {
+                RecordRequestLogDrop("callback_failure", ex);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _pendingRequestLogCount);
+            }
         }
-        catch
+    }
+
+    private void RecordRequestLogDrop(string reason, Exception? exception)
+    {
+        Interlocked.Increment(ref _requestLogDroppedCount);
+        switch (reason)
         {
-            // Logging is best-effort and must not affect the HTTP wire path.
+            case "queue_full":
+                Interlocked.Increment(ref _requestLogQueueFullDropCount);
+                break;
+            case "callback_failure":
+                Interlocked.Increment(ref _requestLogCallbackFailureCount);
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(reason), reason, "Expected queue_full or callback_failure.");
         }
+
+        var category = exception is null ? "resource" : DiagnosticRedactor.ClassifyException(exception);
+        var exceptionType = exception?.GetType().Name ?? "RequestLogQueueFull";
+        Volatile.Write(ref _lastRequestLogDropReason, $"{reason}:{category}:{exceptionType}");
     }
 
     private static string? TryExtractJsonRpcId(string body)

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -1545,11 +1545,12 @@ public partial class McpServer : IDisposable
         var now = DateTimeOffset.UtcNow;
         var dbOpen = ProbeDbHealth(now, out var dbError);
         var httpResponseCleanupDegraded = httpTransport?.ResponseCleanupDegraded ?? false;
+        var httpRequestLogDegraded = httpTransport?.RequestLogDegraded ?? false;
         var auditLogDiagnostics = _auditLog?.SnapshotDiagnostics();
         var auditLogDegraded = IsAuditLogDegraded(auditLogDiagnostics);
         var result = new JsonObject
         {
-            ["status"] = dbOpen && !httpResponseCleanupDegraded && !auditLogDegraded ? "ok" : "degraded",
+            ["status"] = dbOpen && !httpResponseCleanupDegraded && !httpRequestLogDegraded && !auditLogDegraded ? "ok" : "degraded",
             ["uptime_s"] = Math.Max(0, (long)Math.Floor((now - _startedAt).TotalSeconds)),
             ["last_request_at"] = _lastRequestAt.ToString("O", System.Globalization.CultureInfo.InvariantCulture),
             ["db_open"] = dbOpen,
@@ -1563,6 +1564,14 @@ public partial class McpServer : IDisposable
             result["http_max_concurrent_handlers"] = httpTransport.MaxConcurrentHandlers;
             result["http_queued_request_count"] = httpTransport.QueuedRequestCount;
             result["http_request_queue_limit"] = httpTransport.MaxQueuedRequests;
+            result["http_request_log_queue_depth"] = httpTransport.RequestLogQueueDepth;
+            result["http_request_log_queue_capacity"] = httpTransport.RequestLogQueueCapacity;
+            result["http_request_log_dropped_count"] = httpTransport.RequestLogDroppedCount;
+            result["http_request_log_queue_full_drop_count"] = httpTransport.RequestLogQueueFullDropCount;
+            result["http_request_log_callback_failure_count"] = httpTransport.RequestLogCallbackFailureCount;
+            result["http_request_log_degraded"] = httpRequestLogDegraded;
+            if (!string.IsNullOrWhiteSpace(httpTransport.LastRequestLogDropReason))
+                result["http_request_log_last_drop_reason"] = httpTransport.LastRequestLogDropReason;
             result["http_concurrent_handler_rejection_count"] = httpTransport.ConcurrentHandlerLimitRejectionCount;
             result["http_request_queue_rejection_count"] = httpTransport.RequestQueueLimitRejectionCount;
             result["http_event_stream_rejection_count"] = httpTransport.EventStreamLimitRejectionCount;

--- a/src/CodeIndex/Mcp/McpServer.cs
+++ b/src/CodeIndex/Mcp/McpServer.cs
@@ -599,6 +599,7 @@ public partial class McpServer : IDisposable
 
         while (_running)
         {
+            PruneCompletedRequestTasks(tasks);
             string? frame;
             try
             {
@@ -745,6 +746,38 @@ public partial class McpServer : IDisposable
 
         await DrainInFlightTasksAsync(tasks, DefaultEofDrainTimeout, DefaultEofPostCancelDrainTimeout, loopToken).ConfigureAwait(false);
         CommandErrorWriter.WriteStderr("[cdidx-mcp] Server stopped. Restart `cdidx mcp` when your client reconnects.");
+    }
+
+    internal static int PruneCompletedRequestTasks(List<Task> tasks)
+    {
+        var removed = 0;
+        for (var i = tasks.Count - 1; i >= 0; i--)
+        {
+            var task = tasks[i];
+            if (!task.IsCompleted)
+                continue;
+
+            ObserveCompletedRequestTask(task);
+            tasks.RemoveAt(i);
+            removed++;
+        }
+
+        return removed;
+    }
+
+    private static void ObserveCompletedRequestTask(Task task)
+    {
+        if (!task.IsFaulted)
+            return;
+
+        try
+        {
+            task.GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            CommandErrorWriter.WriteStderr($"[cdidx-mcp] In-flight request ended before EOF drain ({ex.GetType().Name}).");
+        }
     }
 
     internal async Task DrainInFlightTasksAsync(
@@ -955,6 +988,8 @@ public partial class McpServer : IDisposable
     /// sync-over-async blocking を避けるため <see cref="ProcessFrameAsync"/> を await する (#3770)。
     /// </summary>
     internal string? ProcessFrame(string line)
+        // Synchronous callers are compatibility entry points for tests and non-async hosts;
+        // transport loops use ProcessFrameAsync directly so request handling stays async.
         => ProcessFrameAsync(line).GetAwaiter().GetResult();
 
     internal async Task<string?> ProcessFrameAsync(string line)
@@ -1333,6 +1368,8 @@ public partial class McpServer : IDisposable
     /// <see cref="HandleMessageAsync(JsonNode)"/> を優先する (#3770)。
     /// </summary>
     internal JsonNode? HandleMessage(JsonNode request)
+        // Keep this sync wrapper for existing in-process callers; async transports call
+        // HandleMessageAsync so server loops do not need a sync-over-async bridge.
         => HandleMessageAsync(request, isolateRequestDb: false).GetAwaiter().GetResult();
 
     internal Task<JsonNode?> HandleMessageAsync(JsonNode request)

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -1177,19 +1177,26 @@ public partial class McpServer
 
     private JsonArray BuildTopFileHistogram<T>(IEnumerable<T> results, Func<T, string?> pathSelector)
     {
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var result in results)
+        {
+            var path = pathSelector(result);
+            if (string.IsNullOrWhiteSpace(path))
+                continue;
+
+            counts[path] = counts.TryGetValue(path, out var count) ? count + 1 : 1;
+        }
+
         var histogram = new JsonArray();
-        foreach (var group in results
-            .Select(pathSelector)
-            .Where(path => !string.IsNullOrWhiteSpace(path))
-            .GroupBy(path => path!, StringComparer.Ordinal)
-            .OrderByDescending(group => group.Count())
-            .ThenBy(group => group.Key, StringComparer.Ordinal)
+        foreach (var (path, count) in counts
+            .OrderByDescending(kv => kv.Value)
+            .ThenBy(kv => kv.Key, StringComparer.Ordinal)
             .Take(5))
         {
             histogram.Add(new JsonObject
             {
-                ["path"] = group.Key,
-                ["count"] = group.Count(),
+                ["path"] = path,
+                ["count"] = count,
             });
         }
 

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -382,7 +382,7 @@ public partial class McpServer
 
     private static int ReadLimit(JsonNode? args, int defaultLimit, ArgumentAdjustmentCollector adjustments)
     {
-        var requested = args?["limit"]?.GetValue<int>();
+        var requested = ReadOptionalIntArgument(args, "limit");
         var effective = Math.Clamp(requested ?? defaultLimit, 1, MaxLimit);
         if (requested.HasValue && requested.Value != effective)
             adjustments.AddClamped("limit", requested.Value, effective, 1, MaxLimit);
@@ -391,7 +391,7 @@ public partial class McpServer
 
     private static int ReadOffset(JsonNode? args, ArgumentAdjustmentCollector adjustments)
     {
-        var requested = args?["offset"]?.GetValue<int>();
+        var requested = ReadOptionalIntArgument(args, "offset");
         var effective = Math.Clamp(requested ?? 0, 0, MaxMcpPaginationOffset);
         if (requested.HasValue && requested.Value != effective)
             adjustments.AddClamped("offset", requested.Value, effective, 0, MaxMcpPaginationOffset);
@@ -400,7 +400,7 @@ public partial class McpServer
 
     private static int ReadSnippetLines(JsonNode? args, int defaultSnippetLines, ArgumentAdjustmentCollector adjustments)
     {
-        var requested = args?["snippetLines"]?.GetValue<int>();
+        var requested = ReadOptionalIntArgument(args, "snippetLines");
         var effective = SearchSnippetFormatter.ClampSnippetLines(requested ?? defaultSnippetLines);
         if (requested.HasValue && requested.Value != effective)
             adjustments.AddClamped("snippetLines", requested.Value, effective, 1, SearchSnippetFormatter.MaxSnippetLines);
@@ -409,7 +409,7 @@ public partial class McpServer
 
     private static int? ReadMapDepth(JsonNode? args, ArgumentAdjustmentCollector adjustments)
     {
-        var requested = args?["depth"]?.GetValue<int>();
+        var requested = ReadOptionalIntArgument(args, "depth");
         if (!requested.HasValue)
             return null;
         if (requested.Value < 0)
@@ -423,6 +423,11 @@ public partial class McpServer
             adjustments.AddClamped("depth", requested.Value, effective, 0, MaxMcpMapDepth);
         return effective;
     }
+
+    private static int? ReadOptionalIntArgument(JsonNode? args, string propertyName)
+        => args?[propertyName] is JsonValue value && value.TryGetValue<int>(out var parsed)
+            ? parsed
+            : null;
 
     private static string ReadResponseFormat(JsonNode? args)
         => args?["format"]?.GetValue<string>()?.Trim().ToLowerInvariant() ?? "full";
@@ -510,7 +515,7 @@ public partial class McpServer
 
     private JsonNode? TryGetValidatedMaxLineWidth(JsonNode? id, JsonNode? args, out int maxLineWidth, string propertyName = "maxLineWidth")
     {
-        var maxLineWidthValue = args?[propertyName]?.GetValue<int>();
+        var maxLineWidthValue = ReadOptionalIntArgument(args, propertyName);
         if (maxLineWidthValue.HasValue && maxLineWidthValue.Value < 0)
         {
             maxLineWidth = LineWidthFormatter.DefaultMaxLineWidth;
@@ -1777,7 +1782,7 @@ public partial class McpServer
             return guardError;
         if (TryReadSearchGuardScope(id, args, out var guardScope) is JsonNode guardScopeError)
             return guardScopeError;
-        var guardWindow = args?["guardWindow"]?.GetValue<int>() ?? DbReader.DefaultSearchGuardWindow;
+        var guardWindow = ReadOptionalIntArgument(args, "guardWindow") ?? DbReader.DefaultSearchGuardWindow;
         if (guardWindow < 0 || guardWindow > DbReader.MaxSearchGuardWindow)
             return CreateToolErrorResponse(id, $"'guardWindow' must be between 0 and {DbReader.MaxSearchGuardWindow}; got {guardWindow}.");
         var suggestExactSubstring = SearchQueryAdvisor.ShouldSuggestExactSubstring(query, rawQuery, exact, prefix);
@@ -1950,7 +1955,7 @@ public partial class McpServer
             return guardError;
         if (TryReadSearchGuardScope(id, args, out var guardScope) is JsonNode guardScopeError)
             return guardScopeError;
-        var guardWindow = args?["guardWindow"]?.GetValue<int>() ?? DbReader.DefaultSearchGuardWindow;
+        var guardWindow = ReadOptionalIntArgument(args, "guardWindow") ?? DbReader.DefaultSearchGuardWindow;
         if (guardWindow < 0 || guardWindow > DbReader.MaxSearchGuardWindow)
             return CreateToolErrorResponse(id, $"'guardWindow' must be between 0 and {DbReader.MaxSearchGuardWindow}; got {guardWindow}.");
 
@@ -3060,7 +3065,7 @@ public partial class McpServer
     private JsonNode ExecuteStatus(JsonNode? id, JsonNode? args)
     {
         var checkWorkspace = args?["check"]?.GetValue<bool>() ?? false;
-        var staleAfterSeconds = args?["staleAfterSeconds"]?.GetValue<int>() ?? (int)TimeSpan.FromDays(1).TotalSeconds;
+        var staleAfterSeconds = ReadOptionalIntArgument(args, "staleAfterSeconds") ?? (int)TimeSpan.FromDays(1).TotalSeconds;
         if (staleAfterSeconds <= 0)
             return CreateToolErrorResponse(id, "staleAfterSeconds must be greater than or equal to 1");
         var explain = args?["explain"]?.GetValue<string>()?.Trim().ToLowerInvariant();
@@ -3495,7 +3500,10 @@ public partial class McpServer
             ["max_bytes"] = diagnostics.MaxBytes,
             ["bytes_written"] = diagnostics.BytesWritten,
             ["disposed"] = diagnostics.Disposed,
+            ["queue_capacity"] = diagnostics.QueueCapacity,
+            ["queue_depth"] = diagnostics.QueueDepth,
             ["dropped_record_count"] = diagnostics.DroppedRecordCount,
+            ["queue_full_drop_count"] = diagnostics.QueueFullDropCount,
             ["serialization_failure_count"] = diagnostics.SerializationFailureCount,
             ["write_failure_count"] = diagnostics.WriteFailureCount,
             ["rotation_failure_count"] = diagnostics.RotationFailureCount,
@@ -3582,28 +3590,28 @@ public partial class McpServer
         if (!TryReadRequiredPathParameter(args, "path", out var path, out var requiredError))
             return CreateToolErrorResponse(id, requiredError!);
 
-        var startLine = args?["startLine"]?.GetValue<int>();
+        var startLine = ReadOptionalIntArgument(args, "startLine");
         if (startLine == null || startLine <= 0)
             return CreateToolErrorResponse(id, "Missing or invalid required parameter: startLine");
 
-        var endLine = args?["endLine"]?.GetValue<int>() ?? startLine.Value;
+        var endLine = ReadOptionalIntArgument(args, "endLine") ?? startLine.Value;
         if (endLine < startLine.Value)
             return CreateToolErrorResponse(id, "endLine must be greater than or equal to startLine");
 
-        var beforeValue = args?["before"]?.GetValue<int>();
+        var beforeValue = ReadOptionalIntArgument(args, "before");
         if (beforeValue.HasValue && beforeValue.Value < 0)
             return CreateToolErrorResponse(id, $"before must be in [0, {MaxContextLines}]");
         var before = ClampContextLines(beforeValue ?? 0);
 
-        var afterValue = args?["after"]?.GetValue<int>();
+        var afterValue = ReadOptionalIntArgument(args, "after");
         if (afterValue.HasValue && afterValue.Value < 0)
             return CreateToolErrorResponse(id, $"after must be in [0, {MaxContextLines}]");
         var after = ClampContextLines(afterValue ?? 0);
         var contextTruncated = beforeValue > MaxContextLines || afterValue > MaxContextLines;
 
-        var focusLine = args?["focusLine"]?.GetValue<int>();
-        var focusColumn = args?["focusColumn"]?.GetValue<int>();
-        var focusLengthValue = args?["focusLength"]?.GetValue<int>();
+        var focusLine = ReadOptionalIntArgument(args, "focusLine");
+        var focusColumn = ReadOptionalIntArgument(args, "focusColumn");
+        var focusLengthValue = ReadOptionalIntArgument(args, "focusLength");
         if (focusLengthValue.HasValue && focusLengthValue.Value <= 0)
             return CreateToolErrorResponse(id, "focusLength must be greater than or equal to 1");
         var focusLength = focusLengthValue ?? 1;
@@ -3699,7 +3707,11 @@ public partial class McpServer
         error = null;
         if (args?["maxOutputBytes"] is not JsonNode node)
             return true;
-        var requested = node.GetValue<int>();
+        if (node is not JsonValue value || !value.TryGetValue<int>(out var requested))
+        {
+            error = "maxOutputBytes must be an integer";
+            return false;
+        }
         if (requested <= 0)
         {
             error = "maxOutputBytes must be greater than or equal to 1";
@@ -3836,17 +3848,17 @@ public partial class McpServer
         var lang = args?["lang"]?.GetValue<string>()?.ToLowerInvariant();
         var excludePaths = ReadStringList(args, "excludePaths");
         var excludeTests = args?["excludeTests"]?.GetValue<bool>() ?? false;
-        var beforeValue = args?["before"]?.GetValue<int>();
+        var beforeValue = ReadOptionalIntArgument(args, "before");
         if (beforeValue.HasValue && beforeValue.Value < 0)
             return CreateToolErrorResponse(id, "before must be greater than or equal to 0");
         var before = ClampContextLines(beforeValue ?? 0);
 
-        var afterValue = args?["after"]?.GetValue<int>();
+        var afterValue = ReadOptionalIntArgument(args, "after");
         if (afterValue.HasValue && afterValue.Value < 0)
             return CreateToolErrorResponse(id, "after must be greater than or equal to 0");
         var after = ClampContextLines(afterValue ?? 0);
         var contextTruncated = beforeValue > MaxContextLines || afterValue > MaxContextLines;
-        var snippetLinesValue = args?["snippetLines"]?.GetValue<int>();
+        var snippetLinesValue = ReadOptionalIntArgument(args, "snippetLines");
         if (snippetLinesValue.HasValue && (snippetLinesValue.Value <= 0 || snippetLinesValue.Value > SearchSnippetFormatter.MaxSnippetLines))
             return CreateToolErrorResponse(id, $"snippetLines must be in [1, {SearchSnippetFormatter.MaxSnippetLines}]");
         if (snippetLinesValue.HasValue)
@@ -3934,8 +3946,12 @@ public partial class McpServer
 
     private JsonNode ExecuteBatchQuery(JsonNode? id, JsonNode? args)
     {
-        var queries = args?["queries"]?.AsArray();
-        if (queries == null || queries.Count == 0)
+        var queriesNode = args?["queries"];
+        if (queriesNode is null)
+            return CreateToolErrorResponse(id, "Missing or empty required parameter: queries");
+        if (queriesNode is not JsonArray queries)
+            return CreateToolErrorResponse(id, "Invalid type for argument 'queries' on tool 'batch_query'. Expected array.");
+        if (queries.Count == 0)
             return CreateToolErrorResponse(id, "Missing or empty required parameter: queries");
 
         if (queries.Count > MaxBatchQuerySize)
@@ -4464,7 +4480,7 @@ public partial class McpServer
     private static int ReadBatchQueryResponseByteLimit(JsonNode? args, ArgumentAdjustmentCollector adjustments)
     {
         var serverLimit = GetBatchQueryResponseByteLimit();
-        var requested = args?["maxResponseBytes"]?.GetValue<int>();
+        var requested = ReadOptionalIntArgument(args, "maxResponseBytes");
         if (!requested.HasValue)
             return serverLimit;
         var effective = Math.Min(requested.Value, serverLimit);
@@ -4816,7 +4832,7 @@ public partial class McpServer
         var deprecatedMaxDepthNode = args?["maxDepth"];
         var usedDeprecatedMaxDepth = deprecatedMaxDepthNode != null;
         var adjustments = new ArgumentAdjustmentCollector();
-        var maxDepthRequested = maxHopsNode?.GetValue<int>() ?? deprecatedMaxDepthNode?.GetValue<int>() ?? 5;
+        var maxDepthRequested = ReadOptionalIntArgument(args, "maxHops") ?? ReadOptionalIntArgument(args, "maxDepth") ?? 5;
         var maxDepth = Math.Clamp(maxDepthRequested, 0, MaxImpactDepth);
         string? maxDepthClampWarning = null;
         string? maxDepthDeprecationWarning = null;
@@ -5601,12 +5617,12 @@ public partial class McpServer
         var rebuild = args?["rebuild"]?.GetValue<bool>() ?? false;
         var dryRun = args?["dryRun"]?.GetValue<bool>() ?? args?["dry_run"]?.GetValue<bool>() ?? false;
         var memoryTrace = args?["memoryTrace"]?.GetValue<bool>() ?? false;
-        var requestedParallelism = args?["parallelism"]?.GetValue<int>();
-        var requestedDebounce = args?["debounce"]?.GetValue<int>();
-        var maxSymbolsPerFile = args?["maxSymbolsPerFile"]?.GetValue<int>() ?? IndexCommandRunner.DefaultMaxSymbolsPerFile;
+        var requestedParallelism = ReadOptionalIntArgument(args, "parallelism");
+        var requestedDebounce = ReadOptionalIntArgument(args, "debounce");
+        var maxSymbolsPerFile = ReadOptionalIntArgument(args, "maxSymbolsPerFile") ?? IndexCommandRunner.DefaultMaxSymbolsPerFile;
         if (maxSymbolsPerFile <= 0 || maxSymbolsPerFile > IndexCommandRunner.MaxSymbolsPerFileLimit)
             return CreateToolErrorResponse(id, $"maxSymbolsPerFile must be between 1 and {IndexCommandRunner.MaxSymbolsPerFileLimit}");
-        var maxReferencesPerFile = args?["maxReferencesPerFile"]?.GetValue<int>() ?? IndexCommandRunner.DefaultMaxReferencesPerFile;
+        var maxReferencesPerFile = ReadOptionalIntArgument(args, "maxReferencesPerFile") ?? IndexCommandRunner.DefaultMaxReferencesPerFile;
         if (maxReferencesPerFile <= 0 || maxReferencesPerFile > IndexCommandRunner.MaxReferencesPerFileLimit)
             return CreateToolErrorResponse(id, $"maxReferencesPerFile must be between 1 and {IndexCommandRunner.MaxReferencesPerFileLimit}");
         if (!TryReadMcpIndexSymlinkPolicy(args, out var symlinkPolicy, out var symlinkPolicyError))

--- a/src/CodeIndex/Models/QueryResults.cs
+++ b/src/CodeIndex/Models/QueryResults.cs
@@ -56,6 +56,8 @@ public readonly record struct SearchCursor(double Score, long ChunkId, int Offse
 
 public readonly record struct QueryCountResult(int Count, int FileCount, bool IncludesSql = false);
 
+public readonly record struct SearchFileCountResult(string Path, int Count);
+
 public readonly record struct FindScanSummary(
     int CandidateFiles,
     int FilesScanned,

--- a/src/CodeIndex/Models/QueryResults.cs
+++ b/src/CodeIndex/Models/QueryResults.cs
@@ -736,6 +736,12 @@ public static class ImpactTruncatedReasons
 
     /// <summary>Internal safety cap fired on a pathological graph.</summary>
     public const string SafetyCap = "safety_cap";
+
+    /// <summary>Path/cycle parent state exceeded the traversal memory budget.</summary>
+    public const string GraphStateBudget = "graph_state_budget";
+
+    /// <summary>Boundary caller probing exceeded its max-depth scan budget.</summary>
+    public const string BoundaryProbeBudget = "boundary_probe_budget";
 }
 
 public static class ImpactTerminationReasons
@@ -745,6 +751,8 @@ public static class ImpactTerminationReasons
     public const string CycleDetected = "cycle_detected";
     public const string RowLimitTruncated = "row_limit_truncated";
     public const string SafetyCap = "safety_cap";
+    public const string GraphStateBudget = "graph_state_budget";
+    public const string BoundaryProbeBudget = "boundary_probe_budget";
     public const string Cancelled = "cancelled";
 }
 

--- a/tests/CodeIndex.Tests/AuditLogSinkTests.cs
+++ b/tests/CodeIndex.Tests/AuditLogSinkTests.cs
@@ -380,6 +380,7 @@ public class AuditLogSinkTests
                 ElapsedMs: 0.5,
                 ErrorCode: 0,
                 ErrorType: null));
+            WaitForAuditLogIdle(sink);
 
             var lines = File.ReadAllLines(path);
             Assert.Single(lines);
@@ -454,6 +455,7 @@ public class AuditLogSinkTests
 
             sink.Record(bigEvent);
             sink.Record(smallEvent);
+            WaitForAuditLogIdle(sink);
 
             Assert.Equal(PrivateLogFile.PrivateFileMode, File.GetUnixFileMode(rotation1));
             Assert.Equal(PrivateLogFile.PrivateFileMode, File.GetUnixFileMode(path));
@@ -501,6 +503,7 @@ public class AuditLogSinkTests
 
             for (var i = 0; i < 3; i++)
                 sink.Record(bigEvent);
+            WaitForAuditLogIdle(sink);
 
             Assert.True(File.Exists(rotation1), "first rotation slot should exist after rotation");
             Assert.True(File.Exists(rotation2), "second rotation slot should exist after three big writes");
@@ -545,6 +548,7 @@ public class AuditLogSinkTests
             // RotationKeep=3 なので path.3 は決して残らない（最古スロットが drop される）。
             for (var i = 0; i < 5; i++)
                 sink.Record(bigEvent);
+            WaitForAuditLogIdle(sink);
 
             Assert.True(File.Exists(rotation1));
             Assert.True(File.Exists(rotation2));
@@ -593,6 +597,7 @@ public class AuditLogSinkTests
                     ErrorCode: 0,
                     ErrorType: null)));
                 Assert.Null(ex);
+                WaitForAuditLogIdle(sink);
 
                 var diagnostics = sink.SnapshotDiagnostics();
                 Assert.Equal(1, diagnostics.DroppedRecordCount);
@@ -687,4 +692,9 @@ public class AuditLogSinkTests
                 Directory.Delete(path, recursive: true);
         }
     }
+
+    private static void WaitForAuditLogIdle(AuditLogSink sink)
+        => Assert.True(
+            sink.WaitForIdle(TimeSpan.FromSeconds(5)),
+            "Timed out waiting for the audit log writer to drain.");
 }

--- a/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
@@ -567,6 +567,15 @@ public class DbCommandRunnerTests
         }
     }
 
+    public static IEnumerable<object[]> RecoverableTraversalFailures()
+    {
+        yield return [new IOException("secret local enumeration path")];
+        yield return [new UnauthorizedAccessException("secret local enumeration path")];
+        yield return [new NotSupportedException("secret local enumeration path")];
+        yield return [new PathTooLongException("secret local enumeration path")];
+        yield return [new ArgumentException("secret local enumeration path")];
+    }
+
     [Fact]
     public void Run_CheckpointJsonSuccessKeepsDiagnosticsArray_Issue3812()
     {
@@ -592,8 +601,9 @@ public class DbCommandRunnerTests
         }
     }
 
-    [Fact]
-    public void Run_CheckpointJsonReportsRecoverableFileNameEnumerationFailure_Issue3833()
+    [Theory]
+    [MemberData(nameof(RecoverableTraversalFailures))]
+    public void Run_CheckpointJsonReportsRecoverableFileNameEnumerationFailure_Issue3833(Exception exception)
     {
         var root = Path.Combine(Path.GetTempPath(), $"cdidx_db_checkpoint_enum_{Guid.NewGuid():N}");
         var dbPath = Path.Combine(root, "codeindex.db");
@@ -601,7 +611,7 @@ public class DbCommandRunnerTests
         {
             Directory.CreateDirectory(root);
             File.WriteAllText(dbPath, "db");
-            DbCommandRunner.EnumerateCheckpointFileNamesForTesting = _ => throw new IOException("secret local enumeration path");
+            DbCommandRunner.EnumerateCheckpointFileNamesForTesting = _ => throw exception;
 
             var (checkpointExit, json) = RunAndCaptureJson(["checkpoint", "enum", "--db", dbPath, "--json"]);
 

--- a/tests/CodeIndex.Tests/DbPathResolverTests.cs
+++ b/tests/CodeIndex.Tests/DbPathResolverTests.cs
@@ -492,6 +492,39 @@ public class DbPathResolverTests
     }
 
     [Fact]
+    public void ResolveProjectRootForQuery_StampedProjectLocalReadOnlyUriAvoidsPathCasingProbe_Issue3828()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_case_stamp");
+        var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+        var previousProbe = PathCasing.IgnoreCaseProbeForTesting;
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+            using (var db = new DbContext(dbPath))
+            {
+                db.InitializeSchema();
+                var writer = new DbWriter(db.Connection);
+                writer.SetMeta(DbContext.IndexedProjectRootMetaKey, projectRoot);
+                writer.SetMeta(DbContext.WorkspacePathCaseSensitiveMetaKey, "true");
+            }
+
+            PathCasing.ResetCacheForTests();
+            PathCasing.IgnoreCaseProbeForTesting = _ => throw new IOException("path casing probe should not run");
+
+            var readOnlyUri = new Uri(dbPath).AbsoluteUri + "?immutable=1";
+            var resolved = DbPathResolver.ResolveProjectRootForQuery(readOnlyUri, dbPathExplicit: true);
+
+            Assert.Equal(projectRoot, resolved);
+        }
+        finally
+        {
+            PathCasing.IgnoreCaseProbeForTesting = previousProbe;
+            PathCasing.ResetCacheForTests();
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void ResolveProjectRootForQuery_ProjectLocalDbPrefersCdidxSiblingOverStoredMetadata()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_db_path_resolver_local");

--- a/tests/CodeIndex.Tests/DbSearchReaderIssueTests.cs
+++ b/tests/CodeIndex.Tests/DbSearchReaderIssueTests.cs
@@ -218,6 +218,62 @@ public sealed class DbSearchReaderIssueTests : IDisposable
         Assert.Contains(DbReader.MaxLiteralSearchTokenCount.ToString(), ex.Message, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void SplitLiteralSearchTokens_RejectsOverlongQuotedPhrase_Issue3794()
+    {
+        var query = "\"" + new string('a', DbReader.MaxLiteralSearchTokenLength + 1) + "\"";
+
+        var ex = Assert.Throws<SearchQueryLimitException>(() => DbReader.SplitLiteralSearchTokens(query));
+
+        Assert.Contains("literal search phrase is too long", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbReader.MaxLiteralSearchTokenLength.ToString(), ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateRawFtsQuery_RejectsHighColumnListFanout_Issue3794()
+    {
+        var columns = string.Join(' ', Enumerable.Repeat("content", DbReader.MaxRawFtsColumnListCount + 1));
+        var query = $"{{{columns}}}: needle";
+
+        var ex = Assert.Throws<FtsQuerySyntaxException>(() => DbReader.ValidateRawFtsQuery(query));
+
+        Assert.Contains("raw FTS5 column list has too many columns", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbReader.MaxRawFtsColumnListCount.ToString(), ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateRawFtsQuery_RejectsOverlongColumnToken_Issue3794()
+    {
+        var column = new string('c', DbReader.MaxRawFtsColumnTokenLength + 1);
+
+        var ex = Assert.Throws<FtsQuerySyntaxException>(() => DbReader.ValidateRawFtsQuery($"{column}: needle"));
+
+        Assert.Contains("raw FTS5 column qualifier is too long", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbReader.MaxRawFtsColumnTokenLength.ToString(), ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildPathLikePattern_RejectsOverlongPathPattern_Issue3794()
+    {
+        var pattern = new string('a', DbReader.MaxPathLikePatternLength + 1);
+
+        var ex = Assert.Throws<SearchQueryLimitException>(() => DbReader.BuildPathLikePattern(pattern));
+
+        Assert.Contains("path pattern is too long", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbReader.MaxPathLikePatternLength.ToString(), ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildPathLikePattern_RejectsWildcardHeavyPathPattern_Issue3794()
+    {
+        var pattern = string.Concat(Enumerable.Repeat("*", DbReader.MaxPathLikePatternWildcards + 1));
+
+        var ex = Assert.Throws<SearchQueryLimitException>(() => DbReader.BuildPathLikePattern(pattern));
+
+        Assert.Contains("path pattern has too many wildcards", ex.Message, StringComparison.Ordinal);
+        Assert.Contains(DbReader.MaxPathLikePatternWildcards.ToString(), ex.Message, StringComparison.Ordinal);
+    }
+
     private void InsertIndexedFile(string path, string lang, string content, DateTime? modified = null)
     {
         var normalized = content.Replace("\r\n", "\n");

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -106,6 +106,164 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
+    public void RunImport_RejectsUnexpectedArchiveEntry_Issue3699()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_import_extra_entry_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var archivePath = CreateArchiveWithEntries(
+                workDir,
+                ("manifest.json", "{}"),
+                ("codeindex.db", "not a database"),
+                ("extra.txt", "unexpected"));
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", dbPath, "--json"], jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            var message = AssertExportImportErrorAndGetMessage(stdout, "import", "open_archive", "import_archive_unexpected_entry");
+            Assert.Contains("unexpected entry", message);
+            Assert.Contains("extra.txt", message);
+            Assert.Contains("manifest.json", message);
+            Assert.Contains("codeindex.db", message);
+            Assert.False(File.Exists(dbPath));
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunImport_RejectsDuplicateArchiveEntry_Issue3699()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_import_duplicate_entry_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var archivePath = CreateArchiveWithEntries(
+                workDir,
+                ("manifest.json", "{}"),
+                ("manifest.json", "{}"),
+                ("codeindex.db", "not a database"));
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", dbPath, "--json"], jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            var message = AssertExportImportErrorAndGetMessage(stdout, "import", "manifest", "import_archive_duplicate_entry");
+            Assert.Contains("duplicate entry", message);
+            Assert.Contains("manifest.json", message);
+            Assert.False(File.Exists(dbPath));
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunImport_RejectsMissingDatabaseEntryWithBoundedDiagnostic_Issue3699()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_import_missing_db_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var manifest = $$"""
+                {"format_version":"1","cdidx_version":"test","user_version":0,"database_sha256":"{{new string('0', 64)}}"}
+                """;
+            var archivePath = CreateArchiveWithEntries(workDir, ("manifest.json", manifest));
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", dbPath, "--json"], jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            var message = AssertExportImportErrorAndGetMessage(stdout, "import", "database_entry", "import_database_entry_missing");
+            Assert.Contains("codeindex.db", message);
+            Assert.False(File.Exists(dbPath));
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunImport_RejectsUnknownExtensionFileListTotalChars_Issue3766()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_unknown_extension_total_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var unknownPaths = Enumerable
+                .Range(0, 33)
+                .Select(index => $"{new string('u', 1000)}{index.ToString("D2", CultureInfo.InvariantCulture)}")
+                .ToArray();
+            var manifest = JsonSerializer.Serialize(new
+            {
+                format_version = "1",
+                cdidx_version = "test",
+                user_version = 0,
+                database_sha256 = new string('0', 64),
+                unknown_extension_files = unknownPaths
+            });
+            var archivePath = CreateArchiveWithManifestAndDatabase(workDir, manifest, [1, 2, 3, 4]);
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", dbPath, "--json"], jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            var message = AssertExportImportErrorAndGetMessage(stdout, "import", "manifest", "import_manifest_incompatible");
+            Assert.Contains("unknown_extension_files total path text exceeds", message);
+            Assert.False(File.Exists(dbPath));
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunImport_CancelledTokenReturnsInterruptedJson_Issue3766()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_import_cancel_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var archivePath = Path.Combine(workDir, "missing.cdidx.zip");
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", dbPath, "--json"], jsonOptions, cts.Token));
+
+            Assert.Equal(CommandExitCodes.Interrupted, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            AssertExportImportError(stdout, "import", "open_archive", "import_interrupted");
+            Assert.False(File.Exists(dbPath));
+        }
+        finally
+        {
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void RunImport_RejectsDeepManifestBeforeDatabaseEntry()
     {
         var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_manifest_depth_{Guid.NewGuid():N}");
@@ -681,6 +839,32 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
+    public void RunExportArchive_CancelledTokenReturnsInterruptedJson_Issue3766()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("export_archive_cancel");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var outputPath = Path.Combine(projectRoot, "codeindex.cdidx.zip");
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunExport([outputPath, "--db", dbPath, "--json"], jsonOptions, "test", cts.Token));
+
+            Assert.Equal(CommandExitCodes.Interrupted, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            AssertExportImportError(stdout, "export", "write_archive", "export_interrupted");
+            Assert.False(File.Exists(outputPath));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunExportArchive_ManifestReportsEmptyUnknownExtensionSampleList_Issue3715()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("export_unknown_extensions_empty");
@@ -1109,6 +1293,30 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
+    public void TryValidateDatabaseEntrySize_RejectsZeroCompressedNonEmptyEntry_Issue3766()
+    {
+        var ok = ExportImportCommandRunner.TryValidateDatabaseEntrySize(
+            uncompressedLength: 1,
+            compressedLength: 0,
+            message: out var message);
+
+        Assert.False(ok);
+        Assert.Contains("zero compressed bytes", message);
+    }
+
+    [Fact]
+    public void TryValidateDatabaseEntrySize_RejectsAbnormalCompressionRatio_Issue3766()
+    {
+        var ok = ExportImportCommandRunner.TryValidateDatabaseEntrySize(
+            uncompressedLength: ExportImportCommandRunner.MaxImportDatabaseCompressionRatio + 1,
+            compressedLength: 1,
+            message: out var message);
+
+        Assert.False(ok);
+        Assert.Contains("compression ratio exceeds", message);
+    }
+
+    [Fact]
     public void CopyToWithLimit_ThrowsBeforeWritingPastLimit()
     {
         using var source = new MemoryStream([1, 2, 3, 4]);
@@ -1132,6 +1340,29 @@ public class ExportImportCommandRunnerTests
         Assert.Equal([1, 2, 3, 4], target.ToArray());
     }
 
+    [Fact]
+    public void CopyToWithLimit_ReportsProgressAndHonorsCancellation_Issue3766()
+    {
+        using var source = new MemoryStream([1, 2, 3, 4]);
+        using var target = new MemoryStream();
+        var progress = new RecordingProgress();
+
+        var copied = ExportImportCommandRunner.CopyToWithLimit(source, target, 4, CancellationToken.None, progress);
+
+        Assert.Equal(4, copied);
+        Assert.Equal([1, 2, 3, 4], target.ToArray());
+        Assert.Equal([4L], progress.Values);
+
+        using var canceledSource = new MemoryStream([5]);
+        using var canceledTarget = new MemoryStream();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            ExportImportCommandRunner.CopyToWithLimit(canceledSource, canceledTarget, 1, cts.Token));
+        Assert.Equal(0, canceledTarget.Length);
+    }
+
     private static string CreateArchiveWithManifest(string workDir, string manifest)
     {
         var archivePath = Path.Combine(workDir, "codeindex.cdidx.zip");
@@ -1139,6 +1370,20 @@ public class ExportImportCommandRunnerTests
         var entry = archive.CreateEntry("manifest.json");
         using var writer = new StreamWriter(entry.Open());
         writer.Write(manifest);
+        return archivePath;
+    }
+
+    private static string CreateArchiveWithEntries(string workDir, params (string Name, string Content)[] entries)
+    {
+        var archivePath = Path.Combine(workDir, $"codeindex-entries-{Guid.NewGuid():N}.cdidx.zip");
+        using var archive = ZipFile.Open(archivePath, ZipArchiveMode.Create);
+        foreach (var (name, content) in entries)
+        {
+            var entry = archive.CreateEntry(name);
+            using var writer = new StreamWriter(entry.Open());
+            writer.Write(content);
+        }
+
         return archivePath;
     }
 
@@ -1205,6 +1450,22 @@ public class ExportImportCommandRunnerTests
         Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("usage").GetString()));
     }
 
+    private static string AssertExportImportErrorAndGetMessage(string stdout, string command, string phase, string errorCode)
+    {
+        using var document = JsonDocument.Parse(stdout);
+        var root = document.RootElement;
+        Assert.Equal("1", root.GetProperty("api_version").GetString());
+        Assert.Equal("error", root.GetProperty("status").GetString());
+        Assert.Equal(command, root.GetProperty("command").GetString());
+        Assert.Equal(phase, root.GetProperty("phase").GetString());
+        Assert.Equal(errorCode, root.GetProperty("error_code").GetString());
+        var message = root.GetProperty("message").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(message));
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("hint").GetString()));
+        Assert.False(string.IsNullOrWhiteSpace(root.GetProperty("usage").GetString()));
+        return message!;
+    }
+
     private static string? ReadMetaValue(string dbPath, string key)
     {
         using var connection = new SqliteConnection(new SqliteConnectionStringBuilder { DataSource = dbPath }.ConnectionString);
@@ -1213,5 +1474,12 @@ public class ExportImportCommandRunnerTests
         command.CommandText = "SELECT value FROM codeindex_meta WHERE key = @key";
         command.Parameters.AddWithValue("@key", key);
         return command.ExecuteScalar() as string;
+    }
+
+    private sealed class RecordingProgress : IProgress<long>
+    {
+        public List<long> Values { get; } = [];
+
+        public void Report(long value) => Values.Add(value);
     }
 }

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -734,6 +734,56 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void LanguageMapOverrides_OverlongLineSkipsOverridesWithWarning_Issue3706()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_langmap_line_length_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var overlongLinePath = Path.Combine(tempDir, "long-line-langmap.yaml");
+            var fallbackPath = Path.Combine(tempDir, "fallback-langmap.yaml");
+            File.WriteAllText(overlongLinePath, new string('x', 16 * 1024 + 1));
+            File.WriteAllText(fallbackPath, "entries:\n- extension: ok\n  language: ruby\n");
+
+            var warnings = new List<string>();
+            var map = LanguageMapOverrides.LoadEffectiveMapFromPathsForTesting(
+                new[] { overlongLinePath, fallbackPath },
+                warnings.Add);
+
+            Assert.Equal("ruby", map[".ok"]);
+            Assert.Contains(warnings, warning => warning.Contains("line 1 exceeds", StringComparison.Ordinal));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(tempDir);
+        }
+    }
+
+    [Fact]
+    public void LanguageMapOverrides_WarningsSanitizeConfigPath_Issue3819()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_langmap_sanitize_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var configPath = Path.Combine(tempDir, "secret-langmap.yaml");
+            File.WriteAllText(configPath, new string('x', 16 * 1024 + 1));
+
+            var warnings = new List<string>();
+            _ = LanguageMapOverrides.LoadEffectiveMapFromPathsForTesting([configPath], warnings.Add);
+
+            var warning = Assert.Single(warnings);
+            Assert.Contains("secret-langmap.yaml", warning, StringComparison.Ordinal);
+            Assert.DoesNotContain(tempDir, warning, StringComparison.Ordinal);
+            Assert.DoesNotContain(tempDir.Replace('\\', '/'), warning, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(tempDir);
+        }
+    }
+
+    [Fact]
     public void LanguageMapOverrides_EntryCountCapTruncatesRemainingOverridesWithWarning()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_langmap_entries_{Guid.NewGuid():N}");
@@ -4379,6 +4429,80 @@ public class FileIndexerTests
                 error => error.Path == ".gitmodules"
                     && error.Severity == FileIndexer.ScanIssueSeverity.Warning
                     && error.Message.Contains("exceeds", StringComparison.OrdinalIgnoreCase));
+            Assert.False(result.HadErrors);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ScanFiles_GitmodulesQuotedPathPreservesCommentCharacters_Issue3819()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            File.WriteAllText(
+                Path.Combine(tempDir, ".gitmodules"),
+                """
+                [submodule "quoted"]
+                    path = "vendor/hash#semi;module" # trailing comment
+                """);
+
+            var submoduleDir = Path.Combine(tempDir, "vendor", "hash#semi;module");
+            Directory.CreateDirectory(submoduleDir);
+            File.WriteAllText(Path.Combine(submoduleDir, ".git"), "gitdir: ../../.git/modules/quoted\n");
+            File.WriteAllText(Path.Combine(submoduleDir, "lib.py"), "def quoted(): pass");
+
+            var files = new FileIndexer(tempDir).ScanFiles();
+            var rel = files.Select(f => Path.GetRelativePath(tempDir, f).Replace('\\', '/')).ToHashSet();
+
+            Assert.Contains("vendor/hash#semi;module/lib.py", rel);
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+                Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public void ScanFilesDetailed_GitmodulesSubmodulePathCapWarns_Issue3819()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"codeindex_test_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(tempDir);
+            File.WriteAllText(Path.Combine(tempDir, "app.py"), "print('hello')");
+
+            var maxPaths = FileIndexer.MaxGitmodulesSubmodulePaths;
+            var gitmodules = new StringBuilder();
+            for (var i = 0; i <= maxPaths; i++)
+            {
+                gitmodules.AppendLine($"[submodule \"m{i}\"]");
+                gitmodules.AppendLine($"    path = vendor/m{i}");
+            }
+
+            File.WriteAllText(Path.Combine(tempDir, ".gitmodules"), gitmodules.ToString());
+
+            var overflowDir = Path.Combine(tempDir, "vendor", $"m{maxPaths}");
+            Directory.CreateDirectory(overflowDir);
+            File.WriteAllText(Path.Combine(overflowDir, ".git"), $"gitdir: ../../.git/modules/m{maxPaths}\n");
+            File.WriteAllText(Path.Combine(overflowDir, "lib.py"), "def over_cap(): pass");
+
+            var result = new FileIndexer(tempDir).ScanFilesDetailed();
+            var rel = result.Files.Select(f => Path.GetRelativePath(tempDir, f).Replace('\\', '/')).ToHashSet();
+
+            Assert.Contains("app.py", rel);
+            Assert.DoesNotContain($"vendor/m{maxPaths}/lib.py", rel);
+            Assert.Contains(
+                result.Errors,
+                error => error.Path == ".gitmodules"
+                    && error.Severity == FileIndexer.ScanIssueSeverity.Warning
+                    && error.Message.Contains($"after {maxPaths}", StringComparison.Ordinal));
             Assert.False(result.HadErrors);
         }
         finally

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -917,15 +917,25 @@ public class FileIndexerTests
         }
     }
 
-    [Fact]
-    public void GetProjectMarkerFingerprint_TraversalFailureReportsWarning_Issue3473()
+    public static IEnumerable<object[]> ProjectMarkerTraversalFailures()
+    {
+        yield return [new IOException("blocked")];
+        yield return [new UnauthorizedAccessException("blocked")];
+        yield return [new NotSupportedException("blocked")];
+        yield return [new PathTooLongException("blocked")];
+        yield return [new ArgumentException("blocked")];
+    }
+
+    [Theory]
+    [MemberData(nameof(ProjectMarkerTraversalFailures))]
+    public void GetProjectMarkerFingerprint_TraversalFailureReportsWarning_Issue3473(Exception exception)
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_msbuild_marker_warning_{Guid.NewGuid():N}");
         var previousEnumerator = FileIndexer.EnumerateProjectMarkerDirectoriesForTesting;
         try
         {
             Directory.CreateDirectory(tempDir);
-            FileIndexer.EnumerateProjectMarkerDirectoriesForTesting = _ => throw new IOException("blocked");
+            FileIndexer.EnumerateProjectMarkerDirectoriesForTesting = _ => throw exception;
             var indexer = new FileIndexer(tempDir, ignoreCase: false);
 
             var result = indexer.GetProjectMarkerFingerprintResultForTesting("msbuild", maxDirectories: 10, maxMarkerFiles: 100);
@@ -934,6 +944,7 @@ public class FileIndexerTests
             var warning = Assert.Single(result.Warnings);
             Assert.Equal(".", warning.Path);
             Assert.Contains("Project marker discovery skipped this subtree", warning.Message, StringComparison.Ordinal);
+            Assert.Contains(exception.GetType().Name, warning.Message, StringComparison.Ordinal);
         }
         finally
         {

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -141,28 +141,31 @@ public class FileIndexerTests
     }
 
     [Fact]
-    public void CaseSensitivityProbeDirectory_CleanupFailureThrows_Issue3439()
+    public void CaseSensitivityProbeDirectory_CleanupFailureDowngradesToDiagnostic_Issue3828()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx-case-probe-cleanup-{Guid.NewGuid():N}");
         Directory.CreateDirectory(tempDir);
         var previousDelete = CaseSensitivityProbeDirectory.DeleteCreatedEmptyDirectoryForTesting;
+        var previousSink = CaseSensitivityProbeDirectory.CleanupDiagnosticSinkForTesting;
+        var diagnostics = new List<CaseSensitivityProbeCleanupDiagnostic>();
         try
         {
-            using var scope = CaseSensitivityProbeDirectory.CreateProbePathScope(tempDir, "case-probe-test-");
+            var scope = CaseSensitivityProbeDirectory.CreateProbePathScope(tempDir, "case-probe-test-");
             CaseSensitivityProbeDirectory.DeleteCreatedEmptyDirectoryForTesting = path => throw new IOException($"blocked: {path}");
+            CaseSensitivityProbeDirectory.CleanupDiagnosticSinkForTesting = diagnostics.Add;
 
-            var ex = Assert.Throws<CaseSensitivityProbeException>(() => scope.Dispose());
+            scope.Dispose();
 
-            Assert.Equal(Path.GetFullPath(tempDir), ex.ProjectRoot);
-            Assert.NotNull(ex.CleanupPath);
-            Assert.EndsWith(
-                $"{CaseSensitivityProbeDirectory.DataDirectoryName}{Path.DirectorySeparatorChar}{CaseSensitivityProbeDirectory.ProbeDirectoryName}",
-                ex.CleanupPath);
-            Assert.IsType<IOException>(ex.InnerException);
+            Assert.Contains(scope.CleanupDiagnostics, diagnostic =>
+                diagnostic.RelativePath == $"{CaseSensitivityProbeDirectory.DataDirectoryName}/{CaseSensitivityProbeDirectory.ProbeDirectoryName}");
+            Assert.Contains(diagnostics, diagnostic =>
+                diagnostic.RelativePath == $"{CaseSensitivityProbeDirectory.DataDirectoryName}/{CaseSensitivityProbeDirectory.ProbeDirectoryName}");
+            Assert.DoesNotContain(diagnostics, diagnostic => diagnostic.RelativePath.Contains(tempDir, StringComparison.Ordinal));
         }
         finally
         {
             CaseSensitivityProbeDirectory.DeleteCreatedEmptyDirectoryForTesting = previousDelete;
+            CaseSensitivityProbeDirectory.CleanupDiagnosticSinkForTesting = previousSink;
             TestProjectHelper.DeleteDirectory(tempDir);
         }
     }

--- a/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+++ b/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
@@ -143,6 +143,12 @@ public class HttpMcpTransportTests : IDisposable
         Assert.True(root.GetProperty("http_max_concurrent_handlers").GetInt32() >= 1);
         Assert.Equal(0, root.GetProperty("http_queued_request_count").GetInt32());
         Assert.True(root.GetProperty("http_request_queue_limit").GetInt32() >= 1);
+        Assert.Equal(0, root.GetProperty("http_request_log_queue_depth").GetInt32());
+        Assert.Equal(0, root.GetProperty("http_request_log_queue_capacity").GetInt32());
+        Assert.Equal(0, root.GetProperty("http_request_log_dropped_count").GetInt64());
+        Assert.Equal(0, root.GetProperty("http_request_log_queue_full_drop_count").GetInt64());
+        Assert.Equal(0, root.GetProperty("http_request_log_callback_failure_count").GetInt64());
+        Assert.False(root.GetProperty("http_request_log_degraded").GetBoolean());
         Assert.Equal(0, root.GetProperty("http_concurrent_handler_rejection_count").GetInt64());
         Assert.Equal(0, root.GetProperty("http_request_queue_rejection_count").GetInt64());
         Assert.Equal(0, root.GetProperty("http_event_stream_rejection_count").GetInt64());
@@ -271,6 +277,55 @@ public class HttpMcpTransportTests : IDisposable
         Assert.Equal("POST", okPost.Method);
         Assert.Equal("/", okPost.Path);
         Assert.Equal((int)HttpStatusCode.OK, okPost.StatusCode);
+    }
+
+    [Fact]
+    public async Task HttpTransport_RequestLogger_DropsWhenQueueSaturated_Issue3747()
+    {
+        using var writerEntered = new ManualResetEventSlim();
+        using var releaseWriter = new ManualResetEventSlim();
+        var records = new ConcurrentQueue<HttpMcpTransport.HttpRequestLogRecord>();
+        await using var harness = await McpHttpHarness.StartAsync(
+            _dbPath,
+            requestLogger: record =>
+            {
+                records.Enqueue(record);
+                writerEntered.Set();
+                releaseWriter.Wait();
+            },
+            requestLogQueueCapacity: 1);
+
+        var healthUri = new Uri(new Uri(harness.Endpoint), "healthz");
+        using var client = new HttpClient();
+        try
+        {
+            using var first = await client.GetAsync(healthUri);
+            Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+            Assert.True(writerEntered.Wait(TimeSpan.FromSeconds(5)), "request log writer should enter the blocking callback");
+
+            using var second = await client.GetAsync(healthUri);
+            Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+            using var third = await client.GetAsync(healthUri);
+            Assert.Equal(HttpStatusCode.OK, third.StatusCode);
+
+            await WaitForRequestLogDropAsync(harness);
+            Assert.True(harness.RequestLogQueueFullDropCount > 0);
+        }
+        finally
+        {
+            releaseWriter.Set();
+        }
+
+        using var degraded = await client.GetAsync(healthUri);
+        Assert.Equal(HttpStatusCode.OK, degraded.StatusCode);
+        using var document = JsonDocument.Parse(await degraded.Content.ReadAsStringAsync());
+        var root = document.RootElement;
+        Assert.Equal("degraded", root.GetProperty("status").GetString());
+        Assert.True(root.GetProperty("http_request_log_dropped_count").GetInt64() > 0);
+        Assert.True(root.GetProperty("http_request_log_queue_full_drop_count").GetInt64() > 0);
+        Assert.Equal(0, root.GetProperty("http_request_log_callback_failure_count").GetInt64());
+        Assert.True(root.GetProperty("http_request_log_degraded").GetBoolean());
+        Assert.Contains("queue_full", root.GetProperty("http_request_log_last_drop_reason").GetString(), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1352,6 +1407,20 @@ public class HttpMcpTransportTests : IDisposable
         return snapshot;
     }
 
+    private static async Task WaitForRequestLogDropAsync(McpHttpHarness harness)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            if (harness.RequestLogDroppedCount > 0)
+                return;
+
+            await Task.Delay(10);
+        }
+
+        Assert.Fail("Expected the request log queue to report at least one dropped record.");
+    }
+
     private static void AssertTooManyRequests(HttpResponseMessage response, string rejectionReason)
     {
         Assert.Equal(HttpStatusCode.TooManyRequests, response.StatusCode);
@@ -1449,6 +1518,10 @@ public class HttpMcpTransportTests : IDisposable
 
         public int EventStreamCount => _transport.EventStreamCount;
 
+        public long RequestLogDroppedCount => _transport.RequestLogDroppedCount;
+
+        public long RequestLogQueueFullDropCount => _transport.RequestLogQueueFullDropCount;
+
         public void RecordResponseCleanupFailure(string kind, string operation, Exception exception)
             => _transport.RecordResponseCleanupFailure(kind, operation, exception);
 
@@ -1468,7 +1541,8 @@ public class HttpMcpTransportTests : IDisposable
             Action<HttpMcpTransport.HttpRequestLogRecord>? requestLogger = null,
             int? maxRequestBodyBytes = null,
             int? maxResponseBodyBytes = null,
-            int? maxQueuedRequests = null)
+            int? maxQueuedRequests = null,
+            int? requestLogQueueCapacity = null)
         {
             var listen = HttpMcpTransport.ResolveListenSpec("127.0.0.1:0");
             var transport = new HttpMcpTransport(
@@ -1479,7 +1553,8 @@ public class HttpMcpTransportTests : IDisposable
                 requestLogger: requestLogger,
                 maxRequestBodyBytes: maxRequestBodyBytes,
                 maxResponseBodyBytes: maxResponseBodyBytes,
-                maxQueuedRequests: maxQueuedRequests);
+                maxQueuedRequests: maxQueuedRequests,
+                requestLogQueueCapacity: requestLogQueueCapacity);
             var server = authenticator is null
                 ? new McpServer(dbPath, ConsoleUi.LoadVersion())
                 : new McpServer(dbPath, ConsoleUi.LoadVersion(), dbPathExplicit: false, authenticator);
@@ -1489,10 +1564,17 @@ public class HttpMcpTransportTests : IDisposable
             // background task may not have entered GetContextAsync yet by the time the test posts.
             // listener が GetContextAsync に入る前に POST が来ないよう、ごく短い待機を挟む。
             await Task.Yield();
-            for (var i = 0; i < 100 && transport.HealthJsonProvider is null && !loopTask.IsCompleted; i++)
+            var healthReadyDeadline = DateTimeOffset.UtcNow.AddSeconds(5);
+            while (transport.HealthJsonProvider is null
+                && !loopTask.IsCompleted
+                && DateTimeOffset.UtcNow < healthReadyDeadline)
+            {
                 await Task.Delay(10);
+            }
             if (loopTask.IsCompleted)
                 await loopTask.ConfigureAwait(false);
+            if (transport.HealthJsonProvider is null)
+                throw new TimeoutException("Timed out waiting for the MCP HTTP health provider to become ready.");
             return new McpHttpHarness(server, transport, cts, loopTask, listen.Prefix);
         }
 

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2757,6 +2757,48 @@ public sealed class Caller
         }
     }
 
+    public static IEnumerable<object[]> SolutionProjectTraversalFailures()
+    {
+        yield return [new IOException("blocked"), "an I/O error"];
+        yield return [new UnauthorizedAccessException("blocked"), "permissions"];
+        yield return [new NotSupportedException("blocked"), "an unsupported path"];
+        yield return [new PathTooLongException("blocked"), "a path that is too long"];
+        yield return [new ArgumentException("blocked"), "an invalid path"];
+    }
+
+    [Theory]
+    [MemberData(nameof(SolutionProjectTraversalFailures))]
+    public void ResolveProjects_FallbackTraversalReportsExpectedFilesystemDiagnostics_Issue3707(
+        Exception exception,
+        string expectedReason)
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_solution_fallback_exception");
+        var previousEnumerateDirectories = SolutionProjectResolver.EnumerateDirectoriesForTesting;
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            SolutionProjectResolver.EnumerateDirectoriesForTesting = _ => throw exception;
+            var diagnostics = new List<string>();
+
+            var projects = SolutionProjectResolver.ResolveProjects(
+                projectRoot,
+                solutionPath: null,
+                SolutionProjectResolverLimits.Default,
+                diagnostics);
+
+            Assert.Empty(projects);
+            var diagnostic = Assert.Single(diagnostics);
+            Assert.Contains("Could not enumerate subdirectories in .", diagnostic, StringComparison.Ordinal);
+            Assert.Contains(expectedReason, diagnostic, StringComparison.Ordinal);
+            Assert.DoesNotContain("blocked", diagnostic, StringComparison.Ordinal);
+        }
+        finally
+        {
+            SolutionProjectResolver.EnumerateDirectoriesForTesting = previousEnumerateDirectories;
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
     [Fact]
     public void ResolveProjects_RejectsFallbackDiscoveryDirectoryTraversalLimit()
     {

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -86,6 +86,21 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void StopObservedJsonPhaseHeartbeat_CancelsPendingTaskWithoutBlocking_Issue3771()
+    {
+        var cts = new CancellationTokenSource();
+        var pending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var stopwatch = Stopwatch.StartNew();
+
+        IndexCommandRunner.StopObservedJsonPhaseHeartbeat((cts, pending.Task));
+
+        stopwatch.Stop();
+        Assert.True(cts.IsCancellationRequested);
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(1));
+        pending.SetResult();
+    }
+
+    [Fact]
     public void ParseArgs_HelpFlagSetsShowHelp()
     {
         var options = IndexCommandRunner.ParseArgs(["--help"]);

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2670,6 +2670,28 @@ public sealed class Caller
     }
 
     [Fact]
+    public void ResolveProjects_RejectsTooManySolutionLines_Issue3706()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_solution_line_count_limit");
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(projectRoot, "Repo.sln"),
+                string.Concat(Enumerable.Repeat("# comment\n", SolutionProjectResolver.MaxSolutionFileLines + 1)));
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => SolutionProjectResolver.ResolveProjects(projectRoot, "Repo.sln"));
+
+            Assert.Contains("solution file contains too many lines", ex.Message);
+            Assert.Contains(SolutionProjectResolver.MaxSolutionFileLines.ToString(CultureInfo.InvariantCulture), ex.Message);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void ResolveProjects_RejectsTooManySolutionProjectReferences_Issue3064()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_solution_project_limit");

--- a/tests/CodeIndex.Tests/IndexFreshnessCheckerTests.cs
+++ b/tests/CodeIndex.Tests/IndexFreshnessCheckerTests.cs
@@ -1,7 +1,10 @@
 using CodeIndex.Cli;
+using CodeIndex.Database;
+using CodeIndex.Indexer;
 
 namespace CodeIndex.Tests;
 
+[Collection("SQLite pool sensitive")]
 public class IndexFreshnessCheckerTests
 {
     [Fact]
@@ -36,5 +39,33 @@ public class IndexFreshnessCheckerTests
         var sample = IndexFreshnessChecker.FormatScanFailureSample("src/Broken.cs", exception);
 
         Assert.Equal("src/Broken.cs: probe-failed", sample);
+    }
+
+    [Fact]
+    public void Check_StampedPathCaseSensitivityAvoidsFilesystemWriteProbe_Issue3828()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_status_case_stamp");
+        var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+        var previousGitProbe = GitHelper.FileSystemIgnoreCaseProbeForTesting;
+        var previousIndexerProbe = FileIndexer.FileSystemIgnoreCaseProbeForTesting;
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(dbPath)!);
+            using var db = new DbContext(dbPath);
+            db.InitializeSchema();
+            var reader = new DbReader(db);
+            GitHelper.FileSystemIgnoreCaseProbeForTesting = _ => throw new IOException("git case probe should not run");
+            FileIndexer.FileSystemIgnoreCaseProbeForTesting = _ => throw new IOException("indexer case probe should not run");
+
+            var result = IndexFreshnessChecker.Check(reader, projectRoot, pathCaseSensitive: true);
+
+            Assert.True(result.Checked);
+        }
+        finally
+        {
+            GitHelper.FileSystemIgnoreCaseProbeForTesting = previousGitProbe;
+            FileIndexer.FileSystemIgnoreCaseProbeForTesting = previousIndexerProbe;
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
     }
 }

--- a/tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
@@ -226,6 +226,47 @@ public class IndexWatchRunnerTests
     }
 
     [Fact]
+    public void BuildPartialUpdateBatches_SplitsBeforeArgumentLimit_Issue3803()
+    {
+        var baseArgs = new List<string> { "/repo", "--json", "--quiet" };
+        var longPath = "/" + new string('a', IndexWatchRunner.MaxSubRunArgumentChars / 2);
+
+        var batches = IndexWatchRunner.BuildPartialUpdateBatches(
+            baseArgs,
+            [longPath + "1", longPath + "2", longPath + "3"]);
+
+        Assert.NotNull(batches);
+        Assert.Equal(3, batches.Count);
+        Assert.All(batches, batch => Assert.Single(batch));
+    }
+
+    [Fact]
+    public void BuildPartialUpdateBatches_OversizedSinglePathRequestsFullRescan_Issue3803()
+    {
+        var baseArgs = new List<string> { "/repo", "--json", "--quiet" };
+        var oversizedPath = "/" + new string('p', IndexWatchRunner.MaxSubRunArgumentChars);
+
+        var batches = IndexWatchRunner.BuildPartialUpdateBatches(baseArgs, [oversizedPath]);
+
+        Assert.Null(batches);
+    }
+
+    [Fact]
+    public void WatchSubRunCaptureWriter_CapsCaptureAndPreservesSpooledOutput_Issue3803()
+    {
+        using var spool = new StringWriter();
+        using var writer = new IndexWatchRunner.WatchSubRunCaptureWriter(10, spool);
+        var payload = new string('x', 32);
+
+        writer.Write(payload);
+        writer.Flush();
+
+        Assert.Equal(new string('x', 10), writer.CapturedText);
+        Assert.True(writer.Truncated);
+        Assert.Equal(payload, spool.ToString());
+    }
+
+    [Fact]
     public void BuildBatchPathSamples_BoundsLongRelativePaths_Issue3804()
     {
         var method = typeof(IndexWatchRunner).GetMethod("BuildBatchPathSamples", BindingFlags.NonPublic | BindingFlags.Static);

--- a/tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
+++ b/tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using System.Text.Json.Nodes;
 using CodeIndex.Cli;
 using CodeIndex.Database;
@@ -199,6 +200,35 @@ public class LegacySchemaMigrationTests : IDisposable
             """;
         cmd.ExecuteNonQuery();
         SqliteConnection.ClearAllPools();
+    }
+
+    private static long ReadForeignKeys(DbContext db)
+    {
+        using var cmd = db.Connection.CreateCommand();
+        cmd.CommandText = "PRAGMA foreign_keys";
+        return Convert.ToInt64(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+    }
+
+    private static void SetForeignKeys(DbContext db, bool enabled)
+    {
+        using var cmd = db.Connection.CreateCommand();
+        cmd.CommandText = $"PRAGMA foreign_keys={(enabled ? 1 : 0)}";
+        cmd.ExecuteNonQuery();
+    }
+
+    private static void InvokePrivateDbContextMethod(DbContext db, string methodName)
+    {
+        var method = typeof(DbContext).GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        try
+        {
+            method!.Invoke(db, parameters: null);
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException != null)
+        {
+            ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+        }
     }
 
     [Fact]
@@ -479,6 +509,90 @@ public class LegacySchemaMigrationTests : IDisposable
         => typeof(DbContext)
             .GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic)!
             .SetValue(db, value);
+
+    [Fact]
+    public void InitializeSchema_ForeignKeysRestoredWhenMigrationWindowFailsInsideTransaction_Issue3678()
+    {
+        using var db = new DbContext(_dbPath);
+        Assert.Equal(1, ReadForeignKeys(db));
+
+        var previousHook = DbContext.ForeignKeysDisabledForTesting;
+        DbContext.ForeignKeysDisabledForTesting = operation =>
+        {
+            if (operation == "EnsureKindCheckConstraintsCurrent")
+                throw new InvalidOperationException("injected kind-check migration failure");
+        };
+
+        try
+        {
+            var ex = Assert.Throws<InvalidOperationException>(db.InitializeSchema);
+
+            Assert.Contains("injected kind-check", ex.Message, StringComparison.Ordinal);
+            Assert.Equal(1, ReadForeignKeys(db));
+        }
+        finally
+        {
+            DbContext.ForeignKeysDisabledForTesting = previousHook;
+        }
+    }
+
+    [Fact]
+    public void MigrationWindow_ForeignKeysRestoredWhenFailureOccursOutsideActiveTransaction_Issue3678()
+    {
+        using var db = new DbContext(_dbPath);
+        db.InitializeSchema();
+        SetForeignKeys(db, enabled: false);
+        Assert.Equal(0, ReadForeignKeys(db));
+
+        var previousHook = DbContext.ForeignKeysDisabledForTesting;
+        DbContext.ForeignKeysDisabledForTesting = operation =>
+        {
+            if (operation == "EnsureKindCheckConstraintsCurrent")
+                throw new InvalidOperationException("injected direct migration failure");
+        };
+
+        try
+        {
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                InvokePrivateDbContextMethod(db, "EnsureKindCheckConstraintsCurrent"));
+
+            Assert.Contains("injected direct", ex.Message, StringComparison.Ordinal);
+            Assert.Equal(0, ReadForeignKeys(db));
+        }
+        finally
+        {
+            DbContext.ForeignKeysDisabledForTesting = previousHook;
+            SetForeignKeys(db, enabled: true);
+        }
+    }
+
+    [Fact]
+    public void InitializeSchema_ForeignKeyRestoreFailureReportsActionableDatabaseError_Issue3678()
+    {
+        using var db = new DbContext(_dbPath);
+        var previousHook = DbContext.ForeignKeysRestoringForTesting;
+        DbContext.ForeignKeysRestoringForTesting = (operation, _) =>
+        {
+            if (operation == "EnsureKindCheckConstraintsCurrent")
+                throw new InvalidOperationException("restore blocked");
+        };
+
+        try
+        {
+            var ex = Assert.Throws<CodeIndexException>(db.InitializeSchema);
+
+            Assert.Equal(CommandErrorCodes.DbError, ex.Code);
+            Assert.Equal(CodeIndexExceptionCategory.Database, ex.Category);
+            Assert.Contains("Failed to restore PRAGMA foreign_keys", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("EnsureKindCheckConstraintsCurrent", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("rerun the command", ex.Hint, StringComparison.OrdinalIgnoreCase);
+            Assert.IsType<InvalidOperationException>(ex.InnerException);
+        }
+        finally
+        {
+            DbContext.ForeignKeysRestoringForTesting = previousHook;
+        }
+    }
 
     [Fact]
     public void DbContext_ReadOnlyFilesystem_FallsBackToReadOnlyOpen()

--- a/tests/CodeIndex.Tests/McpAuditLogTests.cs
+++ b/tests/CodeIndex.Tests/McpAuditLogTests.cs
@@ -17,6 +17,7 @@ public class McpAuditLogTests : IDisposable
 {
     private readonly string _dbPath;
     private readonly string _auditPath;
+    private AuditLogSink? _activeAuditSink;
 
     public McpAuditLogTests()
     {
@@ -35,11 +36,17 @@ public class McpAuditLogTests : IDisposable
         }
     }
 
-    private McpServer CreateServer(AuditLogSink sink) =>
-        new(_dbPath, ConsoleUi.LoadVersion(), dbPathExplicit: false, sink);
+    private McpServer CreateServer(AuditLogSink sink)
+    {
+        _activeAuditSink = sink;
+        return new(_dbPath, ConsoleUi.LoadVersion(), dbPathExplicit: false, sink);
+    }
 
-    private McpServer CreateServerWithFilter(AuditLogSink sink, McpToolFilter filter) =>
-        new(_dbPath, ConsoleUi.LoadVersion(), dbPathExplicit: false, serializeResponse: null, authenticator: null, toolFilter: filter, auditLog: sink);
+    private McpServer CreateServerWithFilter(AuditLogSink sink, McpToolFilter filter)
+    {
+        _activeAuditSink = sink;
+        return new(_dbPath, ConsoleUi.LoadVersion(), dbPathExplicit: false, serializeResponse: null, authenticator: null, toolFilter: filter, auditLog: sink);
+    }
 
     [Fact]
     public void ToolsCall_Ping_EmitsAuditRecordWithCallerFromInitialize()
@@ -97,7 +104,7 @@ public class McpAuditLogTests : IDisposable
         var ping = JsonNode.Parse("""{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"ping","arguments":{}}}""")!;
         _ = server.HandleMessage(ping);
 
-        var rawLog = File.ReadAllText(_auditPath);
+        var rawLog = ReadAuditText();
         Assert.DoesNotContain(name, rawLog, StringComparison.Ordinal);
         Assert.DoesNotContain(version, rawLog, StringComparison.Ordinal);
         var record = ReadOnlyRecord();
@@ -151,7 +158,7 @@ public class McpAuditLogTests : IDisposable
         AssertJsonNullId(response);
         if (File.Exists(_auditPath))
         {
-            var rawLog = File.ReadAllText(_auditPath);
+            var rawLog = ReadAuditText();
             Assert.DoesNotContain(oversizedId, rawLog, StringComparison.Ordinal);
             Assert.True(string.IsNullOrWhiteSpace(rawLog), "oversized request ids must be rejected before tool audit emission");
         }
@@ -252,7 +259,7 @@ public class McpAuditLogTests : IDisposable
         var response = server.HandleMessage(request)!;
 
         Assert.Equal(-32602, response["error"]!["code"]!.GetValue<int>());
-        var rawLog = File.ReadAllText(_auditPath);
+        var rawLog = ReadAuditText();
         Assert.DoesNotContain(toolName, rawLog, StringComparison.Ordinal);
         var record = ReadOnlyRecord();
         Assert.Equal(display.Text, record.GetProperty("tool").GetString());
@@ -288,7 +295,7 @@ public class McpAuditLogTests : IDisposable
 
         Assert.False(response.AsObject().ContainsKey("error"));
         Assert.NotNull(response["result"]);
-        var rawLog = File.ReadAllText(_auditPath);
+        var rawLog = ReadAuditText();
         Assert.DoesNotContain(argumentName, rawLog, StringComparison.Ordinal);
         var record = ReadOnlyRecord();
         Assert.Equal(display.Text, record.GetProperty("arg_keys")[1].GetString());
@@ -341,7 +348,7 @@ public class McpAuditLogTests : IDisposable
         };
         _ = server.HandleMessage(unknown);
 
-        var rawLog = File.ReadAllText(_auditPath);
+        var rawLog = ReadAuditText();
         Assert.DoesNotContain(token, rawLog, StringComparison.Ordinal);
         Assert.DoesNotContain("user:pass", rawLog, StringComparison.Ordinal);
 
@@ -379,7 +386,7 @@ public class McpAuditLogTests : IDisposable
 
         _ = server.HandleMessage(request);
 
-        var rawLog = File.ReadAllText(_auditPath);
+        var rawLog = ReadAuditText();
         Assert.DoesNotContain(longQuery, rawLog, StringComparison.Ordinal);
         var record = ReadOnlyRecord();
         Assert.True(record.GetProperty("arg_values_truncated").GetBoolean());
@@ -488,7 +495,7 @@ public class McpAuditLogTests : IDisposable
 
         Assert.False(response.AsObject().ContainsKey("error"));
         Assert.NotNull(response["result"]);
-        var rawLog = File.ReadAllText(_auditPath);
+        var rawLog = ReadAuditText();
         Assert.DoesNotContain("request_id_truncated", rawLog, StringComparison.Ordinal);
         var record = ReadOnlyRecord();
         Assert.Equal(serializedId, record.GetProperty("request_id").GetString());
@@ -570,12 +577,46 @@ public class McpAuditLogTests : IDisposable
 
         _ = server.HandleMessage(request);
 
-        var rawLog = File.ReadAllText(_auditPath);
+        var rawLog = ReadAuditText();
         Assert.DoesNotContain(secret, rawLog, StringComparison.Ordinal);
         var record = ReadOnlyRecord();
         Assert.Equal(display.Text, record.GetProperty("arg_keys")[0].GetString());
         Assert.Equal(AuditLogSink.RedactedValue, record.GetProperty("arg_values").GetProperty(display.Text).GetString());
         Assert.True(record.GetProperty("arg_values_redacted").GetBoolean());
+    }
+
+    [Fact]
+    public void Record_DropsWhenQueueSaturated_Issue3747()
+    {
+        using var writerEntered = new ManualResetEventSlim();
+        using var releaseWriter = new ManualResetEventSlim();
+        using var sink = new AuditLogSink(_auditPath, AuditLogSink.DefaultMaxBytes, includeValues: false, queueCapacity: 1);
+        sink.BeforeWriteForTests = () =>
+        {
+            writerEntered.Set();
+            releaseWriter.Wait();
+        };
+
+        try
+        {
+            sink.Record(CreateAuditEvent("first"));
+            Assert.True(writerEntered.Wait(TimeSpan.FromSeconds(5)), "audit writer should enter the blocking hook");
+
+            sink.Record(CreateAuditEvent("second"));
+            sink.Record(CreateAuditEvent("third"));
+
+            var diagnostics = WaitForAuditQueueFullDrop(sink);
+            Assert.True(diagnostics.DroppedRecordCount > 0);
+            Assert.True(diagnostics.QueueFullDropCount > 0);
+            Assert.Equal(1, diagnostics.QueueCapacity);
+            Assert.True(diagnostics.QueueDepth > 0);
+            Assert.Contains("queue_full", diagnostics.LastDropReason, StringComparison.Ordinal);
+        }
+        finally
+        {
+            releaseWriter.Set();
+            Assert.True(sink.WaitForIdle(TimeSpan.FromSeconds(5)), "audit log writer did not drain after release");
+        }
     }
 
     [Fact]
@@ -662,10 +703,55 @@ public class McpAuditLogTests : IDisposable
 
     private JsonElement ReadOnlyRecord()
     {
+        WaitForAuditLogIdle();
         var lines = File.ReadAllLines(_auditPath);
         Assert.Single(lines);
         return JsonDocument.Parse(lines[0]).RootElement.Clone();
     }
+
+    private string ReadAuditText()
+    {
+        WaitForAuditLogIdle();
+        return File.ReadAllText(_auditPath);
+    }
+
+    private void WaitForAuditLogIdle()
+    {
+        if (_activeAuditSink is not null)
+            Assert.True(_activeAuditSink.WaitForIdle(TimeSpan.FromSeconds(5)), "audit log writer did not drain within the expected timeout");
+    }
+
+    private static AuditLogSink.AuditLogDiagnostics WaitForAuditQueueFullDrop(AuditLogSink sink)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        AuditLogSink.AuditLogDiagnostics diagnostics;
+        do
+        {
+            diagnostics = sink.SnapshotDiagnostics();
+            if (diagnostics.QueueFullDropCount > 0)
+                return diagnostics;
+
+            Thread.Sleep(10);
+        }
+        while (DateTimeOffset.UtcNow < deadline);
+
+        Assert.Fail("Expected audit log queue saturation to drop at least one record.");
+        return diagnostics;
+    }
+
+    private static AuditLogSink.AuditEvent CreateAuditEvent(string tool) => new(
+        Timestamp: DateTimeOffset.UtcNow,
+        Tool: tool,
+        CallerName: null,
+        CallerVersion: null,
+        RequestId: null,
+        ArgKeys: Array.Empty<string>(),
+        ArgLengths: Array.Empty<KeyValuePair<string, int>>(),
+        ArgValues: null,
+        ResultCount: null,
+        ElapsedMs: 0,
+        ErrorCode: 0,
+        ErrorType: null);
 
     private static void AssertJsonNullId(JsonNode response)
     {

--- a/tests/CodeIndex.Tests/McpServerHistogramTests.cs
+++ b/tests/CodeIndex.Tests/McpServerHistogramTests.cs
@@ -1,7 +1,7 @@
 using System.Reflection;
 using System.Text.Json.Nodes;
+using CodeIndex.Database;
 using CodeIndex.Mcp;
-using CodeIndex.Models;
 
 namespace CodeIndex.Tests;
 

--- a/tests/CodeIndex.Tests/McpServerHistogramTests.cs
+++ b/tests/CodeIndex.Tests/McpServerHistogramTests.cs
@@ -1,0 +1,37 @@
+using System.Reflection;
+using System.Text.Json.Nodes;
+using CodeIndex.Mcp;
+using CodeIndex.Models;
+
+namespace CodeIndex.Tests;
+
+public sealed class McpServerHistogramTests
+{
+    [Fact]
+    public void BuildTopFileHistogram_OrdersCountsDeterministically_Issue3782()
+    {
+        using var server = new McpServer(
+            Path.Combine(Path.GetTempPath(), $"cdidx_mcp_histogram_{Guid.NewGuid():N}.db"),
+            "test");
+        var method = typeof(McpServer).GetMethod("BuildTopFileHistogram", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        var generic = method!.MakeGenericMethod(typeof(SearchResult));
+        var results = new[]
+        {
+            new SearchResult { Path = "src/b.cs" },
+            new SearchResult { Path = "src/a.cs" },
+            new SearchResult { Path = "src/b.cs" },
+            new SearchResult { Path = "src/c.cs" },
+            new SearchResult { Path = "src/c.cs" },
+        };
+
+        var histogram = Assert.IsType<JsonArray>(generic.Invoke(server, [results, new Func<SearchResult, string?>(result => result.Path)]));
+
+        Assert.Equal("src/b.cs", histogram[0]!["path"]!.GetValue<string>());
+        Assert.Equal(2, histogram[0]!["count"]!.GetValue<int>());
+        Assert.Equal("src/c.cs", histogram[1]!["path"]!.GetValue<string>());
+        Assert.Equal(2, histogram[1]!["count"]!.GetValue<int>());
+        Assert.Equal("src/a.cs", histogram[2]!["path"]!.GetValue<string>());
+        Assert.Equal(1, histogram[2]!["count"]!.GetValue<int>());
+    }
+}

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -110,6 +110,31 @@ public class McpServerTests : IDisposable
         Assert.False(MethodCallsType(method!, typeof(SpinWait)));
     }
 
+    [Fact]
+    public void BuildTopFileHistogram_OrdersCountsDeterministically_Issue3782()
+    {
+        var method = typeof(McpServer).GetMethod("BuildTopFileHistogram", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+        var generic = method!.MakeGenericMethod(typeof(SearchResult));
+        var results = new[]
+        {
+            new SearchResult { Path = "src/b.cs" },
+            new SearchResult { Path = "src/a.cs" },
+            new SearchResult { Path = "src/b.cs" },
+            new SearchResult { Path = "src/c.cs" },
+            new SearchResult { Path = "src/c.cs" },
+        };
+
+        var histogram = Assert.IsType<JsonArray>(generic.Invoke(_server, [results, new Func<SearchResult, string?>(result => result.Path)]));
+
+        Assert.Equal("src/b.cs", histogram[0]!["path"]!.GetValue<string>());
+        Assert.Equal(2, histogram[0]!["count"]!.GetValue<int>());
+        Assert.Equal("src/c.cs", histogram[1]!["path"]!.GetValue<string>());
+        Assert.Equal(2, histogram[1]!["count"]!.GetValue<int>());
+        Assert.Equal("src/a.cs", histogram[2]!["path"]!.GetValue<string>());
+        Assert.Equal(1, histogram[2]!["count"]!.GetValue<int>());
+    }
+
     private static bool MethodCallsType(MethodInfo method, Type declaringType)
     {
         var body = method.GetMethodBody()?.GetILAsByteArray();

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -111,31 +111,6 @@ public class McpServerTests : IDisposable
         Assert.False(MethodCallsType(method!, typeof(SpinWait)));
     }
 
-    [Fact]
-    public void BuildTopFileHistogram_OrdersCountsDeterministically_Issue3782()
-    {
-        var method = typeof(McpServer).GetMethod("BuildTopFileHistogram", BindingFlags.NonPublic | BindingFlags.Instance);
-        Assert.NotNull(method);
-        var generic = method!.MakeGenericMethod(typeof(SearchResult));
-        var results = new[]
-        {
-            new SearchResult { Path = "src/b.cs" },
-            new SearchResult { Path = "src/a.cs" },
-            new SearchResult { Path = "src/b.cs" },
-            new SearchResult { Path = "src/c.cs" },
-            new SearchResult { Path = "src/c.cs" },
-        };
-
-        var histogram = Assert.IsType<JsonArray>(generic.Invoke(_server, [results, new Func<SearchResult, string?>(result => result.Path)]));
-
-        Assert.Equal("src/b.cs", histogram[0]!["path"]!.GetValue<string>());
-        Assert.Equal(2, histogram[0]!["count"]!.GetValue<int>());
-        Assert.Equal("src/c.cs", histogram[1]!["path"]!.GetValue<string>());
-        Assert.Equal(2, histogram[1]!["count"]!.GetValue<int>());
-        Assert.Equal("src/a.cs", histogram[2]!["path"]!.GetValue<string>());
-        Assert.Equal(1, histogram[2]!["count"]!.GetValue<int>());
-    }
-
     private static bool MethodCallsType(MethodInfo method, Type declaringType)
     {
         var body = method.GetMethodBody()?.GetILAsByteArray();

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -111,6 +111,50 @@ public class McpServerTests : IDisposable
         Assert.False(MethodCallsType(method!, typeof(SpinWait)));
     }
 
+    [Fact]
+    public void PruneCompletedRequestTasks_RemovesCompletedTasks_Issue3837()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var pending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var tasks = new List<Task>
+        {
+            Task.CompletedTask,
+            pending.Task,
+            Task.FromCanceled(cts.Token),
+        };
+
+        var removed = McpServer.PruneCompletedRequestTasks(tasks);
+
+        Assert.Equal(2, removed);
+        Assert.Same(pending.Task, Assert.Single(tasks));
+    }
+
+    [Fact]
+    public void PruneCompletedRequestTasks_ObservesFaultedTasks_Issue3837()
+    {
+        var pending = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var faulted = Task.FromException(new InvalidOperationException("boom"));
+        var tasks = new List<Task> { pending.Task, faulted };
+        var originalError = Console.Error;
+        using var stderr = new StringWriter();
+        Console.SetError(stderr);
+
+        int removed;
+        try
+        {
+            removed = McpServer.PruneCompletedRequestTasks(tasks);
+        }
+        finally
+        {
+            Console.SetError(originalError);
+        }
+
+        Assert.Equal(1, removed);
+        Assert.Same(pending.Task, Assert.Single(tasks));
+        Assert.Contains("In-flight request ended before EOF drain (InvalidOperationException)", stderr.ToString(), StringComparison.Ordinal);
+    }
+
     private static bool MethodCallsType(MethodInfo method, Type declaringType)
     {
         var body = method.GetMethodBody()?.GetILAsByteArray();

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -10298,6 +10298,49 @@ public sealed class Caller
         Assert.True(results[2]!["ok"]!.GetValue<bool>());
     }
 
+    [Theory]
+    [InlineData("\"twenty\"", "string")]
+    [InlineData("{}", "object")]
+    [InlineData("[]", "array")]
+    public void ToolsCall_NumericArgumentsRejectWrongJsonShapes_Issue3791(string limitJson, string expectedActual)
+    {
+        var request = JsonNode.Parse(
+            """{"jsonrpc":"2.0","id":3791,"method":"tools/call","params":{"name":"search","arguments":{"query":"App","limit":"""
+            + limitJson
+            + """}}}""")!;
+
+        var response = _server.HandleMessage(request)!;
+
+        var error = response["error"]!;
+        Assert.Equal(-32602, error["code"]!.GetValue<int>());
+        Assert.Contains("Invalid type for argument 'limit'", error["message"]!.GetValue<string>(), StringComparison.Ordinal);
+        var data = error["data"]!;
+        Assert.Equal("limit", data["parameter"]!.GetValue<string>());
+        Assert.Equal("integer", data["expected"]!.GetValue<string>());
+        Assert.Equal(expectedActual, data["actual"]!.GetValue<string>());
+    }
+
+    [Theory]
+    [InlineData("\"not an array\"", "string")]
+    [InlineData("{}", "object")]
+    public void ToolsCall_BatchQueryRejectsNonArrayQueries_Issue3791(string queriesJson, string expectedActual)
+    {
+        var request = JsonNode.Parse(
+            """{"jsonrpc":"2.0","id":3791,"method":"tools/call","params":{"name":"batch_query","arguments":{"queries":"""
+            + queriesJson
+            + """}}}""")!;
+
+        var response = _server.HandleMessage(request)!;
+
+        var error = response["error"]!;
+        Assert.Equal(-32602, error["code"]!.GetValue<int>());
+        Assert.Contains("Invalid type for argument 'queries'", error["message"]!.GetValue<string>(), StringComparison.Ordinal);
+        var data = error["data"]!;
+        Assert.Equal("queries", data["parameter"]!.GetValue<string>());
+        Assert.Equal("array", data["expected"]!.GetValue<string>());
+        Assert.Equal(expectedActual, data["actual"]!.GetValue<string>());
+    }
+
     [Fact]
     public void ToolsCall_BatchQuery_ReportsMalformedSlotsAndActualExecutionCounts_Issue1838_1992_1994()
     {

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Runtime.InteropServices;
@@ -1407,23 +1408,59 @@ public class ProgramRunnerTests
     }
 
     [Fact]
-    public void CreateInstallerProcessStartInfo_UsesArgumentList()
+    public void CreateInstallerProcessStartInfo_UsesExplicitLaunchContract_Issue3685()
     {
         if (OperatingSystem.IsWindows())
             return;
 
+        var root = Path.Combine(Path.GetTempPath(), $"cdidx installer launch {Guid.NewGuid():N}");
+        var script = Path.Combine(root, "install script's path.sh");
         var startInfo = ProgramRunner.CreateInstallerProcessStartInfo(
-            "/tmp/install script's path.sh",
-            "v1.27.0",
-            "/opt/cdidx install");
+            script,
+            "v1.27.0-rc.1",
+            "/opt/cdidx install & safe");
 
         Assert.True(Path.IsPathFullyQualified(startInfo.FileName));
         Assert.Equal("bash", Path.GetFileName(startInfo.FileName));
         Assert.NotEqual("bash", startInfo.FileName);
         Assert.False(startInfo.UseShellExecute);
+        Assert.False(startInfo.RedirectStandardOutput);
+        Assert.False(startInfo.RedirectStandardError);
         Assert.Equal(string.Empty, startInfo.Arguments);
-        Assert.Equal(["/tmp/install script's path.sh", "v1.27.0"], startInfo.ArgumentList.ToArray());
-        Assert.Equal("/opt/cdidx install", startInfo.Environment["CDIDX_INSTALL_DIR"]);
+        Assert.Equal(Path.GetFullPath(root), startInfo.WorkingDirectory);
+        Assert.Equal([Path.GetFullPath(script), "v1.27.0-rc.1"], startInfo.ArgumentList.ToArray());
+        Assert.Equal("/opt/cdidx install & safe", startInfo.Environment["CDIDX_INSTALL_DIR"]);
+    }
+
+    [Fact]
+    public void RunInstallerProcess_StartFailureReturnsInstallError_Issue3685()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"cdidx_installer_start_{Guid.NewGuid():N}");
+            Directory.CreateDirectory(root);
+            try
+            {
+                var startInfo = new ProcessStartInfo
+                {
+                    FileName = Path.Combine(root, "missing-installer-shell"),
+                    UseShellExecute = false,
+                };
+                startInfo.ArgumentList.Add(Path.Combine(root, "install script.sh"));
+
+                var (exitCode, stdout, stderr) = CaptureConsole(() =>
+                    ProgramRunner.RunInstallerProcess(startInfo, TimeSpan.FromSeconds(10)));
+
+                Assert.Equal(CommandExitCodes.InstallError, exitCode);
+                Assert.Empty(stdout);
+                Assert.Contains("failed to start install.sh for upgrade", stderr);
+                Assert.Contains("rerun `install.sh` manually", stderr);
+            }
+            finally
+            {
+                TestProjectHelper.DeleteDirectory(root);
+            }
+        }
     }
 
     [Fact]
@@ -1895,6 +1932,7 @@ exit 7
             var checksumManifest = $"{installerSha256}  install.sh\n";
             var previousFactory = ProgramRunner.UpgradeHttpClientFactory;
             var previousDelete = ProgramRunner.DeleteUpgradeInstallerDirectoryForTesting;
+            string? cleanupDirectory = null;
             ProgramRunner.UpgradeHttpClientFactory = () => new HttpClient(
                 new UpgradeAssetResponseHandler(
                     checksumManifest,
@@ -1903,7 +1941,11 @@ exit 7
             {
                 Timeout = Timeout.InfiniteTimeSpan,
             };
-            ProgramRunner.DeleteUpgradeInstallerDirectoryForTesting = _ => throw new IOException("directory delete denied");
+            ProgramRunner.DeleteUpgradeInstallerDirectoryForTesting = path =>
+            {
+                cleanupDirectory = path;
+                throw new IOException("directory delete denied");
+            };
 
             try
             {
@@ -1916,11 +1958,15 @@ exit 7
                 Assert.True(doc.RootElement.GetProperty("install_succeeded").GetBoolean());
                 Assert.Contains("Warning: failed to delete upgrade installer temporary directory", stderr);
                 Assert.Contains("IOException", stderr);
+                Assert.NotNull(cleanupDirectory);
+                Assert.True(Directory.Exists(cleanupDirectory));
             }
             finally
             {
                 ProgramRunner.UpgradeHttpClientFactory = previousFactory;
                 ProgramRunner.DeleteUpgradeInstallerDirectoryForTesting = previousDelete;
+                if (cleanupDirectory != null)
+                    TestProjectHelper.DeleteDirectory(cleanupDirectory);
                 TestProjectHelper.DeleteDirectory(cacheRoot);
             }
         }
@@ -2027,6 +2073,141 @@ exit 7
         {
             if (File.Exists(path))
                 File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void TryCheckInstallDirectoryWritable_RootPathRejected_Issue3733()
+    {
+        var rootPath = Path.GetPathRoot(Path.GetFullPath(Path.GetTempPath()));
+        Assert.False(string.IsNullOrEmpty(rootPath));
+
+        var writable = ProgramRunner.TryCheckInstallDirectoryWritable(rootPath!, out var diagnostic);
+
+        Assert.False(writable);
+        Assert.Contains("filesystem root", diagnostic, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryCheckInstallDirectoryWritable_SymlinkRejected_Issue3733()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), $"cdidx_install_dir_link_{Guid.NewGuid():N}");
+        var target = Path.Combine(root, "target");
+        var link = Path.Combine(root, "link");
+        try
+        {
+            Directory.CreateDirectory(target);
+            Directory.CreateSymbolicLink(link, target);
+
+            var writable = ProgramRunner.TryCheckInstallDirectoryWritable(link, out var diagnostic);
+
+            Assert.False(writable);
+            Assert.Contains("symbolic link", diagnostic, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(link))
+                Directory.Delete(link);
+            TestProjectHelper.DeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void TryCheckInstallDirectoryWritable_GroupWritableDirectoryRejected_Issue3733()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var path = Path.Combine(Path.GetTempPath(), $"cdidx_install_dir_mode_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(path);
+            File.SetUnixFileMode(
+                path,
+                DataDirectorySecurity.PrivateDirectoryMode | UnixFileMode.GroupWrite);
+
+            var writable = ProgramRunner.TryCheckInstallDirectoryWritable(path, out var diagnostic);
+
+            Assert.False(writable);
+            Assert.Contains("group- or world-writable", diagnostic, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(path))
+                File.SetUnixFileMode(path, DataDirectorySecurity.PrivateDirectoryMode);
+            TestProjectHelper.DeleteDirectory(path);
+        }
+    }
+
+    [Fact]
+    public void TryValidateUpgradeInstallerDirectoryCleanupTarget_RejectsOutsideTempRoot_Issue3659()
+    {
+        var tempRoot = Path.GetFullPath(Path.GetTempPath());
+        var outside = Path.GetPathRoot(tempRoot);
+        Assert.False(string.IsNullOrEmpty(outside));
+        if (string.Equals(
+                Path.TrimEndingDirectorySeparator(tempRoot),
+                Path.TrimEndingDirectorySeparator(outside!),
+                OperatingSystem.IsWindows() || OperatingSystem.IsMacOS()
+                    ? StringComparison.OrdinalIgnoreCase
+                    : StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        var valid = ProgramRunner.TryValidateUpgradeInstallerDirectoryCleanupTarget(
+            outside!,
+            out _,
+            out var failureReason);
+
+        Assert.False(valid);
+        Assert.Contains("outside the expected cleanup root", failureReason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryValidateUpgradeInstallerDirectoryCleanupTarget_RejectsUnexpectedPrefix_Issue3659()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"cdidx-other-{Guid.NewGuid():N}");
+
+        var valid = ProgramRunner.TryValidateUpgradeInstallerDirectoryCleanupTarget(
+            path,
+            out _,
+            out var failureReason);
+
+        Assert.False(valid);
+        Assert.Contains("expected upgrade temporary-directory prefix", failureReason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TryValidateUpgradeInstallerDirectoryCleanupTarget_RejectsSymlink_Issue3659()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), $"cdidx_cleanup_link_{Guid.NewGuid():N}");
+        var target = Path.Combine(root, "target");
+        var link = Path.Combine(Path.GetTempPath(), $"cdidx-install-link-{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(target);
+            Directory.CreateSymbolicLink(link, target);
+
+            var valid = ProgramRunner.TryValidateUpgradeInstallerDirectoryCleanupTarget(
+                link,
+                out _,
+                out var failureReason);
+
+            Assert.False(valid);
+            Assert.Contains("symbolic link", failureReason, StringComparison.Ordinal);
+        }
+        finally
+        {
+            if (Directory.Exists(link))
+                Directory.Delete(link);
+            TestProjectHelper.DeleteDirectory(root);
         }
     }
 

--- a/tests/CodeIndex.Tests/QueryCommandRunnerGraphTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerGraphTests.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using System.Text.Json;
 using CodeIndex.Cli;
 using CodeIndex.Database;
@@ -103,6 +104,92 @@ public partial class QueryCommandRunnerTests
         Assert.Contains("--depth must be less than or equal to 64", stderr);
         Assert.Contains($"Usage: {ConsoleUi.GetUsageLine("impact")}", stderr);
         Assert.DoesNotContain("database not found", stderr);
+    }
+
+    [Fact]
+    public void GetTransitiveCallers_MaxDepthBoundaryProbeBudgetTerminatesStably_Issue3820()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_impact_boundary_probe_budget");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            using var db = new DbContext(dbPath);
+            var writer = new DbWriter(db.Connection);
+            var fileId = writer.UpsertFile(new FileRecord
+            {
+                Path = "src/Dense.cs",
+                Lang = "csharp",
+                Size = 1,
+                Lines = 1,
+                Modified = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            });
+
+            var references = new List<ReferenceRecord>();
+            for (var i = 0; i < ImpactBoundaryCallerProbeSourceCount(); i++)
+            {
+                references.Add(new ReferenceRecord
+                {
+                    FileId = fileId,
+                    SymbolName = "Root",
+                    ReferenceKind = "call",
+                    Line = i + 1,
+                    Column = 1,
+                    Context = $"Caller{i}();",
+                    ContainerKind = "function",
+                    ContainerName = $"Caller{i}",
+                });
+
+                if (i == 0)
+                    continue;
+
+                references.Add(new ReferenceRecord
+                {
+                    FileId = fileId,
+                    SymbolName = "Caller0",
+                    ReferenceKind = "call",
+                    Line = i + 1,
+                    Column = 1,
+                    Context = $"Caller{i}();",
+                    ContainerKind = "function",
+                    ContainerName = $"Caller{i}",
+                });
+            }
+
+            writer.InsertReferences(references);
+            writer.MarkGraphReady();
+            using var reader = new DbReader(db.Connection);
+            var visited = Enumerable.Range(1, ImpactBoundaryCallerProbeSourceCount() - 1)
+                .Select(i => $"src/Dense.cs:Caller{i}:call")
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            var method = typeof(DbReader).GetMethod("InspectBoundaryCallers", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(method);
+
+            var inspection = method!.Invoke(reader,
+            [
+                "Caller0",
+                "Root",
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                visited,
+                new Dictionary<string, HashSet<string>>(StringComparer.OrdinalIgnoreCase),
+                new List<ImpactCycleResult>(),
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+                "csharp",
+                null,
+                null,
+                false,
+            ]);
+            Assert.NotNull(inspection);
+            var type = inspection!.GetType();
+
+            Assert.True((bool)type.GetProperty("HasUnvisitedCaller")!.GetValue(inspection)!);
+            Assert.True((bool)type.GetProperty("ProbeBudgetHit")!.GetValue(inspection)!);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+
+        static int ImpactBoundaryCallerProbeSourceCount() => DbReader.ImpactBoundaryCallerProbeBudget + 100;
     }
 
     [Theory]

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -1559,6 +1559,104 @@ public partial class QueryCommandRunnerTests
         }
     }
 
+    [Fact]
+    public void RunSearch_ExternalRecipeCountValidationReportsBoundedDiagnostic_Issue3751()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_recipe_count_3751");
+        try
+        {
+            var recipePath = Path.Combine(projectRoot, "many-recipes.json");
+            var recipes = Enumerable.Range(0, 33)
+                .Select(index => $$"""
+                    {
+                      "name": "local-audit-{{index}}",
+                      "description": "Exercise count validation.",
+                      "queries": [
+                        {
+                          "name": "marker-{{index}}",
+                          "query": "Marker{{index}}",
+                          "description": "Find the configured marker."
+                        }
+                      ]
+                    }
+                    """);
+            File.WriteAllText(recipePath, "[" + string.Join(",", recipes) + "]");
+
+            using var env = EnvironmentVariableScope.Capture(SearchAuditRecipes.RecipePathsEnvironmentVariable);
+            env.Set(SearchAuditRecipes.RecipePathsEnvironmentVariable, recipePath);
+
+            var registry = SearchAuditRecipes.Load();
+
+            Assert.Contains(
+                "recipe source #1 has more than 32 recipes; extra entries are ignored.",
+                registry.Diagnostics);
+            Assert.DoesNotContain(registry.Recipes, recipe => recipe.Name == "local-audit-32");
+            Assert.Contains(registry.Recipes, recipe => recipe.Name == "local-audit-31");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunSearch_ExternalRecipeQueryAndLabelValidationReportsBoundedDiagnostics_Issue3751()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_recipe_query_label_3751");
+        try
+        {
+            var recipePath = Path.Combine(projectRoot, "invalid-recipes.json");
+            var longQuery = new string('q', QueryLimits.MaxQueryLength + 1);
+            var longLabel = new string('l', 65);
+            File.WriteAllText(
+                recipePath,
+                $$"""
+                [
+                  {
+                    "name": "local-audit",
+                    "description": "Exercise query and label validation.",
+                    "queries": [
+                      {
+                        "name": "too-long-query",
+                        "query": "{{longQuery}}",
+                        "description": "This query should be rejected."
+                      },
+                      {
+                        "name": "bounded-labels",
+                        "query": "BoundedNeedle",
+                        "description": "This query should keep only valid labels.",
+                        "recommended_labels": ["audit", "{{longLabel}}", ""]
+                      }
+                    ]
+                  }
+                ]
+                """);
+
+            using var env = EnvironmentVariableScope.Capture(SearchAuditRecipes.RecipePathsEnvironmentVariable);
+            env.Set(SearchAuditRecipes.RecipePathsEnvironmentVariable, recipePath);
+
+            var registry = SearchAuditRecipes.Load();
+
+            Assert.Contains(
+                $"recipe source #1 item #1 field 'query' exceeds {QueryLimits.MaxQueryLength} characters.",
+                registry.Diagnostics);
+            Assert.Contains(
+                "recipe source #1 recipe 'local-audit' query 'bounded-labels' label #2 exceeds 64 characters.",
+                registry.Diagnostics);
+            Assert.Contains(
+                "recipe source #1 recipe 'local-audit' query 'bounded-labels' label #3 must be a non-empty string.",
+                registry.Diagnostics);
+            var recipe = Assert.Single(registry.Recipes.Where(recipe => recipe.Name == "local-audit"));
+            var query = Assert.Single(recipe.Queries);
+            Assert.Equal("bounded-labels", query.Name);
+            Assert.Equal(["audit"], query.RecommendedLabels);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
     [Theory]
     [InlineData("count")]
     [InlineData("csv")]

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -1585,6 +1585,22 @@ public partial class QueryCommandRunnerTests
         Assert.Contains("--json=array is not supported with --list-recipes", stderr);
     }
 
+    [Theory]
+    [InlineData("NaN:1:0")]
+    [InlineData("Infinity:1:0")]
+    [InlineData("1:-1:0")]
+    [InlineData("1:1:-1")]
+    public void RunSearch_RecipeInvalidCursorDomain_ReturnsUsageError_Issue3837(string cursor)
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+            ["--recipe", "risky-code/raw-diagnostic-echo", "--cursor", cursor],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("--cursor", stderr, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void RunSearch_RecipeJsonRunsBuiltInQueries_Issue3144()
     {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -11,6 +11,38 @@ namespace CodeIndex.Tests;
 public partial class QueryCommandRunnerTests
 {
     [Fact]
+    public void RunSearch_GroupByFileCountStreamsFileCounts_Issue3741()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_group_by_file_count");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/b.cs", "csharp", "Needle();\nNeedle();\n");
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/a.cs", "csharp", "Needle();\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["Needle", "--db", dbPath, "--exact-substring", "--group-by", "file", "--count", "--json"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = ParseJsonOutput(stdout);
+            var root = document.RootElement;
+            Assert.Equal(2, root.GetProperty("count").GetInt32());
+            Assert.Equal(2, root.GetProperty("files").GetInt32());
+            var groups = root.GetProperty("groups").EnumerateArray().ToArray();
+            Assert.Equal("src/a.cs", groups[0].GetProperty("file").GetString());
+            Assert.Equal(1, groups[0].GetProperty("count").GetInt32());
+            Assert.Equal("src/b.cs", groups[1].GetProperty("file").GetString());
+            Assert.Equal(1, groups[1].GetProperty("count").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunSearch_JsonIncludesMatchOrigins_Issue3423()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_match_origins");

--- a/tests/CodeIndex.Tests/SearchSnippetFormatterTests.cs
+++ b/tests/CodeIndex.Tests/SearchSnippetFormatterTests.cs
@@ -274,6 +274,34 @@ public class SearchSnippetFormatterTests
     }
 
     [Fact]
+    public void BuildExcerpt_PreferredMatchLineScanIsBounded_Issue3742()
+    {
+        var content = string.Join('\n', Enumerable.Range(1, SearchSnippetFormatter.MaxPreferredMatchScanLines + 100)
+            .Select(_ => "Target"));
+
+        var excerpt = SearchSnippetFormatter.BuildExcerpt(
+            content,
+            "Target",
+            absoluteStartLine: 1,
+            maxLines: 3,
+            preferredMatchLine: SearchSnippetFormatter.MaxPreferredMatchScanLines + 50);
+
+        Assert.Equal(1, excerpt.FocusLine);
+        Assert.Equal(SearchSnippetFormatter.MaxPreferredMatchScanLines - 3, excerpt.DroppedMatchLineCount);
+
+        var scan = InvokeFindMatchingLineIndexes(
+            content,
+            "Target",
+            [],
+            caseSensitive: false,
+            normalizeCSharpVerbatimNames: false,
+            maxTrackedWindowLines: SearchSnippetFormatter.MaxPreferredMatchScanLines,
+            maxScannedLines: SearchSnippetFormatter.MaxPreferredMatchScanLines,
+            maxScannedChars: int.MaxValue);
+        Assert.Equal(SearchSnippetFormatter.MaxPreferredMatchScanLines, scan.TotalMatchCount);
+    }
+
+    [Fact]
     public void ToCompactResults_PreparedQueryContextRemainsLanguageAwareAcrossResults()
     {
         var context = SearchSnippetFormatter.PrepareQueryContext("Foo.Bar");
@@ -539,12 +567,14 @@ public class SearchSnippetFormatterTests
         string[] tokens,
         bool caseSensitive,
         bool normalizeCSharpVerbatimNames,
-        int maxTrackedWindowLines)
+        int maxTrackedWindowLines,
+        int maxScannedLines = int.MaxValue,
+        int maxScannedChars = int.MaxValue)
     {
         var method = typeof(SearchSnippetFormatter).GetMethod("FindMatchingLineIndexes", BindingFlags.Static | BindingFlags.NonPublic);
         Assert.NotNull(method);
 
-        var scan = method.Invoke(null, [content, query, tokens, caseSensitive, normalizeCSharpVerbatimNames, maxTrackedWindowLines]);
+        var scan = method.Invoke(null, [content, query, tokens, caseSensitive, normalizeCSharpVerbatimNames, maxTrackedWindowLines, maxScannedLines, maxScannedChars]);
         Assert.NotNull(scan);
 
         var type = scan!.GetType();

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -19511,6 +19511,30 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void Extract_TypeScript_TsconfigWarningSanitizesConfigPath_Issue3819()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("tsconfig_alias_sanitize_symbols");
+        try
+        {
+            WriteFile(projectRoot, "tsconfig.json", "{ invalid json");
+            var sourcePath = WriteFile(projectRoot, "src/main.ts", "import { Button } from \"@/components/Button\";\n");
+
+            List<SymbolRecord> symbols = [];
+            var stderr = ConsoleCapture.CaptureError(() =>
+                symbols = SymbolExtractor.Extract(1, "typescript", File.ReadAllText(sourcePath), sourcePath));
+
+            Assert.Contains(symbols, s => s.Kind == "import" && s.Name == "@/components/Button");
+            Assert.Contains("Skipped TypeScript path alias config tsconfig.json", stderr, StringComparison.Ordinal);
+            Assert.DoesNotContain(projectRoot, stderr, StringComparison.Ordinal);
+            Assert.DoesNotContain(projectRoot.Replace('\\', '/'), stderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Extract_TypeScript_UnreadableTsconfigSkipsPathAliasesWithReadFailedWarning_Issue3438()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("tsconfig_alias_unreadable_symbols");


### PR DESCRIPTION
## Summary
- Add explicit caps for literal search token growth, raw FTS column fanout, and path glob fanout.
- Stream grouped file search counts and MCP top-file histograms without avoidable result grouping/materialization.
- Bound preferred-line snippet scans and impact traversal boundary/state probing with stable truncation reasons.
- Merge latest `origin/main` and keep `AnalyzeFtsQuery` diagnostics non-throwing for overlong-token analysis.

## Validation
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~Issue3794|FullyQualifiedName~DbReaderTests.AnalyzeFtsQuery_AllTokensTooLong_ReturnsDegradedReason"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore`
- `git diff --check origin/main...HEAD`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Changelog
- `changelog.d/unreleased/3794.fixed.md`
- `changelog.d/unreleased/3782.fixed.md`
- `changelog.d/unreleased/3741.fixed.md`
- `changelog.d/unreleased/3742.fixed.md`
- `changelog.d/unreleased/3820.fixed.md`

## Review
No blocking/actionable issues found.

Fixes #3794
Fixes #3782
Fixes #3741
Fixes #3742
Fixes #3820