### PR TITLE
[codex] Harden DB cancellation and import diagnostics

### DIFF
--- a/changelog.d/unreleased/3736.fixed.md
+++ b/changelog.d/unreleased/3736.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3736
+affected:
+  - src/CodeIndex/Cli/DiffCommandRunner.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+  - tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+---
+
+## English
+
+- **`cdidx diff` now has cancellation checkpoints and truncation diagnostics (#3736)** — large database comparisons can stop cleanly and JSON output reports when sample limits hide additional diff rows.
+
+## 日本語
+
+- **`cdidx diff` に cancellation checkpoint と truncation diagnostics を追加しました (#3736)** — 大きな database 比較を安全に停止でき、JSON 出力が sample limit によって追加の差分行を省略したことを報告するようになりました。

--- a/changelog.d/unreleased/3738.fixed.md
+++ b/changelog.d/unreleased/3738.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3738
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+  - tests/CodeIndex.Tests/DatabaseTests.cs
+---
+
+## English
+
+- **DbWriter batch inserts now expose cancellation and progress checkpoints (#3738)** — chunk, symbol, and reference batch writes now check cancellation between batches and emit bounded progress checkpoints for long write operations.
+
+## 日本語
+
+- **DbWriter の batch insert が cancellation と progress checkpoint を公開するようになりました (#3738)** — chunk / symbol / reference の batch 書き込みが batch 間で cancellation を確認し、長い書き込み処理向けに上限付き progress checkpoint を出すようになりました。

--- a/changelog.d/unreleased/3772.fixed.md
+++ b/changelog.d/unreleased/3772.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3772
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+  - tests/CodeIndex.Tests/DatabaseTests.cs
+---
+
+## English
+
+- **DbWriter transaction gate waits are now cancellable and diagnosable (#3772)** — transaction acquisition now honors cancellation tokens and timeout errors include bounded owner and waiter operation details for contention triage.
+
+## 日本語
+
+- **DbWriter の transaction gate 待機をキャンセル可能かつ診断可能にしました (#3772)** — transaction 取得が cancellation token を尊重し、timeout error に owner / waiter の operation 情報を上限付きで含めるようになりました。

--- a/changelog.d/unreleased/3811.fixed.md
+++ b/changelog.d/unreleased/3811.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 3811
+affected:
+  - src/CodeIndex/Cli/DbCommandRunner.cs
+  - src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - tests/CodeIndex.Tests/DatabaseTests.cs
+  - tests/CodeIndex.Tests/DbCommandRunnerTests.cs
+---
+
+## English
+
+- **DB maintenance commands now honor cancellation and report progress boundaries (#3811)** — `cdidx db` maintenance paths and `cdidx vacuum` pass cancellation tokens into SQLite work, apply the shared busy-timeout policy to direct maintenance connections, and emit bounded maintenance progress phases.
+
+## 日本語
+
+- **DB maintenance command が cancellation と progress boundary を尊重するようになりました (#3811)** — `cdidx db` の maintenance 経路と `cdidx vacuum` が SQLite 処理へ cancellation token を渡し、直接 maintenance 接続にも共通 busy-timeout policy を適用し、上限付きの maintenance progress phase を出すようになりました。

--- a/changelog.d/unreleased/3818.fixed.md
+++ b/changelog.d/unreleased/3818.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3818
+affected:
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+  - tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+---
+
+## English
+
+- **Export/import copy and replacement diagnostics are now more robust (#3818)** — archive copy and import validation paths now honor cancellation tokens, and JSON import failures include residual replacement-state diagnostics when database replacement rollback is involved.
+
+## 日本語
+
+- **export/import の copy と replacement diagnostics を強化しました (#3818)** — archive copy と import validation 経路が cancellation token を尊重し、database replacement の rollback が関わる JSON import failure で残存 replacement state diagnostics を返すようになりました。

--- a/src/CodeIndex/Cli/DbCommandRunner.cs
+++ b/src/CodeIndex/Cli/DbCommandRunner.cs
@@ -27,12 +27,21 @@ public static class DbCommandRunner
     internal const int SchemaEntryLimit = 200;
     internal const int SchemaSqlTextLimit = 8192;
     private static readonly char[] InvalidCheckpointNameChars = Path.GetInvalidFileNameChars();
+    private static readonly AsyncLocal<Action<string, string>?> ScopedMaintenanceProgressForTesting = new();
     internal static Action? RestoreFailureAfterBackupForTesting { get; set; }
     internal static Action<string>? DeleteTemporaryDirectoryForTesting { get; set; }
     internal static Func<IEnumerable<string>>? IntegrityCheckRowsForTesting { get; set; }
     internal static Func<string, IEnumerable<string>>? EnumerateCheckpointFileNamesForTesting { get; set; }
+    internal static Action<string, string>? MaintenanceProgressForTesting
+    {
+        get => ScopedMaintenanceProgressForTesting.Value;
+        set => ScopedMaintenanceProgressForTesting.Value = value;
+    }
 
     public static int Run(string[] cmdArgs, JsonSerializerOptions jsonOptions)
+        => Run(cmdArgs, jsonOptions, CancellationToken.None);
+
+    public static int Run(string[] cmdArgs, JsonSerializerOptions jsonOptions, CancellationToken cancellationToken)
     {
         var options = ParseArgs(cmdArgs);
         if (options.ShowHelp)
@@ -94,25 +103,34 @@ public static class DbCommandRunner
                 "Point `--db` at an existing `codeindex.db`, or run `cdidx index <projectPath>` first to create one.",
                 CommandErrorCodes.DbNotFound);
 
-        if (options.Schema)
-            return RunSchema(options, jsonOptions, dbPath, isUri);
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
 
-        if (options.Prune)
-            return RunPrune(options, jsonOptions, dbPath, isUri);
+            if (options.Schema)
+                return RunSchema(options, jsonOptions, dbPath, isUri, cancellationToken);
 
-        if (options.Checkpoint)
-            return RunCheckpoint(options, jsonOptions);
+            if (options.Prune)
+                return RunPrune(options, jsonOptions, dbPath, isUri, cancellationToken);
 
-        if (options.ListCheckpoints)
-            return RunListCheckpoints(options, jsonOptions);
+            if (options.Checkpoint)
+                return RunCheckpoint(options, jsonOptions);
 
-        if (options.Restore)
-            return RunRestore(options, jsonOptions);
+            if (options.ListCheckpoints)
+                return RunListCheckpoints(options, jsonOptions);
 
-        if (options.RestoreBackups)
-            return RunRestoreBackups(options, jsonOptions);
+            if (options.Restore)
+                return RunRestore(options, jsonOptions);
 
-        return RunIntegrityCheck(options, jsonOptions, dbPath, isUri);
+            if (options.RestoreBackups)
+                return RunRestoreBackups(options, jsonOptions);
+
+            return RunIntegrityCheck(options, jsonOptions, dbPath, isUri, cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            return WriteMaintenanceCancelled(options.Json, jsonOptions, "db maintenance command");
+        }
     }
 
     public static int RunIntegrityCheck(string[] cmdArgs, JsonSerializerOptions jsonOptions) => Run(cmdArgs, jsonOptions);
@@ -124,11 +142,13 @@ public static class DbCommandRunner
         return CreateCheckpoint(fullDbPath, name).CheckpointPath;
     }
 
-    private static int RunIntegrityCheck(DbCommandOptions options, JsonSerializerOptions jsonOptions, string dbPath, bool isUri)
+    private static int RunIntegrityCheck(DbCommandOptions options, JsonSerializerOptions jsonOptions, string dbPath, bool isUri, CancellationToken cancellationToken)
     {
         try
         {
-            var result = RunIntegrityCheckPragma(dbPath);
+            ReportMaintenanceProgress("integrity_check", "start", dbPath);
+            var result = RunIntegrityCheckPragma(dbPath, cancellationToken);
+            ReportMaintenanceProgress("integrity_check", "complete", dbPath);
             var issues = result.Rows;
             var ok = issues.Count == 1 && string.Equals(issues[0], "ok", StringComparison.Ordinal);
             var jsonContext = CliJsonSerializerContextFactory.Create(jsonOptions);
@@ -171,6 +191,10 @@ public static class DbCommandRunner
 
             return ok ? CommandExitCodes.Success : CommandExitCodes.DatabaseError;
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             if (JsonOutputFailure.TryHandle(ex, out var exitCode))
@@ -186,11 +210,13 @@ public static class DbCommandRunner
         }
     }
 
-    private static int RunSchema(DbCommandOptions options, JsonSerializerOptions jsonOptions, string dbPath, bool isUri)
+    private static int RunSchema(DbCommandOptions options, JsonSerializerOptions jsonOptions, string dbPath, bool isUri, CancellationToken cancellationToken)
     {
         try
         {
-            var schema = ReadSchema(dbPath);
+            ReportMaintenanceProgress("schema", "start", dbPath);
+            var schema = ReadSchema(dbPath, cancellationToken);
+            ReportMaintenanceProgress("schema", "complete", dbPath);
             var fullPath = DbPathResolver.FormatDbPathForDisplay(dbPath);
             if (options.Json)
             {
@@ -230,6 +256,10 @@ public static class DbCommandRunner
 
             return CommandExitCodes.Success;
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             if (JsonOutputFailure.TryHandle(ex, out var exitCode))
@@ -245,7 +275,7 @@ public static class DbCommandRunner
         }
     }
 
-    private static int RunPrune(DbCommandOptions options, JsonSerializerOptions jsonOptions, string dbPath, bool isUri)
+    private static int RunPrune(DbCommandOptions options, JsonSerializerOptions jsonOptions, string dbPath, bool isUri, CancellationToken cancellationToken)
     {
         if (!options.PruneApply && !options.PruneDryRun)
             return WriteCommandError(
@@ -276,7 +306,9 @@ public static class DbCommandRunner
 
         try
         {
-            var result = PruneOrphans(dbPath, apply: options.PruneApply);
+            ReportMaintenanceProgress("prune", "start", dbPath);
+            var result = PruneOrphans(dbPath, apply: options.PruneApply, cancellationToken);
+            ReportMaintenanceProgress("prune", "complete", dbPath);
             var fullPath = DbPathResolver.FormatDbPathForDisplay(dbPath);
             if (options.Json)
             {
@@ -306,6 +338,10 @@ public static class DbCommandRunner
             }
 
             return CommandExitCodes.Success;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -599,23 +635,29 @@ public static class DbCommandRunner
     // pragma side effects of the normal DbContext open path.
     // PRAGMA integrity_check は問題が無ければ 1 行の `"ok"` を、破損があれば最大 N 行の検出結果を返す。
     // 読み取りのみのため read-only 接続で十分で、DbContext の WAL モード設定副作用を避けられる。
-    private static DbIntegrityCheckReadResult RunIntegrityCheckPragma(string dbPath)
+    private static DbIntegrityCheckReadResult RunIntegrityCheckPragma(string dbPath, CancellationToken cancellationToken)
     {
         if (IntegrityCheckRowsForTesting != null)
-            return BoundIntegrityRows(IntegrityCheckRowsForTesting());
+            return BoundIntegrityRows(IntegrityCheckRowsForTesting(), cancellationToken);
 
+        cancellationToken.ThrowIfCancellationRequested();
         var connectionString = DbPathResolver.BuildSqliteConnectionString(dbPath, SqliteOpenMode.ReadOnly);
 
         using var connection = new SqliteConnection(connectionString);
+        ReportMaintenanceProgress("integrity_check", "open_connection", dbPath);
         connection.Open();
+        ApplyBusyTimeout(connection, cancellationToken);
         using var cmd = connection.CreateCommand();
         cmd.CommandText = $"PRAGMA integrity_check({IntegrityCheckRowLimit + 1})";
+        ReportMaintenanceProgress("integrity_check", "read_rows", dbPath);
+        cancellationToken.ThrowIfCancellationRequested();
         using var reader = cmd.ExecuteReader();
         var rows = new List<string>();
         var rowsTruncated = false;
         var textTruncated = false;
         while (reader.Read())
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (rows.Count >= IntegrityCheckRowLimit)
             {
                 rowsTruncated = true;
@@ -630,13 +672,17 @@ public static class DbCommandRunner
         return new DbIntegrityCheckReadResult(rows.Count > 0 ? rows : new List<string> { "ok" }, rowsTruncated, textTruncated);
     }
 
-    private static DbSchemaReadResult ReadSchema(string dbPath)
+    private static DbSchemaReadResult ReadSchema(string dbPath, CancellationToken cancellationToken)
     {
-        using var connection = OpenConnection(dbPath, writable: false);
+        using var connection = OpenConnection(dbPath, writable: false, cancellationToken);
+        ReportMaintenanceProgress("schema", "read_version", dbPath);
+        cancellationToken.ThrowIfCancellationRequested();
         using var versionCmd = connection.CreateCommand();
         versionCmd.CommandText = "PRAGMA user_version";
         var rawVersion = versionCmd.ExecuteScalar();
         var userVersion = rawVersion is long l ? (int)l : (rawVersion is int i ? i : 0);
+        cancellationToken.ThrowIfCancellationRequested();
+        ReportMaintenanceProgress("schema", "count_objects", dbPath);
         var objectTypeCounts = ReadSchemaObjectTypeCounts(connection);
 
         using var cmd = connection.CreateCommand();
@@ -648,12 +694,15 @@ public static class DbCommandRunner
             LIMIT @entry_limit";
         cmd.Parameters.AddWithValue("@sql_limit", SchemaSqlTextLimit + 1);
         cmd.Parameters.AddWithValue("@entry_limit", SchemaEntryLimit + 1);
+        ReportMaintenanceProgress("schema", "read_entries", dbPath);
+        cancellationToken.ThrowIfCancellationRequested();
         using var reader = cmd.ExecuteReader();
         var entries = new List<DbSchemaEntryJsonResult>();
         var entriesTruncated = false;
         var sqlTruncated = false;
         while (reader.Read())
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (entries.Count >= SchemaEntryLimit)
             {
                 entriesTruncated = true;
@@ -708,13 +757,14 @@ public static class DbCommandRunner
         return counts;
     }
 
-    private static DbIntegrityCheckReadResult BoundIntegrityRows(IEnumerable<string> rawRows)
+    private static DbIntegrityCheckReadResult BoundIntegrityRows(IEnumerable<string> rawRows, CancellationToken cancellationToken)
     {
         var rows = new List<string>();
         var rowsTruncated = false;
         var textTruncated = false;
         foreach (var raw in rawRows)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (rows.Count >= IntegrityCheckRowLimit)
             {
                 rowsTruncated = true;
@@ -736,12 +786,14 @@ public static class DbCommandRunner
         return (text[..limit] + " [truncated]", true);
     }
 
-    private static (int OrphanSymbolReferences, int OrphanReferenceLines, int OrphanSymbols, int Total, List<DbDiagnosticJsonResult> Warnings) PruneOrphans(string dbPath, bool apply)
+    private static (int OrphanSymbolReferences, int OrphanReferenceLines, int OrphanSymbols, int Total, List<DbDiagnosticJsonResult> Warnings) PruneOrphans(string dbPath, bool apply, CancellationToken cancellationToken)
     {
-        using var connection = OpenConnection(dbPath, writable: apply);
+        using var connection = OpenConnection(dbPath, writable: apply, cancellationToken);
+        cancellationToken.ThrowIfCancellationRequested();
         using var transaction = apply ? connection.BeginTransaction() : null;
         var warnings = new List<DbDiagnosticJsonResult>();
 
+        ReportMaintenanceProgress("prune", "count_symbol_references", dbPath);
         var orphanSymbolReferences = Count(connection, transaction, @"
             SELECT COUNT(*)
             FROM symbol_references sr
@@ -749,20 +801,23 @@ public static class DbCommandRunner
             LEFT JOIN reference_lines rl ON rl.id = sr.reference_line_id
             LEFT JOIN files rlf ON rlf.id = rl.file_id
             WHERE f.id IS NULL
-               OR (sr.reference_line_id IS NOT NULL AND (rl.id IS NULL OR rlf.id IS NULL))");
+               OR (sr.reference_line_id IS NOT NULL AND (rl.id IS NULL OR rlf.id IS NULL))", cancellationToken);
+        ReportMaintenanceProgress("prune", "count_reference_lines", dbPath);
         var orphanReferenceLines = Count(connection, transaction, @"
             SELECT COUNT(*)
             FROM reference_lines rl
             LEFT JOIN files f ON f.id = rl.file_id
-            WHERE f.id IS NULL");
+            WHERE f.id IS NULL", cancellationToken);
+        ReportMaintenanceProgress("prune", "count_symbols", dbPath);
         var orphanSymbols = Count(connection, transaction, @"
             SELECT COUNT(*)
             FROM symbols s
             LEFT JOIN files f ON f.id = s.file_id
-            WHERE f.id IS NULL");
+            WHERE f.id IS NULL", cancellationToken);
 
         if (apply)
         {
+            ReportMaintenanceProgress("prune", "delete_symbol_references", dbPath);
             Execute(connection, transaction, @"
                 DELETE FROM symbol_references
                 WHERE file_id NOT IN (SELECT id FROM files)
@@ -770,12 +825,17 @@ public static class DbCommandRunner
                        SELECT rl.id
                        FROM reference_lines rl
                        INNER JOIN files f ON f.id = rl.file_id
-                   ))");
-            Execute(connection, transaction, "DELETE FROM reference_lines WHERE file_id NOT IN (SELECT id FROM files)");
-            Execute(connection, transaction, "DELETE FROM symbols WHERE file_id NOT IN (SELECT id FROM files)");
+                   ))", cancellationToken);
+            ReportMaintenanceProgress("prune", "delete_reference_lines", dbPath);
+            Execute(connection, transaction, "DELETE FROM reference_lines WHERE file_id NOT IN (SELECT id FROM files)", cancellationToken);
+            ReportMaintenanceProgress("prune", "delete_symbols", dbPath);
+            Execute(connection, transaction, "DELETE FROM symbols WHERE file_id NOT IN (SELECT id FROM files)", cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+            ReportMaintenanceProgress("prune", "commit", dbPath);
             transaction!.Commit();
-            Execute(connection, null, "PRAGMA optimize");
-            var walWarning = RunWalCheckpointTruncate(connection);
+            ReportMaintenanceProgress("prune", "optimize", dbPath);
+            Execute(connection, null, "PRAGMA optimize", cancellationToken);
+            var walWarning = RunWalCheckpointTruncate(connection, cancellationToken);
             if (walWarning is not null)
                 warnings.Add(walWarning);
         }
@@ -784,41 +844,71 @@ public static class DbCommandRunner
         return (orphanSymbolReferences, orphanReferenceLines, orphanSymbols, total, warnings);
     }
 
-    private static SqliteConnection OpenConnection(string dbPath, bool writable)
+    private static SqliteConnection OpenConnection(string dbPath, bool writable, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var connectionString = DbPathResolver.BuildSqliteConnectionString(
             dbPath,
             writable ? SqliteOpenMode.ReadWrite : SqliteOpenMode.ReadOnly);
         var connection = new SqliteConnection(connectionString);
-        connection.Open();
-        return connection;
+        try
+        {
+            connection.Open();
+            ApplyBusyTimeout(connection, cancellationToken);
+            return connection;
+        }
+        catch
+        {
+            connection.Dispose();
+            throw;
+        }
     }
 
-    private static int Count(SqliteConnection connection, SqliteTransaction? transaction, string sql)
+    private static void ApplyBusyTimeout(SqliteConnection connection, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = $"PRAGMA busy_timeout={DbPragmaPolicy.ReadBusyTimeoutMs(DbContext.BusyTimeoutEnvironmentVariable)}";
+        cmd.ExecuteNonQuery();
+    }
+
+    private static int Count(SqliteConnection connection, SqliteTransaction? transaction, string sql, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
         using var cmd = connection.CreateCommand();
         cmd.Transaction = transaction;
         cmd.CommandText = sql;
-        return Convert.ToInt32(cmd.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
+        var result = Convert.ToInt32(cmd.ExecuteScalar(), System.Globalization.CultureInfo.InvariantCulture);
+        cancellationToken.ThrowIfCancellationRequested();
+        return result;
     }
 
-    private static void Execute(SqliteConnection connection, SqliteTransaction? transaction, string sql)
+    private static void Execute(SqliteConnection connection, SqliteTransaction? transaction, string sql, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         using var cmd = connection.CreateCommand();
         cmd.Transaction = transaction;
         cmd.CommandText = sql;
         cmd.ExecuteNonQuery();
+        cancellationToken.ThrowIfCancellationRequested();
     }
 
-    private static DbDiagnosticJsonResult? RunWalCheckpointTruncate(SqliteConnection connection)
+    private static DbDiagnosticJsonResult? RunWalCheckpointTruncate(SqliteConnection connection, CancellationToken cancellationToken)
     {
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
+            ReportMaintenanceProgress("prune", "wal_checkpoint_truncate", connection.DataSource);
             using var cmd = connection.CreateCommand();
             cmd.CommandText = "PRAGMA wal_checkpoint(TRUNCATE)";
             DbContext.WalCheckpointTruncateExecutedForTesting?.Invoke(connection.DataSource);
             cmd.ExecuteNonQuery();
+            cancellationToken.ThrowIfCancellationRequested();
             return null;
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
         }
         catch (Exception)
         {
@@ -1616,6 +1706,21 @@ public static class DbCommandRunner
     private static int WriteCommandError(bool json, JsonSerializerOptions jsonOptions, string message, int exitCode, string? hint = null, string? errorCode = null, string? category = null)
     {
         return CommandErrorWriter.WriteJsonOrHuman(json, jsonOptions, message, exitCode, hint, errorCode: errorCode, category: category);
+    }
+
+    private static int WriteMaintenanceCancelled(bool json, JsonSerializerOptions jsonOptions, string operation)
+        => WriteCommandError(
+            json,
+            jsonOptions,
+            $"{operation} cancelled before it could complete",
+            CommandExitCodes.CancelledBySignal,
+            "Retry the command after the cancelling operation completes.",
+            CommandErrorCodes.Interrupted);
+
+    private static void ReportMaintenanceProgress(string operation, string phase, string dbPath)
+    {
+        GlobalToolLog.Info($"db_maintenance_progress operation={operation} phase={phase} db_path={ConsoleUi.FormatBoundedValue(dbPath)}");
+        MaintenanceProgressForTesting?.Invoke(operation, phase);
     }
 }
 

--- a/src/CodeIndex/Cli/DiffCommandRunner.cs
+++ b/src/CodeIndex/Cli/DiffCommandRunner.cs
@@ -21,6 +21,9 @@ public static class DiffCommandRunner
     private const int UnreadableExitCode = 3;
 
     public static int Run(string[] args, JsonSerializerOptions jsonOptions)
+        => Run(args, jsonOptions, CancellationToken.None);
+
+    public static int Run(string[] args, JsonSerializerOptions jsonOptions, CancellationToken cancellationToken)
     {
         var options = ParseArgs(args);
         if (options.ShowHelp)
@@ -49,7 +52,9 @@ public static class DiffCommandRunner
 
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var leftHeader = ReadHeader(options.LeftDb!);
+            cancellationToken.ThrowIfCancellationRequested();
             var rightHeader = ReadHeader(options.RightDb!);
             if (leftHeader.SchemaVersion != rightHeader.SchemaVersion)
             {
@@ -58,11 +63,21 @@ public static class DiffCommandRunner
                 return SchemaMismatchExitCode;
             }
 
-            var result = BuildDiff(leftHeader, rightHeader, options);
+            var result = BuildDiff(leftHeader, rightHeader, options, cancellationToken);
 
             WriteResult(result, options, jsonOptions);
 
             return result.Identical ? CommandExitCodes.Success : DriftExitCode;
+        }
+        catch (OperationCanceledException)
+        {
+            return WriteCommandError(
+                options.Json || options.SummaryOnly,
+                jsonOptions,
+                "diff comparison cancelled before it could complete",
+                CommandExitCodes.CancelledBySignal,
+                "Retry the diff with a smaller database pair or after the cancelling operation completes.",
+                CommandErrorCodes.Interrupted);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SqliteException or InvalidOperationException)
         {
@@ -276,7 +291,7 @@ public static class DiffCommandRunner
             symbol_references.container_name_folded
         """;
 
-    private static DiffJsonResult BuildDiff(DiffDbHeader left, DiffDbHeader right, DiffCommandOptions options)
+    private static DiffJsonResult BuildDiff(DiffDbHeader left, DiffDbHeader right, DiffCommandOptions options, CancellationToken cancellationToken)
     {
         var summary = new DiffSummaryJsonResult(
             left.FileCount,
@@ -296,6 +311,7 @@ public static class DiffCommandRunner
         var filesOnlyInRight = new List<string>();
         var symbolsOnlyInLeft = new List<string>();
         var symbolsOnlyInRight = new List<string>();
+        var diagnostics = new List<DiffDiagnosticJsonResult>();
         var identical =
             summary.SchemaVersionsEqual &&
             summary.FileCountDelta == 0 &&
@@ -309,32 +325,38 @@ public static class DiffCommandRunner
 
         if (!options.SummaryOnly)
         {
-            var fileDiff = DiffOrderedStrings(leftConnection, rightConnection, FilePathRowsSql, options.Limit);
+            cancellationToken.ThrowIfCancellationRequested();
+            var fileDiff = DiffOrderedStrings(leftConnection, rightConnection, FilePathRowsSql, options.Limit, cancellationToken);
             filesOnlyInLeft = fileDiff.OnlyInLeft;
             filesOnlyInRight = fileDiff.OnlyInRight;
             identical = identical && fileDiff.Equal;
+            AddTruncationDiagnostic(diagnostics, fileDiff.Truncated, "file differences");
         }
 
         if (options.Detailed)
         {
-            var symbolDiff = DiffOrderedRows(leftConnection, rightConnection, leftSymbolRowsSql, rightSymbolRowsSql, options.Limit);
+            cancellationToken.ThrowIfCancellationRequested();
+            var symbolDiff = DiffOrderedRows(leftConnection, rightConnection, leftSymbolRowsSql, rightSymbolRowsSql, options.Limit, cancellationToken);
             symbolsOnlyInLeft = symbolDiff.OnlyInLeft;
             symbolsOnlyInRight = symbolDiff.OnlyInRight;
             identical = identical && symbolDiff.Equal;
+            AddTruncationDiagnostic(diagnostics, symbolDiff.Truncated, "symbol differences");
         }
 
         if (identical)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             identical =
-                RowsEqual(leftConnection, rightConnection, FileRowsSql) &&
-                RowsEqual(leftConnection, rightConnection, ChunkRowsSql) &&
-                RowsEqual(leftConnection, rightConnection, ReferenceLineRowsSql) &&
-                RowsEqual(leftConnection, rightConnection, FileIssueRowsSql) &&
-                RowsEqual(leftConnection, rightConnection, MetaRowsSql) &&
-                (options.Detailed || RowsEqual(leftConnection, rightConnection, leftSymbolRowsSql, rightSymbolRowsSql)) &&
-                RowsEqual(leftConnection, rightConnection, ReferenceRowsSql);
+                RowsEqual(leftConnection, rightConnection, FileRowsSql, cancellationToken) &&
+                RowsEqual(leftConnection, rightConnection, ChunkRowsSql, cancellationToken) &&
+                RowsEqual(leftConnection, rightConnection, ReferenceLineRowsSql, cancellationToken) &&
+                RowsEqual(leftConnection, rightConnection, FileIssueRowsSql, cancellationToken) &&
+                RowsEqual(leftConnection, rightConnection, MetaRowsSql, cancellationToken) &&
+                (options.Detailed || RowsEqual(leftConnection, rightConnection, leftSymbolRowsSql, rightSymbolRowsSql, cancellationToken)) &&
+                RowsEqual(leftConnection, rightConnection, ReferenceRowsSql, cancellationToken);
         }
 
+        var truncated = diagnostics.Count > 0;
         return new DiffJsonResult(
             identical ? "identical" : "different",
             identical,
@@ -346,7 +368,18 @@ public static class DiffCommandRunner
             options.Detailed ? symbolsOnlyInLeft : null,
             options.Detailed ? symbolsOnlyInRight : null,
             options.Limit,
-            options.Detailed);
+            options.Detailed,
+            truncated,
+            truncated ? diagnostics : null);
+    }
+
+    private static void AddTruncationDiagnostic(List<DiffDiagnosticJsonResult> diagnostics, bool truncated, string area)
+    {
+        if (!truncated)
+            return;
+        diagnostics.Add(new DiffDiagnosticJsonResult(
+            "diff_samples_truncated",
+            $"{area} exceeded the requested diff sample limit; rerun with a higher --limit for more rows."));
     }
 
     private static DiffJsonResult BuildSchemaMismatchDiff(DiffDbHeader left, DiffDbHeader right, DiffCommandOptions options)
@@ -380,17 +413,21 @@ public static class DiffCommandRunner
     }
 
     private static OrderedRowsDiff DiffOrderedRows(SqliteConnection leftConnection, SqliteConnection rightConnection, string sql, int limit)
-        => DiffOrderedRows(leftConnection, rightConnection, sql, sql, limit);
+        => DiffOrderedRows(leftConnection, rightConnection, sql, sql, limit, CancellationToken.None);
 
     private static OrderedRowsDiff DiffOrderedRows(
         SqliteConnection leftConnection,
         SqliteConnection rightConnection,
         string leftSql,
         string rightSql,
-        int limit)
+        int limit,
+        CancellationToken cancellationToken)
     {
         if (limit == 0)
-            return new OrderedRowsDiff(RowsEqual(leftConnection, rightConnection, leftSql, rightSql), [], []);
+        {
+            var rowsEqual = RowsEqual(leftConnection, rightConnection, leftSql, rightSql, cancellationToken);
+            return new OrderedRowsDiff(rowsEqual, [], [], !rowsEqual);
+        }
 
         using var leftCommand = leftConnection.CreateCommand();
         leftCommand.CommandText = leftSql;
@@ -403,20 +440,22 @@ public static class DiffCommandRunner
         var onlyInRight = new List<string>(limit);
         var leftRowsRead = 0;
         var rightRowsRead = 0;
-        var leftHasValue = TryReadRow(leftReader, out var leftValue, ref leftRowsRead, "left");
-        var rightHasValue = TryReadRow(rightReader, out var rightValue, ref rightRowsRead, "right");
+        var leftHasValue = TryReadRow(leftReader, out var leftValue, ref leftRowsRead, "left", cancellationToken);
+        var rightHasValue = TryReadRow(rightReader, out var rightValue, ref rightRowsRead, "right", cancellationToken);
         var equal = true;
+        var truncated = false;
 
         while (leftHasValue || rightHasValue)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var comparison = leftHasValue && rightHasValue
                 ? CompareRows(leftValue, rightValue)
                 : leftHasValue ? -1 : 1;
 
             if (comparison == 0)
             {
-                leftHasValue = TryReadRow(leftReader, out leftValue, ref leftRowsRead, "left");
-                rightHasValue = TryReadRow(rightReader, out rightValue, ref rightRowsRead, "right");
+                leftHasValue = TryReadRow(leftReader, out leftValue, ref leftRowsRead, "left", cancellationToken);
+                rightHasValue = TryReadRow(rightReader, out rightValue, ref rightRowsRead, "right", cancellationToken);
                 continue;
             }
 
@@ -425,26 +464,36 @@ public static class DiffCommandRunner
             {
                 if (onlyInLeft.Count < limit)
                     onlyInLeft.Add(EncodeRow(leftValue.SortValues));
-                leftHasValue = TryReadRow(leftReader, out leftValue, ref leftRowsRead, "left");
+                else
+                    truncated = true;
+                leftHasValue = TryReadRow(leftReader, out leftValue, ref leftRowsRead, "left", cancellationToken);
             }
             else
             {
                 if (onlyInRight.Count < limit)
                     onlyInRight.Add(EncodeRow(rightValue.SortValues));
-                rightHasValue = TryReadRow(rightReader, out rightValue, ref rightRowsRead, "right");
+                else
+                    truncated = true;
+                rightHasValue = TryReadRow(rightReader, out rightValue, ref rightRowsRead, "right", cancellationToken);
             }
 
             if (onlyInLeft.Count >= limit && onlyInRight.Count >= limit)
+            {
+                truncated = truncated || leftHasValue || rightHasValue;
                 break;
+            }
         }
 
-        return new OrderedRowsDiff(equal, onlyInLeft, onlyInRight);
+        return new OrderedRowsDiff(equal, onlyInLeft, onlyInRight, truncated);
     }
 
-    private static OrderedRowsDiff DiffOrderedStrings(SqliteConnection leftConnection, SqliteConnection rightConnection, string sql, int limit)
+    private static OrderedRowsDiff DiffOrderedStrings(SqliteConnection leftConnection, SqliteConnection rightConnection, string sql, int limit, CancellationToken cancellationToken)
     {
         if (limit == 0)
-            return new OrderedRowsDiff(StringRowsEqual(leftConnection, rightConnection, sql), [], []);
+        {
+            var rowsEqual = StringRowsEqual(leftConnection, rightConnection, sql, cancellationToken);
+            return new OrderedRowsDiff(rowsEqual, [], [], !rowsEqual);
+        }
 
         using var leftCommand = leftConnection.CreateCommand();
         leftCommand.CommandText = sql;
@@ -457,20 +506,22 @@ public static class DiffCommandRunner
         var onlyInRight = new List<string>(limit);
         var leftRowsRead = 0;
         var rightRowsRead = 0;
-        var leftHasValue = TryReadString(leftReader, out var leftValue, ref leftRowsRead, "left");
-        var rightHasValue = TryReadString(rightReader, out var rightValue, ref rightRowsRead, "right");
+        var leftHasValue = TryReadString(leftReader, out var leftValue, ref leftRowsRead, "left", cancellationToken);
+        var rightHasValue = TryReadString(rightReader, out var rightValue, ref rightRowsRead, "right", cancellationToken);
         var equal = true;
+        var truncated = false;
 
         while (leftHasValue || rightHasValue)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var comparison = leftHasValue && rightHasValue
                 ? string.CompareOrdinal(leftValue, rightValue)
                 : leftHasValue ? -1 : 1;
 
             if (comparison == 0)
             {
-                leftHasValue = TryReadString(leftReader, out leftValue, ref leftRowsRead, "left");
-                rightHasValue = TryReadString(rightReader, out rightValue, ref rightRowsRead, "right");
+                leftHasValue = TryReadString(leftReader, out leftValue, ref leftRowsRead, "left", cancellationToken);
+                rightHasValue = TryReadString(rightReader, out rightValue, ref rightRowsRead, "right", cancellationToken);
                 continue;
             }
 
@@ -479,26 +530,36 @@ public static class DiffCommandRunner
             {
                 if (onlyInLeft.Count < limit)
                     onlyInLeft.Add(leftValue);
-                leftHasValue = TryReadString(leftReader, out leftValue, ref leftRowsRead, "left");
+                else
+                    truncated = true;
+                leftHasValue = TryReadString(leftReader, out leftValue, ref leftRowsRead, "left", cancellationToken);
             }
             else
             {
                 if (onlyInRight.Count < limit)
                     onlyInRight.Add(rightValue);
-                rightHasValue = TryReadString(rightReader, out rightValue, ref rightRowsRead, "right");
+                else
+                    truncated = true;
+                rightHasValue = TryReadString(rightReader, out rightValue, ref rightRowsRead, "right", cancellationToken);
             }
 
             if (onlyInLeft.Count >= limit && onlyInRight.Count >= limit)
+            {
+                truncated = truncated || leftHasValue || rightHasValue;
                 break;
+            }
         }
 
-        return new OrderedRowsDiff(equal, onlyInLeft, onlyInRight);
+        return new OrderedRowsDiff(equal, onlyInLeft, onlyInRight, truncated);
     }
 
     private static bool RowsEqual(SqliteConnection leftConnection, SqliteConnection rightConnection, string sql)
-        => RowsEqual(leftConnection, rightConnection, sql, sql);
+        => RowsEqual(leftConnection, rightConnection, sql, sql, CancellationToken.None);
 
-    private static bool RowsEqual(SqliteConnection leftConnection, SqliteConnection rightConnection, string leftSql, string rightSql)
+    private static bool RowsEqual(SqliteConnection leftConnection, SqliteConnection rightConnection, string sql, CancellationToken cancellationToken)
+        => RowsEqual(leftConnection, rightConnection, sql, sql, cancellationToken);
+
+    private static bool RowsEqual(SqliteConnection leftConnection, SqliteConnection rightConnection, string leftSql, string rightSql, CancellationToken cancellationToken)
     {
         using var leftCommand = leftConnection.CreateCommand();
         leftCommand.CommandText = leftSql;
@@ -509,20 +570,21 @@ public static class DiffCommandRunner
 
         var leftRowsRead = 0;
         var rightRowsRead = 0;
-        var leftHasValue = TryReadRow(leftReader, out var leftValue, ref leftRowsRead, "left");
-        var rightHasValue = TryReadRow(rightReader, out var rightValue, ref rightRowsRead, "right");
+        var leftHasValue = TryReadRow(leftReader, out var leftValue, ref leftRowsRead, "left", cancellationToken);
+        var rightHasValue = TryReadRow(rightReader, out var rightValue, ref rightRowsRead, "right", cancellationToken);
         while (leftHasValue && rightHasValue)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (CompareRows(leftValue, rightValue) != 0)
                 return false;
-            leftHasValue = TryReadRow(leftReader, out leftValue, ref leftRowsRead, "left");
-            rightHasValue = TryReadRow(rightReader, out rightValue, ref rightRowsRead, "right");
+            leftHasValue = TryReadRow(leftReader, out leftValue, ref leftRowsRead, "left", cancellationToken);
+            rightHasValue = TryReadRow(rightReader, out rightValue, ref rightRowsRead, "right", cancellationToken);
         }
 
         return leftHasValue == rightHasValue;
     }
 
-    private static bool StringRowsEqual(SqliteConnection leftConnection, SqliteConnection rightConnection, string sql)
+    private static bool StringRowsEqual(SqliteConnection leftConnection, SqliteConnection rightConnection, string sql, CancellationToken cancellationToken)
     {
         using var leftCommand = leftConnection.CreateCommand();
         leftCommand.CommandText = sql;
@@ -533,21 +595,23 @@ public static class DiffCommandRunner
 
         var leftRowsRead = 0;
         var rightRowsRead = 0;
-        var leftHasValue = TryReadString(leftReader, out var leftValue, ref leftRowsRead, "left");
-        var rightHasValue = TryReadString(rightReader, out var rightValue, ref rightRowsRead, "right");
+        var leftHasValue = TryReadString(leftReader, out var leftValue, ref leftRowsRead, "left", cancellationToken);
+        var rightHasValue = TryReadString(rightReader, out var rightValue, ref rightRowsRead, "right", cancellationToken);
         while (leftHasValue && rightHasValue)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!string.Equals(leftValue, rightValue, StringComparison.Ordinal))
                 return false;
-            leftHasValue = TryReadString(leftReader, out leftValue, ref leftRowsRead, "left");
-            rightHasValue = TryReadString(rightReader, out rightValue, ref rightRowsRead, "right");
+            leftHasValue = TryReadString(leftReader, out leftValue, ref leftRowsRead, "left", cancellationToken);
+            rightHasValue = TryReadString(rightReader, out rightValue, ref rightRowsRead, "right", cancellationToken);
         }
 
         return leftHasValue == rightHasValue;
     }
 
-    private static bool TryReadRow(SqliteDataReader reader, out DiffRow value, ref int rowsRead, string side)
+    private static bool TryReadRow(SqliteDataReader reader, out DiffRow value, ref int rowsRead, string side, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (!reader.Read())
         {
             value = DiffRow.Empty;
@@ -631,8 +695,9 @@ public static class DiffCommandRunner
         return left.Length.CompareTo(right.Length);
     }
 
-    private static bool TryReadString(SqliteDataReader reader, out string value, ref int rowsRead, string side)
+    private static bool TryReadString(SqliteDataReader reader, out string value, ref int rowsRead, string side, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         if (!reader.Read())
         {
             value = string.Empty;
@@ -895,7 +960,8 @@ public static class DiffCommandRunner
     private sealed record OrderedRowsDiff(
         bool Equal,
         List<string> OnlyInLeft,
-        List<string> OnlyInRight);
+        List<string> OnlyInRight,
+        bool Truncated);
 
     private sealed record DiffRow(
         object?[] SortValues)

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -36,14 +36,20 @@ internal static class ExportImportCommandRunner
     private const string CtagsExportUsage = "cdidx export ctags [--output <path>] [--db <path>] [--json] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests]";
 
     public static int RunExport(string[] args, JsonSerializerOptions jsonOptions, string appVersion)
+        => RunExport(args, jsonOptions, appVersion, CancellationToken.None);
+
+    public static int RunExport(string[] args, JsonSerializerOptions jsonOptions, string appVersion, CancellationToken cancellationToken)
     {
         if (args.Length > 0 && args[0] == "ctags")
             return RunExportCtags(args[1..], jsonOptions);
 
-        return RunExportArchive(args, jsonOptions, appVersion);
+        return RunExportArchive(args, jsonOptions, appVersion, cancellationToken);
     }
 
     public static int RunImport(string[] args, JsonSerializerOptions jsonOptions)
+        => RunImport(args, jsonOptions, CancellationToken.None);
+
+    public static int RunImport(string[] args, JsonSerializerOptions jsonOptions, CancellationToken cancellationToken)
     {
         string? archivePath = null;
         string? dbPath = null;
@@ -103,6 +109,7 @@ internal static class ExportImportCommandRunner
         var phase = PhaseOpenArchive;
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (dryRun)
             {
                 tempDirectory = DataDirectorySecurity.CreateSensitiveTempDirectory("codeindex-import-").FullName;
@@ -116,12 +123,13 @@ internal static class ExportImportCommandRunner
 
             using (var archive = ZipFile.OpenRead(archivePath))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 AddImportValidationPhase(validationPhases, PhaseOpenArchive);
                 phase = PhaseManifest;
                 var manifestEntry = archive.GetEntry(ManifestEntryName);
                 if (manifestEntry == null)
                     return WriteImportError(wantsJson, jsonOptions, PhaseManifest, "import_manifest_missing", "archive is missing manifest.json.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
-                if (!TryReadManifest(manifestEntry, jsonOptions, out var manifest, out var manifestError))
+                if (!TryReadManifest(manifestEntry, jsonOptions, out var manifest, out var manifestError, cancellationToken))
                     return WriteImportError(wantsJson, jsonOptions, PhaseManifest, "import_manifest_invalid", $"archive manifest is invalid: {manifestError}.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
                 if (!TryValidateManifestHeader(manifest, out var manifestHeaderError))
                     return WriteImportError(wantsJson, jsonOptions, PhaseManifest, "import_manifest_incompatible", $"archive manifest is invalid: {manifestHeaderError}.", "re-export from a compatible CodeIndex database.", ImportUsage);
@@ -135,23 +143,24 @@ internal static class ExportImportCommandRunner
                 if (!TryValidateDatabaseEntrySize(dbEntry.Length, dbEntry.CompressedLength, out var sizeValidationMessage))
                     return WriteImportError(wantsJson, jsonOptions, PhaseDatabaseEntry, "import_database_entry_too_large", sizeValidationMessage, "re-export a smaller CodeIndex database or rebuild a smaller index.", ImportUsage);
 
-                ExtractDatabaseEntryToFile(dbEntry, tempPath);
+                ExtractDatabaseEntryToFile(dbEntry, tempPath, cancellationToken);
                 AddImportValidationPhase(validationPhases, PhaseDatabaseEntry);
 
                 phase = PhaseSha256;
-                if (!TryValidateImportedManifest(manifest, tempPath, out var manifestValidationMessage, out var manifestValidationPhase))
+                if (!TryValidateImportedManifest(manifest, tempPath, out var manifestValidationMessage, out var manifestValidationPhase, cancellationToken))
                     return WriteImportError(wantsJson, jsonOptions, manifestValidationPhase, "import_manifest_mismatch", $"archive manifest mismatch: {manifestValidationMessage}.", "re-export from a compatible CodeIndex database.", ImportUsage);
                 AddImportValidationPhase(validationPhases, PhaseSha256);
             }
 
             phase = PhaseSqliteValidate;
-            if (!DbContext.TryValidateExistingCodeIndexDb(tempPath, out var validationMessage, out _))
+            if (!DbContext.TryValidateExistingCodeIndexDb(tempPath, out var validationMessage, out _, cancellationToken: cancellationToken))
                 return WriteImportError(wantsJson, jsonOptions, PhaseSqliteValidate, "import_database_invalid", $"archive database is invalid: {validationMessage}.", "re-export from a compatible CodeIndex database.", ImportUsage);
             AddImportValidationPhase(validationPhases, PhaseSqliteValidate);
             SqliteConnection.ClearAllPools();
 
             if (prunePaths)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 phase = PhasePrunePaths;
                 RewriteImportedProjectRoot(tempPath, importTargetProjectRoot);
                 AddImportValidationPhase(validationPhases, PhasePrunePaths);
@@ -196,7 +205,7 @@ internal static class ExportImportCommandRunner
             }
 
             phase = PhaseReplaceDb;
-            ReplaceImportedDatabase(tempPath, fullDbPath);
+            ReplaceImportedDatabase(tempPath, fullDbPath, cancellationToken);
             if (wantsJson)
             {
                 var manifest = importedManifest ?? throw new InvalidDataException("archive manifest was not loaded");
@@ -224,6 +233,30 @@ internal static class ExportImportCommandRunner
             }
             return CommandExitCodes.Success;
         }
+        catch (OperationCanceledException)
+        {
+            return WriteImportError(
+                wantsJson,
+                jsonOptions,
+                phase,
+                CommandErrorCodes.Interrupted,
+                "import cancelled before it could complete.",
+                "retry `cdidx import` after the cancelling operation completes.",
+                ImportUsage,
+                CommandExitCodes.CancelledBySignal);
+        }
+        catch (ImportReplacementException ex)
+        {
+            return WriteImportError(
+                wantsJson,
+                jsonOptions,
+                PhaseReplaceDb,
+                "import_replacement_failed",
+                $"import failed ({CommandErrorWriter.FormatSanitizedException(ex.InnerException ?? ex)}).",
+                "check destination database permissions and inspect diagnostics for residual replacement state.",
+                ImportUsage,
+                diagnostics: ex.Diagnostics);
+        }
         catch (Exception ex) when (ex is IOException or InvalidDataException or UnauthorizedAccessException or SqliteException)
         {
             return WriteImportError(wantsJson, jsonOptions, phase, "import_failed", $"import failed ({CommandErrorWriter.FormatSanitizedException(ex)}).", "check the archive path and destination database permissions.", ImportUsage);
@@ -240,7 +273,7 @@ internal static class ExportImportCommandRunner
         }
     }
 
-    private static int RunExportArchive(string[] args, JsonSerializerOptions jsonOptions, string appVersion)
+    private static int RunExportArchive(string[] args, JsonSerializerOptions jsonOptions, string appVersion, CancellationToken cancellationToken)
     {
         string? outputPath = null;
         string? dbPath = null;
@@ -291,6 +324,7 @@ internal static class ExportImportCommandRunner
         var phase = PhaseWriteArchive;
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             snapshotDirectory = DataDirectorySecurity.CreateSensitiveTempDirectory("codeindex-export-").FullName;
             snapshotPath = Path.Combine(snapshotDirectory, "codeindex.db");
             var outputDirectory = Path.GetDirectoryName(fullOutputPath);
@@ -298,24 +332,37 @@ internal static class ExportImportCommandRunner
                 Directory.CreateDirectory(outputDirectory);
 
             phase = PhaseSqliteValidate;
-            CreateDatabaseSnapshot(normalizedDbPath, snapshotPath);
+            CreateDatabaseSnapshot(normalizedDbPath, snapshotPath, cancellationToken);
             ExportManifest manifest;
             using (var snapshotConnection = new SqliteConnection(CreateUnpooledConnectionString(snapshotPath)))
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 snapshotConnection.Open();
-                manifest = BuildManifest(snapshotConnection, appVersion);
+                manifest = BuildManifest(snapshotConnection, appVersion, cancellationToken);
             }
             SqliteConnection.ClearAllPools();
             phase = PhaseSha256;
-            manifest = manifest with { DatabaseSha256 = ComputeSha256(snapshotPath) };
+            manifest = manifest with { DatabaseSha256 = ComputeSha256(snapshotPath, cancellationToken) };
             phase = PhaseWriteArchive;
-            WriteExportArchiveFile(fullOutputPath, snapshotPath, manifest, jsonOptions);
+            WriteExportArchiveFile(fullOutputPath, snapshotPath, manifest, jsonOptions, cancellationToken);
 
             if (wantsJson)
                 Console.WriteLine(JsonSerializer.Serialize(new ExportArchiveResult("1", fullOutputPath, fullSourceDbPath), jsonOptions));
             else
                 Console.WriteLine($"Exported CodeIndex archive to {fullOutputPath}");
             return CommandExitCodes.Success;
+        }
+        catch (OperationCanceledException)
+        {
+            return WriteExportError(
+                wantsJson,
+                jsonOptions,
+                phase,
+                CommandErrorCodes.Interrupted,
+                "export cancelled before it could complete.",
+                "retry `cdidx export` after the cancelling operation completes.",
+                "cdidx export <archive> [--db <path>] [--json]",
+                CommandExitCodes.CancelledBySignal);
         }
         catch (Exception ex)
         {
@@ -567,12 +614,14 @@ internal static class ExportImportCommandRunner
             .Append(SanitizeCtagsField(value));
     }
 
-    private static ExportManifest BuildManifest(SqliteConnection connection, string appVersion)
+    private static ExportManifest BuildManifest(SqliteConnection connection, string appVersion, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var userVersion = ReadSqliteUserVersion(connection);
         var projectRoot = ReadMetaString(connection, DbContext.IndexedProjectRootMetaKey);
         var indexedHead = ReadMetaString(connection, DbContext.IndexedHeadShaMetaKey);
         var unknownExtensionFiles = ReadUnknownExtensionFileSample(connection);
+        cancellationToken.ThrowIfCancellationRequested();
         return new ExportManifest(
             "1",
             appVersion,
@@ -580,10 +629,10 @@ internal static class ExportImportCommandRunner
             projectRoot,
             indexedHead,
             string.Empty,
-            FileCount: ReadTableCount(connection, "files"),
-            ChunkCount: ReadTableCount(connection, "chunks"),
-            SymbolCount: ReadTableCount(connection, "symbols"),
-            ReferenceCount: ReadTableCount(connection, "symbol_references"),
+            FileCount: ReadTableCount(connection, "files", cancellationToken),
+            ChunkCount: ReadTableCount(connection, "chunks", cancellationToken),
+            SymbolCount: ReadTableCount(connection, "symbols", cancellationToken),
+            ReferenceCount: ReadTableCount(connection, "symbol_references", cancellationToken),
             GraphReady: (userVersion & DbContext.GraphReadyFlag) != 0,
             IssuesReady: (userVersion & DbContext.IssuesReadyFlag) != 0,
             FoldReady: (userVersion & DbContext.FoldReadyFlag) != 0,
@@ -612,19 +661,23 @@ internal static class ExportImportCommandRunner
     }
 
     internal static void WriteExportArchiveFile(string outputPath, string snapshotPath, ExportManifest manifest, JsonSerializerOptions jsonOptions)
+        => WriteExportArchiveFile(outputPath, snapshotPath, manifest, jsonOptions, CancellationToken.None);
+
+    internal static void WriteExportArchiveFile(string outputPath, string snapshotPath, ExportManifest manifest, JsonSerializerOptions jsonOptions, CancellationToken cancellationToken)
     {
         var fullOutputPath = Path.GetFullPath(outputPath);
         AtomicFileWriter.Write(
             fullOutputPath,
             stream =>
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 using var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true);
                 AddTextEntry(archive, ManifestEntryName, JsonSerializer.Serialize(manifest, jsonOptions));
                 var dbEntry = archive.CreateEntry(DatabaseEntryName, CompressionLevel.SmallestSize);
                 dbEntry.LastWriteTime = DeterministicZipTimestamp;
                 using var source = File.OpenRead(snapshotPath);
                 using var target = dbEntry.Open();
-                source.CopyTo(target);
+                CopyToWithLimit(source, target, long.MaxValue, DatabaseEntryName, cancellationToken);
             });
     }
 
@@ -647,12 +700,18 @@ internal static class ExportImportCommandRunner
     }
 
     private static string ComputeSha256(string path)
+        => ComputeSha256(path, CancellationToken.None);
+
+    private static string ComputeSha256(string path, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         using var stream = File.OpenRead(path);
-        return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
+        var hash = Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
+        cancellationToken.ThrowIfCancellationRequested();
+        return hash;
     }
 
-    private static bool TryReadManifest(ZipArchiveEntry manifestEntry, JsonSerializerOptions jsonOptions, out ExportManifest manifest, out string message)
+    private static bool TryReadManifest(ZipArchiveEntry manifestEntry, JsonSerializerOptions jsonOptions, out ExportManifest manifest, out string message, CancellationToken cancellationToken)
     {
         if (!TryValidateManifestEntrySize(manifestEntry, out message))
         {
@@ -662,10 +721,12 @@ internal static class ExportImportCommandRunner
 
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             using var stream = manifestEntry.Open();
             using var manifestBytes = new MemoryStream((int)Math.Min(Math.Max(manifestEntry.Length, 0), MaxImportManifestBytes));
-            CopyToWithLimit(stream, manifestBytes, MaxImportManifestBytes, ManifestEntryName);
+            CopyToWithLimit(stream, manifestBytes, MaxImportManifestBytes, ManifestEntryName, cancellationToken);
             manifestBytes.Position = 0;
+            cancellationToken.ThrowIfCancellationRequested();
             var parsedManifest = JsonSerializer.Deserialize<ExportManifest>(manifestBytes, CreateImportManifestJsonOptions(jsonOptions));
             if (parsedManifest == null)
             {
@@ -810,10 +871,10 @@ internal static class ExportImportCommandRunner
         return true;
     }
 
-    private static bool TryValidateImportedManifest(ExportManifest manifest, string dbPath, out string message, out string phase)
+    private static bool TryValidateImportedManifest(ExportManifest manifest, string dbPath, out string message, out string phase, CancellationToken cancellationToken)
     {
         phase = PhaseSha256;
-        var actualSha256 = ComputeSha256(dbPath);
+        var actualSha256 = ComputeSha256(dbPath, cancellationToken);
         if (!string.Equals(manifest.DatabaseSha256, actualSha256, StringComparison.OrdinalIgnoreCase))
         {
             message = "database_sha256 does not match codeindex.db";
@@ -824,13 +885,14 @@ internal static class ExportImportCommandRunner
         int actualUserVersion;
         try
         {
+            cancellationToken.ThrowIfCancellationRequested();
             using var connection = new SqliteConnection(CreateUnpooledConnectionString(dbPath));
             connection.Open();
             actualUserVersion = ReadSqliteUserVersion(connection);
-            if (!TryValidateManifestCount(manifest.FileCount, connection, "files", "file_count", out message)
-                || !TryValidateManifestCount(manifest.ChunkCount, connection, "chunks", "chunk_count", out message)
-                || !TryValidateManifestCount(manifest.SymbolCount, connection, "symbols", "symbol_count", out message)
-                || !TryValidateManifestCount(manifest.ReferenceCount, connection, "symbol_references", "reference_count", out message))
+            if (!TryValidateManifestCount(manifest.FileCount, connection, "files", "file_count", out message, cancellationToken)
+                || !TryValidateManifestCount(manifest.ChunkCount, connection, "chunks", "chunk_count", out message, cancellationToken)
+                || !TryValidateManifestCount(manifest.SymbolCount, connection, "symbols", "symbol_count", out message, cancellationToken)
+                || !TryValidateManifestCount(manifest.ReferenceCount, connection, "symbol_references", "reference_count", out message, cancellationToken))
             {
                 return false;
             }
@@ -859,7 +921,7 @@ internal static class ExportImportCommandRunner
         return Convert.ToInt32(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
     }
 
-    private static bool TryValidateManifestCount(long? expected, SqliteConnection connection, string tableName, string fieldName, out string message)
+    private static bool TryValidateManifestCount(long? expected, SqliteConnection connection, string tableName, string fieldName, out string message, CancellationToken cancellationToken)
     {
         if (expected == null)
         {
@@ -867,7 +929,7 @@ internal static class ExportImportCommandRunner
             return true;
         }
 
-        var actual = ReadTableCount(connection, tableName);
+        var actual = ReadTableCount(connection, tableName, cancellationToken);
         if (actual != expected.Value)
         {
             message = $"manifest {fieldName} `{expected.Value}` does not match codeindex.db {tableName} count `{actual}`";
@@ -903,7 +965,11 @@ internal static class ExportImportCommandRunner
     }
 
     private static long ReadTableCount(SqliteConnection connection, string tableName)
+        => ReadTableCount(connection, tableName, CancellationToken.None);
+
+    private static long ReadTableCount(SqliteConnection connection, string tableName, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         using var cmd = connection.CreateCommand();
         cmd.CommandText = tableName switch
         {
@@ -913,7 +979,9 @@ internal static class ExportImportCommandRunner
             "symbol_references" => "SELECT COUNT(*) FROM symbol_references",
             _ => throw new ArgumentOutOfRangeException(nameof(tableName), tableName, "Unsupported manifest count table."),
         };
-        return Convert.ToInt64(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+        var count = Convert.ToInt64(cmd.ExecuteScalar(), CultureInfo.InvariantCulture);
+        cancellationToken.ThrowIfCancellationRequested();
+        return count;
     }
 
     private static string? ReadMetaString(SqliteConnection connection, string key)
@@ -1017,28 +1085,38 @@ internal static class ExportImportCommandRunner
         return true;
     }
 
-    private static void ExtractDatabaseEntryToFile(ZipArchiveEntry dbEntry, string destinationPath)
+    private static void ExtractDatabaseEntryToFile(ZipArchiveEntry dbEntry, string destinationPath, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         using var source = dbEntry.Open();
         using var target = File.Open(destinationPath, FileMode.Create, FileAccess.Write, FileShare.None);
-        CopyToWithLimit(source, target, MaxImportDatabaseBytes);
+        CopyToWithLimit(source, target, MaxImportDatabaseBytes, cancellationToken);
     }
 
     internal static long CopyToWithLimit(Stream source, Stream target, long maxBytes)
         => CopyToWithLimit(source, target, maxBytes, DatabaseEntryName);
 
+    internal static long CopyToWithLimit(Stream source, Stream target, long maxBytes, CancellationToken cancellationToken)
+        => CopyToWithLimit(source, target, maxBytes, DatabaseEntryName, cancellationToken);
+
     private static long CopyToWithLimit(Stream source, Stream target, long maxBytes, string entryName)
+        => CopyToWithLimit(source, target, maxBytes, entryName, CancellationToken.None);
+
+    private static long CopyToWithLimit(Stream source, Stream target, long maxBytes, string entryName, CancellationToken cancellationToken)
     {
         var buffer = new byte[ImportCopyBufferSize];
         long totalBytes = 0;
         int bytesRead;
+        cancellationToken.ThrowIfCancellationRequested();
         while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (totalBytes > maxBytes - bytesRead)
                 throw new InvalidDataException($"archive {entryName} exceeds the import limit of {ConsoleUi.FormatBytes(maxBytes)}.");
 
             target.Write(buffer, 0, bytesRead);
             totalBytes += bytesRead;
+            cancellationToken.ThrowIfCancellationRequested();
         }
 
         return totalBytes;
@@ -1079,13 +1157,19 @@ internal static class ExportImportCommandRunner
             : prefix;
 
     internal static void CreateDatabaseSnapshot(string sourceDbPath, string snapshotPath)
+        => CreateDatabaseSnapshot(sourceDbPath, snapshotPath, CancellationToken.None);
+
+    internal static void CreateDatabaseSnapshot(string sourceDbPath, string snapshotPath, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         using var source = new SqliteConnection(CreateUnpooledConnectionString(sourceDbPath));
         using var destination = new SqliteConnection(CreateUnpooledConnectionString(snapshotPath));
         source.Open();
         destination.Open();
         DataDirectorySecurity.ApplyPrivateFileMode(snapshotPath);
+        cancellationToken.ThrowIfCancellationRequested();
         source.BackupDatabase(destination);
+        cancellationToken.ThrowIfCancellationRequested();
         DataDirectorySecurity.ApplyPrivateFileMode(snapshotPath);
     }
 
@@ -1101,7 +1185,11 @@ internal static class ExportImportCommandRunner
         }.ConnectionString;
 
     internal static void ReplaceImportedDatabase(string tempPath, string fullDbPath)
+        => ReplaceImportedDatabase(tempPath, fullDbPath, CancellationToken.None);
+
+    internal static void ReplaceImportedDatabase(string tempPath, string fullDbPath, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var dbBackupPath = MoveExistingReplacementFileToBackup(fullDbPath);
         var sidecarBackups = new List<ReplacementBackup>(capacity: 2);
         try
@@ -1109,10 +1197,12 @@ internal static class ExportImportCommandRunner
             AddReplacementBackup(sidecarBackups, fullDbPath + "-wal");
             AddReplacementBackup(sidecarBackups, fullDbPath + "-shm");
 
+            cancellationToken.ThrowIfCancellationRequested();
             File.Move(tempPath, fullDbPath, overwrite: false);
+            cancellationToken.ThrowIfCancellationRequested();
             ApplyImportedDatabasePrivateFileMode(fullDbPath);
         }
-        catch (Exception ex) when (IsRecoverableReplacementException(ex))
+        catch (OperationCanceledException)
         {
             try
             {
@@ -1120,16 +1210,70 @@ internal static class ExportImportCommandRunner
             }
             catch (Exception rollbackEx) when (IsRecoverableReplacementException(rollbackEx))
             {
+                CommandErrorWriter.WriteStderr($"Warning: failed to roll back cancelled imported database replacement ({CommandErrorWriter.FormatSanitizedException(rollbackEx)}).");
+            }
+
+            throw;
+        }
+        catch (Exception ex) when (IsRecoverableReplacementException(ex))
+        {
+            Exception? rollbackFailure = null;
+            try
+            {
+                RollBackImportedDatabaseReplacement(fullDbPath, dbBackupPath, sidecarBackups);
+            }
+            catch (Exception rollbackEx) when (IsRecoverableReplacementException(rollbackEx))
+            {
+                rollbackFailure = rollbackEx;
                 CommandErrorWriter.WriteStderr($"Warning: failed to roll back imported database replacement ({CommandErrorWriter.FormatSanitizedException(rollbackEx)}).");
             }
 
-            throw new IOException("import database replacement failed; rolled back the previous destination database when possible.", ex);
+            throw new ImportReplacementException(
+                "import database replacement failed; rolled back the previous destination database when possible.",
+                ex,
+                BuildReplacementDiagnostics(tempPath, fullDbPath, dbBackupPath, sidecarBackups, rollbackFailure));
         }
 
         DeleteReplacementBackup(dbBackupPath, "import replaced database backup");
         foreach (var backup in sidecarBackups)
             DeleteReplacementBackup(backup.BackupPath, "import replaced database sidecar backup", DeleteSqliteSidecarForTesting);
     }
+
+    private static IReadOnlyList<ExportImportDiagnosticResult> BuildReplacementDiagnostics(
+        string tempPath,
+        string fullDbPath,
+        string? dbBackupPath,
+        IReadOnlyList<ReplacementBackup> sidecarBackups,
+        Exception? rollbackFailure)
+    {
+        var diagnostics = new List<ExportImportDiagnosticResult>
+        {
+            CreateResidualStateDiagnostic("import_replace_destination_state", "destination database", fullDbPath),
+            CreateResidualStateDiagnostic("import_replace_staged_state", "staged import database", tempPath),
+        };
+
+        if (dbBackupPath != null)
+            diagnostics.Add(CreateResidualStateDiagnostic("import_replace_backup_state", "destination database backup", dbBackupPath));
+
+        foreach (var backup in sidecarBackups)
+            diagnostics.Add(CreateResidualStateDiagnostic("import_replace_sidecar_backup_state", "destination sidecar backup", backup.BackupPath));
+
+        if (rollbackFailure != null)
+        {
+            diagnostics.Add(new ExportImportDiagnosticResult(
+                "import_replace_rollback_failed",
+                $"Rollback failed while restoring the previous destination database ({CommandErrorWriter.FormatSanitizedException(rollbackFailure)}).",
+                ConsoleUi.FormatBoundedValue(fullDbPath)));
+        }
+
+        return diagnostics;
+    }
+
+    private static ExportImportDiagnosticResult CreateResidualStateDiagnostic(string code, string description, string path)
+        => new(
+            code,
+            $"{description} exists after replacement failure: {(File.Exists(path) ? "true" : "false")}.",
+            ConsoleUi.FormatBoundedValue(path));
 
     private static void ApplyImportedDatabasePrivateFileMode(string fullDbPath)
     {
@@ -1333,8 +1477,10 @@ internal static class ExportImportCommandRunner
         string errorCode,
         string message,
         string hint,
-        string usage)
-        => WriteStructuredError(json, jsonOptions, ImportCommandName, phase, errorCode, message, hint, usage);
+        string usage,
+        int exitCode = CommandExitCodes.UsageError,
+        IReadOnlyList<ExportImportDiagnosticResult>? diagnostics = null)
+        => WriteStructuredError(json, jsonOptions, ImportCommandName, phase, errorCode, message, hint, usage, exitCode, diagnostics);
 
     private static int WriteExportError(
         bool json,
@@ -1343,8 +1489,10 @@ internal static class ExportImportCommandRunner
         string errorCode,
         string message,
         string hint,
-        string usage)
-        => WriteStructuredError(json, jsonOptions, ExportCommandName, phase, errorCode, message, hint, usage);
+        string usage,
+        int exitCode = CommandExitCodes.UsageError,
+        IReadOnlyList<ExportImportDiagnosticResult>? diagnostics = null)
+        => WriteStructuredError(json, jsonOptions, ExportCommandName, phase, errorCode, message, hint, usage, exitCode, diagnostics);
 
     private static int WriteStructuredError(
         bool json,
@@ -1354,17 +1502,19 @@ internal static class ExportImportCommandRunner
         string errorCode,
         string message,
         string hint,
-        string usage)
+        string usage,
+        int exitCode,
+        IReadOnlyList<ExportImportDiagnosticResult>? diagnostics)
     {
         if (json)
         {
             Console.WriteLine(JsonSerializer.Serialize(
-                new ExportImportErrorResult("1", "error", command, phase, errorCode, message, hint, usage),
+                new ExportImportErrorResult("1", "error", command, phase, errorCode, message, hint, usage, diagnostics),
                 CliJsonSerializerContextFactory.Create(jsonOptions).ExportImportErrorResult));
-            return CommandExitCodes.UsageError;
+            return exitCode;
         }
 
-        return WriteError(message, hint, usage);
+        return CommandErrorWriter.Write(message, exitCode, hint, usage);
     }
 
     private static void AddImportValidationPhase(
@@ -1437,7 +1587,16 @@ internal static class ExportImportCommandRunner
         [property: JsonPropertyName("error_code")] string ErrorCode,
         [property: JsonPropertyName("message")] string Message,
         [property: JsonPropertyName("hint")] string Hint,
-        [property: JsonPropertyName("usage")] string Usage);
+        [property: JsonPropertyName("usage")] string Usage,
+        [property: JsonPropertyName("diagnostics")]
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        IReadOnlyList<ExportImportDiagnosticResult>? Diagnostics = null);
+    internal sealed record ExportImportDiagnosticResult(
+        [property: JsonPropertyName("code")] string Code,
+        [property: JsonPropertyName("message")] string Message,
+        [property: JsonPropertyName("path")]
+        [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        string? Path = null);
     internal sealed record ImportValidationPhaseResult(
         [property: JsonPropertyName("phase")] string Phase,
         [property: JsonPropertyName("status")] string Status,
@@ -1499,4 +1658,15 @@ internal static class ExportImportCommandRunner
         [property: JsonPropertyName("unknown_extension_file_sample_count")] int? UnknownExtensionFileSampleCount = null,
         [property: JsonPropertyName("unknown_extension_file_sample_limit")] int? UnknownExtensionFileSampleLimit = null,
         [property: JsonPropertyName("unknown_extension_file_sample_truncated")] bool? UnknownExtensionFileSampleTruncated = null);
+
+    private sealed class ImportReplacementException : IOException
+    {
+        internal ImportReplacementException(string message, Exception innerException, IReadOnlyList<ExportImportDiagnosticResult> diagnostics)
+            : base(message, innerException)
+        {
+            Diagnostics = diagnostics;
+        }
+
+        internal IReadOnlyList<ExportImportDiagnosticResult> Diagnostics { get; }
+    }
 }

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -13,12 +13,15 @@ internal static class ExportImportCommandRunner
 {
     private const string ManifestEntryName = "manifest.json";
     private const string DatabaseEntryName = "codeindex.db";
+    private static readonly string[] ExpectedImportArchiveEntryNames = [ManifestEntryName, DatabaseEntryName];
     internal const int MaxImportManifestBytes = 64 * 1024;
     internal const int MaxImportManifestJsonDepth = 16;
     internal const long MaxImportDatabaseBytes = 8L * 1024 * 1024 * 1024;
+    internal const long MaxImportDatabaseCompressionRatio = 1000;
     private const int ImportCopyBufferSize = 81920;
     private const int ManifestUnknownExtensionFileLimit = DbContext.UnknownExtensionFilePathSampleLimit;
     private const int ManifestUnknownExtensionPathCharLimit = 4096;
+    private const int ManifestUnknownExtensionFilesTotalCharLimit = 32 * 1024;
     private static readonly DateTimeOffset DeterministicZipTimestamp = new(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
     private const string ExportCommandName = "export";
     private const string ImportCommandName = "import";
@@ -35,10 +38,11 @@ internal static class ExportImportCommandRunner
     private const string ImportUsage = "cdidx import <archive> [--db <path>] [--prune-paths] [--dry-run|--check] [--json]";
     private const string CtagsExportUsage = "cdidx export ctags [--output <path>] [--db <path>] [--json] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests]";
 
-    public static int RunExport(string[] args, JsonSerializerOptions jsonOptions, string appVersion)
-        => RunExport(args, jsonOptions, appVersion, CancellationToken.None);
-
-    public static int RunExport(string[] args, JsonSerializerOptions jsonOptions, string appVersion, CancellationToken cancellationToken)
+    public static int RunExport(
+        string[] args,
+        JsonSerializerOptions jsonOptions,
+        string appVersion,
+        CancellationToken cancellationToken = default)
     {
         if (args.Length > 0 && args[0] == "ctags")
             return RunExportCtags(args[1..], jsonOptions);
@@ -46,10 +50,7 @@ internal static class ExportImportCommandRunner
         return RunExportArchive(args, jsonOptions, appVersion, cancellationToken);
     }
 
-    public static int RunImport(string[] args, JsonSerializerOptions jsonOptions)
-        => RunImport(args, jsonOptions, CancellationToken.None);
-
-    public static int RunImport(string[] args, JsonSerializerOptions jsonOptions, CancellationToken cancellationToken)
+    public static int RunImport(string[] args, JsonSerializerOptions jsonOptions, CancellationToken cancellationToken = default)
     {
         string? archivePath = null;
         string? dbPath = null;
@@ -125,10 +126,25 @@ internal static class ExportImportCommandRunner
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 AddImportValidationPhase(validationPhases, PhaseOpenArchive);
+                if (!TryValidateImportArchiveEntries(
+                        archive,
+                        out var manifestEntry,
+                        out var dbEntry,
+                        out var entryValidationPhase,
+                        out var entryValidationErrorCode,
+                        out var entryValidationMessage))
+                {
+                    return WriteImportError(
+                        wantsJson,
+                        jsonOptions,
+                        entryValidationPhase,
+                        entryValidationErrorCode,
+                        entryValidationMessage,
+                        "use an archive produced by `cdidx export <archive>`.",
+                        ImportUsage);
+                }
+
                 phase = PhaseManifest;
-                var manifestEntry = archive.GetEntry(ManifestEntryName);
-                if (manifestEntry == null)
-                    return WriteImportError(wantsJson, jsonOptions, PhaseManifest, "import_manifest_missing", "archive is missing manifest.json.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
                 if (!TryReadManifest(manifestEntry, jsonOptions, out var manifest, out var manifestError, cancellationToken))
                     return WriteImportError(wantsJson, jsonOptions, PhaseManifest, "import_manifest_invalid", $"archive manifest is invalid: {manifestError}.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
                 if (!TryValidateManifestHeader(manifest, out var manifestHeaderError))
@@ -137,9 +153,8 @@ internal static class ExportImportCommandRunner
                 AddImportValidationPhase(validationPhases, PhaseManifest);
 
                 phase = PhaseDatabaseEntry;
-                var dbEntry = archive.GetEntry(DatabaseEntryName);
                 if (dbEntry == null)
-                    return WriteImportError(wantsJson, jsonOptions, PhaseDatabaseEntry, "import_database_entry_missing", "archive is missing codeindex.db.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
+                    return WriteImportError(wantsJson, jsonOptions, PhaseDatabaseEntry, "import_database_entry_missing", $"archive is missing {DatabaseEntryName}.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
                 if (!TryValidateDatabaseEntrySize(dbEntry.Length, dbEntry.CompressedLength, out var sizeValidationMessage))
                     return WriteImportError(wantsJson, jsonOptions, PhaseDatabaseEntry, "import_database_entry_too_large", sizeValidationMessage, "re-export a smaller CodeIndex database or rebuild a smaller index.", ImportUsage);
 
@@ -711,6 +726,67 @@ internal static class ExportImportCommandRunner
         return hash;
     }
 
+    private static bool TryValidateImportArchiveEntries(
+        ZipArchive archive,
+        out ZipArchiveEntry manifestEntry,
+        out ZipArchiveEntry? databaseEntry,
+        out string phase,
+        out string errorCode,
+        out string message)
+    {
+        manifestEntry = null!;
+        databaseEntry = null!;
+        phase = PhaseOpenArchive;
+        errorCode = string.Empty;
+        message = string.Empty;
+
+        var entries = new Dictionary<string, ZipArchiveEntry>(StringComparer.Ordinal);
+        foreach (var entry in archive.Entries)
+        {
+            if (!IsExpectedImportArchiveEntryName(entry.FullName))
+            {
+                errorCode = "import_archive_unexpected_entry";
+                message = $"archive contains unexpected entry {ConsoleUi.FormatBoundedValue(entry.FullName)}; expected only {FormatExpectedImportArchiveEntryNames()}.";
+                return false;
+            }
+
+            if (entries.ContainsKey(entry.FullName))
+            {
+                phase = GetImportArchiveEntryPhase(entry.FullName);
+                errorCode = "import_archive_duplicate_entry";
+                message = $"archive contains duplicate entry {ConsoleUi.FormatBoundedValue(entry.FullName)}.";
+                return false;
+            }
+
+            entries.Add(entry.FullName, entry);
+        }
+
+        if (!entries.TryGetValue(ManifestEntryName, out var foundManifestEntry))
+        {
+            phase = PhaseManifest;
+            errorCode = "import_manifest_missing";
+            message = $"archive is missing {ManifestEntryName}.";
+            return false;
+        }
+
+        manifestEntry = foundManifestEntry;
+        entries.TryGetValue(DatabaseEntryName, out databaseEntry);
+        return true;
+    }
+
+    private static bool IsExpectedImportArchiveEntryName(string name)
+        => Array.Exists(ExpectedImportArchiveEntryNames, expected => string.Equals(expected, name, StringComparison.Ordinal));
+
+    private static string GetImportArchiveEntryPhase(string name)
+        => string.Equals(name, ManifestEntryName, StringComparison.Ordinal)
+            ? PhaseManifest
+            : string.Equals(name, DatabaseEntryName, StringComparison.Ordinal)
+                ? PhaseDatabaseEntry
+                : PhaseOpenArchive;
+
+    private static string FormatExpectedImportArchiveEntryNames()
+        => string.Join(", ", ExpectedImportArchiveEntryNames.Select(name => $"`{name}`"));
+
     internal static string FormatImportManifestReadException(Exception ex)
         => CommandErrorWriter.FormatSanitizedException(ex);
 
@@ -860,11 +936,25 @@ internal static class ExportImportCommandRunner
 
         if (manifest.UnknownExtensionFiles != null)
         {
+            var totalPathChars = 0;
             foreach (var path in manifest.UnknownExtensionFiles)
             {
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    message = "unknown_extension_files contains an empty path";
+                    return false;
+                }
+
                 if (path.Length > ManifestUnknownExtensionPathCharLimit)
                 {
                     message = $"unknown_extension_files contains a path longer than {ManifestUnknownExtensionPathCharLimit} characters";
+                    return false;
+                }
+
+                totalPathChars += path.Length;
+                if (totalPathChars > ManifestUnknownExtensionFilesTotalCharLimit)
+                {
+                    message = $"unknown_extension_files total path text exceeds the manifest limit of {ManifestUnknownExtensionFilesTotalCharLimit} characters";
                     return false;
                 }
             }
@@ -1084,6 +1174,18 @@ internal static class ExportImportCommandRunner
             return false;
         }
 
+        if (uncompressedLength > 0 && compressedLength == 0)
+        {
+            message = "archive codeindex.db compression metadata is invalid: non-empty entry has zero compressed bytes";
+            return false;
+        }
+
+        if (compressedLength > 0 && uncompressedLength > compressedLength * MaxImportDatabaseCompressionRatio)
+        {
+            message = $"archive codeindex.db compression ratio exceeds the import limit of {MaxImportDatabaseCompressionRatio}:1";
+            return false;
+        }
+
         message = string.Empty;
         return true;
     }
@@ -1099,27 +1201,41 @@ internal static class ExportImportCommandRunner
     internal static long CopyToWithLimit(Stream source, Stream target, long maxBytes)
         => CopyToWithLimit(source, target, maxBytes, DatabaseEntryName);
 
-    internal static long CopyToWithLimit(Stream source, Stream target, long maxBytes, CancellationToken cancellationToken)
-        => CopyToWithLimit(source, target, maxBytes, DatabaseEntryName, cancellationToken);
+    internal static long CopyToWithLimit(
+        Stream source,
+        Stream target,
+        long maxBytes,
+        CancellationToken cancellationToken,
+        IProgress<long>? progress = null)
+        => CopyToWithLimit(source, target, maxBytes, DatabaseEntryName, cancellationToken, progress);
 
     private static long CopyToWithLimit(Stream source, Stream target, long maxBytes, string entryName)
         => CopyToWithLimit(source, target, maxBytes, entryName, CancellationToken.None);
 
-    private static long CopyToWithLimit(Stream source, Stream target, long maxBytes, string entryName, CancellationToken cancellationToken)
+    private static long CopyToWithLimit(
+        Stream source,
+        Stream target,
+        long maxBytes,
+        string entryName,
+        CancellationToken cancellationToken = default,
+        IProgress<long>? progress = null)
     {
         var buffer = new byte[ImportCopyBufferSize];
         long totalBytes = 0;
         int bytesRead;
-        cancellationToken.ThrowIfCancellationRequested();
-        while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
+        while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            bytesRead = source.Read(buffer, 0, buffer.Length);
+            if (bytesRead == 0)
+                break;
+
             if (totalBytes > maxBytes - bytesRead)
                 throw new InvalidDataException($"archive {entryName} exceeds the import limit of {ConsoleUi.FormatBytes(maxBytes)}.");
 
             target.Write(buffer, 0, bytesRead);
             totalBytes += bytesRead;
-            cancellationToken.ThrowIfCancellationRequested();
+            progress?.Report(totalBytes);
         }
 
         return totalBytes;

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -199,7 +199,13 @@ internal sealed record DiffJsonResult(
     [property: JsonPropertyName("symbols_only_in_left")] List<string>? SymbolsOnlyInLeft,
     [property: JsonPropertyName("symbols_only_in_right")] List<string>? SymbolsOnlyInRight,
     [property: JsonPropertyName("limit")] int Limit,
-    [property: JsonPropertyName("detailed")] bool Detailed);
+    [property: JsonPropertyName("detailed")] bool Detailed,
+    [property: JsonPropertyName("truncated")] bool Truncated = false,
+    [property: JsonPropertyName("diagnostics")] List<DiffDiagnosticJsonResult>? Diagnostics = null);
+
+internal sealed record DiffDiagnosticJsonResult(
+    [property: JsonPropertyName("code")] string Code,
+    [property: JsonPropertyName("message")] string Message);
 
 internal sealed record DiffSummaryOnlyJsonResult(
     [property: JsonPropertyName("status")] string Status,

--- a/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
@@ -254,7 +254,7 @@ internal static partial class ProgramRunner
             "hooks" => HookCommandRunner.Run(subArgs, context.JsonOptions),
             "backfill-fold" => IndexCommandRunner.RunBackfillFold(subArgs, context.JsonOptions),
             "optimize" => IndexCommandRunner.RunOptimizeFts(subArgs, context.JsonOptions),
-            "vacuum" => QueryCommandRunner.RunVacuum(subArgs, context.JsonOptions),
+            "vacuum" => QueryCommandRunner.RunVacuum(subArgs, context.JsonOptions, context.CancellationToken),
             "validate-config" => CdidxConfigFile.RunValidate(subArgs, context.JsonOptions),
             "config" => subArgs.Length > 0 && subArgs[0] == "show"
                 ? CdidxConfigFile.RunShow(subArgs[1..], context.JsonOptions)
@@ -265,7 +265,7 @@ internal static partial class ProgramRunner
                     CommandExitCodes.UsageError,
                     "use `cdidx config show`."),
             "workspace" => WorkspaceCommandRunner.Run(subArgs, context.JsonOptions),
-            "db" => DbCommandRunner.Run(subArgs, context.JsonOptions),
+            "db" => DbCommandRunner.Run(subArgs, context.JsonOptions, context.CancellationToken),
             "report" => ReportCommandRunner.Run(subArgs, context.JsonOptions, context.AppVersion),
             "test-extractor" => RunTestExtractor(subArgs, context.JsonOptions),
             _ when IsProjectPathArg(commandName)

--- a/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
@@ -248,8 +248,8 @@ internal static partial class ProgramRunner
         {
             "upgrade" => RunUpgrade(subArgs, context.JsonOptions, context.AppVersion, context.CancellationToken),
             "index" => IndexCommandRunner.Run(subArgs, context.JsonOptions),
-            "export" => ExportImportCommandRunner.RunExport(subArgs, context.JsonOptions, context.AppVersion),
-            "import" => ExportImportCommandRunner.RunImport(subArgs, context.JsonOptions),
+            "export" => ExportImportCommandRunner.RunExport(subArgs, context.JsonOptions, context.AppVersion, context.CancellationToken),
+            "import" => ExportImportCommandRunner.RunImport(subArgs, context.JsonOptions, context.CancellationToken),
             "diff" => DiffCommandRunner.Run(subArgs, context.JsonOptions, context.CancellationToken),
             "hooks" => HookCommandRunner.Run(subArgs, context.JsonOptions),
             "backfill-fold" => IndexCommandRunner.RunBackfillFold(subArgs, context.JsonOptions),

--- a/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
@@ -250,7 +250,7 @@ internal static partial class ProgramRunner
             "index" => IndexCommandRunner.Run(subArgs, context.JsonOptions),
             "export" => ExportImportCommandRunner.RunExport(subArgs, context.JsonOptions, context.AppVersion),
             "import" => ExportImportCommandRunner.RunImport(subArgs, context.JsonOptions),
-            "diff" => DiffCommandRunner.Run(subArgs, context.JsonOptions),
+            "diff" => DiffCommandRunner.Run(subArgs, context.JsonOptions, context.CancellationToken),
             "hooks" => HookCommandRunner.Run(subArgs, context.JsonOptions),
             "backfill-fold" => IndexCommandRunner.RunBackfillFold(subArgs, context.JsonOptions),
             "optimize" => IndexCommandRunner.RunOptimizeFts(subArgs, context.JsonOptions),

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -2399,16 +2399,22 @@ public static partial class QueryCommandRunner
     private static bool TryParseSearchCursor(string value, out SearchCursor cursor)
     {
         cursor = default;
-        var parts = value.Split(':');
-        if (parts.Length != 3)
+        var lastSeparator = value.LastIndexOf(':');
+        if (lastSeparator <= 0 || lastSeparator == value.Length - 1)
             return false;
-        if (!double.TryParse(parts[0], NumberStyles.Float, CultureInfo.InvariantCulture, out var score) ||
-            !long.TryParse(parts[1], NumberStyles.Integer, CultureInfo.InvariantCulture, out var chunkId) ||
-            !int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var offset) ||
-            offset < 0)
-        {
+
+        var firstSeparator = value.LastIndexOf(':', lastSeparator - 1);
+        if (firstSeparator <= 0 || firstSeparator == lastSeparator - 1)
             return false;
-        }
+
+        if (!double.TryParse(value.AsSpan(0, firstSeparator), NumberStyles.Float, CultureInfo.InvariantCulture, out var score)
+            || !double.IsFinite(score))
+            return false;
+        if (!long.TryParse(value.AsSpan(firstSeparator + 1, lastSeparator - firstSeparator - 1), NumberStyles.None, CultureInfo.InvariantCulture, out var chunkId)
+            || chunkId < 0)
+            return false;
+        if (!int.TryParse(value.AsSpan(lastSeparator + 1), NumberStyles.None, CultureInfo.InvariantCulture, out var offset) || offset < 0)
+            return false;
 
         cursor = new SearchCursor(score, chunkId, offset);
         return true;

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -6366,6 +6366,9 @@ public static partial class QueryCommandRunner
     }
 
     public static int RunVacuum(string[] cmdArgs, JsonSerializerOptions jsonOptions)
+        => RunVacuum(cmdArgs, jsonOptions, CancellationToken.None);
+
+    public static int RunVacuum(string[] cmdArgs, JsonSerializerOptions jsonOptions, CancellationToken cancellationToken)
     {
         var options = ParseArgs(
             cmdArgs,
@@ -6387,39 +6390,53 @@ public static partial class QueryCommandRunner
         if (TryWriteUnexpectedPositionals("vacuum", options))
             return CommandExitCodes.UsageError;
 
-        if (!DbContext.TryValidateExistingCodeIndexDb(options.DbPath, out var validationMessage, out var isNotFound))
+        try
         {
-            CommandErrorWriter.WriteStderr($"Error [{(isNotFound ? CommandErrorCodes.DbNotFound : CommandErrorCodes.DbError)}]: {validationMessage}");
-            CommandErrorWriter.WriteStderr(isNotFound
-                ? "Hint: point `--db` at an existing `codeindex.db`, or run `cdidx index <projectPath>` first to create one."
-                : "Hint: point `--db` at an existing CodeIndex database created by `cdidx index`, then retry `cdidx vacuum`.");
-            return isNotFound ? CommandExitCodes.NotFound : CommandExitCodes.DatabaseError;
-        }
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!DbContext.TryValidateExistingCodeIndexDb(options.DbPath, out var validationMessage, out var isNotFound, cancellationToken: cancellationToken))
+            {
+                CommandErrorWriter.WriteStderr($"Error [{(isNotFound ? CommandErrorCodes.DbNotFound : CommandErrorCodes.DbError)}]: {validationMessage}");
+                CommandErrorWriter.WriteStderr(isNotFound
+                    ? "Hint: point `--db` at an existing `codeindex.db`, or run `cdidx index <projectPath>` first to create one."
+                    : "Hint: point `--db` at an existing CodeIndex database created by `cdidx index`, then retry `cdidx vacuum`.");
+                return isNotFound ? CommandExitCodes.NotFound : CommandExitCodes.DatabaseError;
+            }
 
-        using var db = new DbContext(options.DbPath);
-        var result = db.RunIncrementalVacuum(options.DryRun);
-        if (options.Json)
-        {
-            Console.WriteLine(JsonSerializer.Serialize(
-                result,
-                CliJsonSerializerContextFactory.Create(jsonOptions).VacuumResult));
-        }
-        else
-        {
-            Console.WriteLine(result.DryRun
-                ? $"Vacuum dry run: estimated reclaimable {result.EstimatedPagesReclaimable:N0} page(s) ({result.EstimatedBytesReclaimable:N0} bytes)."
-                : $"Vacuum complete: reclaimed {result.PagesReclaimed:N0} page(s) ({result.BytesReclaimed:N0} bytes).");
-            Console.WriteLine(ConsoleUi.FormatSummaryLine("Page size", $"{result.PageSize:N0} bytes"));
-            Console.WriteLine(ConsoleUi.FormatSummaryLine("Pages", $"{result.PageCountBefore:N0} -> {result.PageCountAfter:N0}"));
-            Console.WriteLine(ConsoleUi.FormatSummaryLine("Freelist", $"{result.FreelistCountBefore:N0} -> {result.FreelistCountAfter:N0}"));
-            Console.WriteLine(ConsoleUi.FormatSummaryLine("AutoVac", $"{result.AutoVacuumModeBeforeName} -> {result.AutoVacuumModeAfterName}"));
-            if (result.MaintenanceGuidance.RecommendedCommand != "none")
-                Console.WriteLine(ConsoleUi.FormatSummaryLine("Recommend", result.MaintenanceGuidance.RecommendedCommand));
-            if (!string.IsNullOrWhiteSpace(result.MaintenanceGuidance.PostMaintenanceFollowUp))
-                Console.WriteLine(ConsoleUi.FormatSummaryLine("Follow-up", result.MaintenanceGuidance.PostMaintenanceFollowUp));
-        }
+            using var db = new DbContext(options.DbPath, cancellationToken);
+            var result = db.RunIncrementalVacuum(options.DryRun, cancellationToken);
+            if (options.Json)
+            {
+                Console.WriteLine(JsonSerializer.Serialize(
+                    result,
+                    CliJsonSerializerContextFactory.Create(jsonOptions).VacuumResult));
+            }
+            else
+            {
+                Console.WriteLine(result.DryRun
+                    ? $"Vacuum dry run: estimated reclaimable {result.EstimatedPagesReclaimable:N0} page(s) ({result.EstimatedBytesReclaimable:N0} bytes)."
+                    : $"Vacuum complete: reclaimed {result.PagesReclaimed:N0} page(s) ({result.BytesReclaimed:N0} bytes).");
+                Console.WriteLine(ConsoleUi.FormatSummaryLine("Page size", $"{result.PageSize:N0} bytes"));
+                Console.WriteLine(ConsoleUi.FormatSummaryLine("Pages", $"{result.PageCountBefore:N0} -> {result.PageCountAfter:N0}"));
+                Console.WriteLine(ConsoleUi.FormatSummaryLine("Freelist", $"{result.FreelistCountBefore:N0} -> {result.FreelistCountAfter:N0}"));
+                Console.WriteLine(ConsoleUi.FormatSummaryLine("AutoVac", $"{result.AutoVacuumModeBeforeName} -> {result.AutoVacuumModeAfterName}"));
+                if (result.MaintenanceGuidance.RecommendedCommand != "none")
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("Recommend", result.MaintenanceGuidance.RecommendedCommand));
+                if (!string.IsNullOrWhiteSpace(result.MaintenanceGuidance.PostMaintenanceFollowUp))
+                    Console.WriteLine(ConsoleUi.FormatSummaryLine("Follow-up", result.MaintenanceGuidance.PostMaintenanceFollowUp));
+            }
 
-        return CommandExitCodes.Success;
+            return CommandExitCodes.Success;
+        }
+        catch (OperationCanceledException)
+        {
+            return CommandErrorWriter.WriteJsonOrHuman(
+                options.Json,
+                jsonOptions,
+                "vacuum cancelled before it could complete",
+                CommandExitCodes.CancelledBySignal,
+                "Retry `cdidx vacuum` after the cancelling operation completes.",
+                errorCode: CommandErrorCodes.Interrupted);
+        }
     }
 
     public static int RunImpact(string[] cmdArgs, JsonSerializerOptions jsonOptions)

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -2218,9 +2218,7 @@ public class DbContext : IDisposable
         const string oldSymbolReferences = "_symbol_references_file_line_key";
         var quotedOldReferenceLines = SqliteIdentifier.Quote(oldReferenceLines);
         var quotedOldSymbolReferences = SqliteIdentifier.Quote(oldSymbolReferences);
-        var foreignKeys = ReadPragmaLong("foreign_keys");
-        Execute("PRAGMA foreign_keys=OFF");
-        try
+        RunWithForeignKeysDisabledForMigration("EnsureReferenceLinesContextKey", () =>
         {
             Execute($"DROP TABLE IF EXISTS {quotedOldSymbolReferences}");
             Execute($"DROP TABLE IF EXISTS {quotedOldReferenceLines}");
@@ -2233,11 +2231,7 @@ public class DbContext : IDisposable
             Execute($"DROP TABLE {quotedOldSymbolReferences}");
             Execute($"DROP TABLE {quotedOldReferenceLines}");
             InvokeForeignKeyValidationBeforeCheckForTesting("reference_lines_context_key");
-        }
-        finally
-        {
-            Execute($"PRAGMA foreign_keys={foreignKeys}");
-        }
+        });
 
         ValidateForeignKeysAfterMigration("reference_lines_context_key");
         _schemaCache?.Refresh();
@@ -2324,10 +2318,8 @@ public class DbContext : IDisposable
             """;
         const string symbolReferencesColumns = "id, file_id, symbol_name, reference_kind, line, column_number, context, reference_line_id, container_kind, container_name, symbol_name_folded, container_name_folded, is_self_reference, is_mutual_recursion";
 
-        var foreignKeys = ReadPragmaLong("foreign_keys");
         var rebuilt = false;
-        Execute("PRAGMA foreign_keys=OFF");
-        try
+        RunWithForeignKeysDisabledForMigration("EnsureKindCheckConstraintsCurrent", () =>
         {
             if (!TableCheckContainsAll("symbols", SymbolKindCatalog.SymbolKinds))
             {
@@ -2343,14 +2335,44 @@ public class DbContext : IDisposable
 
             if (rebuilt)
                 InvokeForeignKeyValidationBeforeCheckForTesting("kind_check_constraints");
-        }
-        finally
-        {
-            Execute($"PRAGMA foreign_keys={foreignKeys}");
-        }
+        });
 
         if (rebuilt)
             ValidateForeignKeysAfterMigration("kind_check_constraints");
+    }
+
+    private void RunWithForeignKeysDisabledForMigration(string operation, Action action)
+    {
+        var foreignKeys = ReadPragmaLong("foreign_keys");
+        Execute("PRAGMA foreign_keys=OFF");
+        ExceptionDispatchInfo? operationFailure = null;
+        try
+        {
+            ForeignKeysDisabledForTesting?.Invoke(operation);
+            action();
+        }
+        catch (Exception ex)
+        {
+            operationFailure = ExceptionDispatchInfo.Capture(ex);
+        }
+
+        try
+        {
+            ForeignKeysRestoringForTesting?.Invoke(operation, foreignKeys);
+            Execute($"PRAGMA foreign_keys={foreignKeys}");
+        }
+        catch (Exception ex)
+        {
+            throw new CodeIndexException(
+                code: CommandErrorCodes.DbError,
+                category: CodeIndexExceptionCategory.Database,
+                message: $"Failed to restore PRAGMA foreign_keys after {operation}.",
+                path: _connection.DataSource,
+                hint: "Close other database connections, restore write access if needed, and rerun the command before trusting further migration work.",
+                innerException: ex);
+        }
+
+        operationFailure?.Throw();
     }
 
     private void InvokeForeignKeyValidationBeforeCheckForTesting(string phase)

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -105,6 +105,7 @@ public class DbContext : IDisposable
     private static readonly AsyncLocal<Action<SqliteCommand>?> ScopedPlannerStatisticsCommandCreatedForTesting = new();
     private static readonly AsyncLocal<Action<string, string>?> ScopedPlannerStatisticsCommandExecutedForTesting = new();
     private static readonly AsyncLocal<Action<string>?> ScopedWalCheckpointTruncateExecutedForTesting = new();
+    private static readonly AsyncLocal<Action<string, string>?> ScopedMaintenanceProgressForTesting = new();
 
     internal static Action<string>? OptimizePragmaExecutedForTesting
     {
@@ -128,6 +129,12 @@ public class DbContext : IDisposable
     {
         get => ScopedWalCheckpointTruncateExecutedForTesting.Value;
         set => ScopedWalCheckpointTruncateExecutedForTesting.Value = value;
+    }
+
+    internal static Action<string, string>? MaintenanceProgressForTesting
+    {
+        get => ScopedMaintenanceProgressForTesting.Value;
+        set => ScopedMaintenanceProgressForTesting.Value = value;
     }
 
     public SqliteConnection Connection => _connection;
@@ -459,7 +466,11 @@ public class DbContext : IDisposable
                 cancellationToken: cancellationToken);
             using var cmd = connection.CreateCommand();
             cmd.CommandText = "PRAGMA wal_checkpoint(TRUNCATE)";
+            cancellationToken.ThrowIfCancellationRequested();
+            ReportMaintenanceProgress("wal_checkpoint", "truncate_start", dbPath);
             cmd.ExecuteNonQuery();
+            ReportMaintenanceProgress("wal_checkpoint", "truncate_complete", dbPath);
+            cancellationToken.ThrowIfCancellationRequested();
             return true;
         }
         catch (Exception ex) when (ex is SqliteException or CodeIndexException)
@@ -469,19 +480,31 @@ public class DbContext : IDisposable
     }
 
     public bool TryCheckpointWalTruncate()
+        => TryCheckpointWalTruncate(CancellationToken.None);
+
+    public bool TryCheckpointWalTruncate(CancellationToken cancellationToken)
     {
         if (_isReadOnly)
             return false;
 
+        cancellationToken.ThrowIfCancellationRequested();
         _walCheckpointAttempted = true;
         try
         {
             using var cmd = _connection.CreateCommand();
             cmd.CommandText = "PRAGMA wal_checkpoint(TRUNCATE)";
             WalCheckpointTruncateExecutedForTesting?.Invoke(_connection.DataSource);
+            ReportMaintenanceProgress("wal_checkpoint", "truncate_start", _connection.DataSource);
             cmd.ExecuteNonQuery();
+            ReportMaintenanceProgress("wal_checkpoint", "truncate_complete", _connection.DataSource);
+            cancellationToken.ThrowIfCancellationRequested();
             _walCheckpointSucceeded = true;
             return true;
+        }
+        catch (OperationCanceledException)
+        {
+            _walCheckpointSucceeded = false;
+            throw;
         }
         catch (Exception)
         {
@@ -588,6 +611,9 @@ public class DbContext : IDisposable
     }
 
     public VacuumResult RunIncrementalVacuum(bool dryRun = false)
+        => RunIncrementalVacuum(dryRun, CancellationToken.None);
+
+    public VacuumResult RunIncrementalVacuum(bool dryRun, CancellationToken cancellationToken)
     {
         if (_isReadOnly && !dryRun)
         {
@@ -599,17 +625,27 @@ public class DbContext : IDisposable
                 hint: "Copy the database to writable storage or rerun cdidx without a read-only --db URI.");
         }
 
+        cancellationToken.ThrowIfCancellationRequested();
+        ReportMaintenanceProgress("vacuum", "metrics_before", _connection.DataSource);
         var before = ReadVacuumMetrics();
+        cancellationToken.ThrowIfCancellationRequested();
         if (!dryRun && before.AutoVacuumMode == 2)
         {
+            ReportMaintenanceProgress("vacuum", "incremental_vacuum", _connection.DataSource);
             Execute($"PRAGMA incremental_vacuum({before.FreelistCount})");
         }
         else if (!dryRun)
         {
+            ReportMaintenanceProgress("vacuum", "enable_incremental_autovacuum", _connection.DataSource);
             Execute("PRAGMA auto_vacuum=INCREMENTAL");
+            cancellationToken.ThrowIfCancellationRequested();
+            ReportMaintenanceProgress("vacuum", "vacuum_rebuild", _connection.DataSource);
             Execute("VACUUM");
         }
+        cancellationToken.ThrowIfCancellationRequested();
+        ReportMaintenanceProgress("vacuum", "metrics_after", _connection.DataSource);
         var after = dryRun ? before : ReadVacuumMetrics();
+        cancellationToken.ThrowIfCancellationRequested();
         var pagesReclaimed = dryRun ? 0 : Math.Max(0, before.PageCount - after.PageCount);
         var bytesReclaimed = pagesReclaimed * after.PageSize;
         var estimatedPagesReclaimable = Math.Max(0, before.FreelistCount);
@@ -642,6 +678,12 @@ public class DbContext : IDisposable
             AutoVacuumModeAfter: after.AutoVacuumMode,
             AutoVacuumModeAfterName: MaintenanceGuidanceBuilder.FormatAutoVacuumMode(after.AutoVacuumMode) ?? "unknown",
             MaintenanceGuidance: guidance);
+    }
+
+    private static void ReportMaintenanceProgress(string operation, string phase, string dbPath)
+    {
+        GlobalToolLog.Info($"db_maintenance_progress operation={operation} phase={phase} db_path={ConsoleUi.FormatBoundedValue(dbPath)}");
+        MaintenanceProgressForTesting?.Invoke(operation, phase);
     }
 
     private VacuumMetrics ReadVacuumMetrics()

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -4,6 +4,7 @@ using CodeIndex.Indexer;
 using CodeIndex.Models;
 using Microsoft.Data.Sqlite;
 using System.Globalization;
+using System.Runtime.ExceptionServices;
 
 namespace CodeIndex.Database;
 
@@ -112,6 +113,8 @@ public class DbContext : IDisposable
     private static readonly AsyncLocal<Action<string, string>?> ScopedPlannerStatisticsCommandExecutedForTesting = new();
     private static readonly AsyncLocal<Action<string>?> ScopedWalCheckpointTruncateExecutedForTesting = new();
     private static readonly AsyncLocal<Action<string, string>?> ScopedMaintenanceProgressForTesting = new();
+    private static readonly AsyncLocal<Action<string>?> ScopedForeignKeysDisabledForTesting = new();
+    private static readonly AsyncLocal<Action<string, long>?> ScopedForeignKeysRestoringForTesting = new();
     private static readonly AsyncLocal<Action<SqliteConnection, string>?> ScopedForeignKeyValidationBeforeCheckForTesting = new();
 
     internal static Action<string>? OptimizePragmaExecutedForTesting
@@ -142,6 +145,18 @@ public class DbContext : IDisposable
     {
         get => ScopedMaintenanceProgressForTesting.Value;
         set => ScopedMaintenanceProgressForTesting.Value = value;
+    }
+
+    internal static Action<string>? ForeignKeysDisabledForTesting
+    {
+        get => ScopedForeignKeysDisabledForTesting.Value;
+        set => ScopedForeignKeysDisabledForTesting.Value = value;
+    }
+
+    internal static Action<string, long>? ForeignKeysRestoringForTesting
+    {
+        get => ScopedForeignKeysRestoringForTesting.Value;
+        set => ScopedForeignKeysRestoringForTesting.Value = value;
     }
 
     internal static Action<SqliteConnection, string>? ForeignKeyValidationBeforeCheckForTesting

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -69,6 +69,8 @@ public class DbWriter
     private int _transactionDepth;
     private int _transactionOwnerThreadId;
     private Guid _transactionOwnerToken;
+    private string? _transactionOwnerOperation;
+    private DateTimeOffset _transactionOwnerAcquiredAtUtc;
     private bool? _hasIssueMetadataColumns;
     internal static TimeSpan? TransactionStateContentionTimeoutForTesting { get; set; }
     // Outermost SqliteTransaction currently held open by this writer (null when no
@@ -163,8 +165,14 @@ public class DbWriter
     /// SQLiteはネストされたBEGIN TRANSACTIONをサポートしないため、ネスト時はSAVEPOINTを使用する。
     /// </summary>
     public TransactionScope BeginTransaction()
+        => BeginTransaction(CancellationToken.None, operation: null);
+
+    public TransactionScope BeginTransaction(CancellationToken cancellationToken)
+        => BeginTransaction(cancellationToken, operation: null);
+
+    internal TransactionScope BeginTransaction(CancellationToken cancellationToken, string? operation)
     {
-        var gateLease = EnterTransactionGate();
+        var gateLease = EnterTransactionGate(cancellationToken, operation);
         try
         {
             if (_transactionDepth == 0)
@@ -191,10 +199,14 @@ public class DbWriter
         }
     }
 
-    private TransactionGateLease EnterTransactionGate()
+    private TransactionGateLease EnterTransactionGate(CancellationToken cancellationToken = default, string? operation = null)
     {
+        var timeout = GetTransactionStateContentionTimeout();
+        var stopwatch = Stopwatch.StartNew();
+        var operationLabel = string.IsNullOrWhiteSpace(operation) ? "transaction" : operation.Trim();
         while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             lock (_transactionStateLock)
             {
                 if (_transactionDepth > 0 &&
@@ -204,7 +216,14 @@ public class DbWriter
                     return TransactionGateLease.None;
             }
 
-            _transactionGate.Wait();
+            var waitMilliseconds = GetTransactionStateContentionWaitMilliseconds(timeout, stopwatch);
+            if (waitMilliseconds <= 0)
+                throw new InvalidOperationException(BuildTransactionGateTimeoutMessage(operationLabel, stopwatch));
+
+            if (!_transactionGate.Wait(waitMilliseconds, cancellationToken))
+                continue;
+
+            var ownsSemaphore = true;
             lock (_transactionStateLock)
             {
                 if (_transactionDepth == 0)
@@ -213,13 +232,17 @@ public class DbWriter
                     var token = Guid.NewGuid();
                     _transactionOwnerThreadId = Environment.CurrentManagedThreadId;
                     _transactionOwnerToken = token;
+                    _transactionOwnerOperation = operationLabel;
+                    _transactionOwnerAcquiredAtUtc = DateTimeOffset.UtcNow;
                     _currentTransactionGateToken.Value = token;
+                    ownsSemaphore = false;
                     return new TransactionGateLease(this, token, previousToken);
                 }
             }
 
-            _transactionGate.Release();
-            WaitForTransactionDepthToClear();
+            if (ownsSemaphore)
+                _transactionGate.Release();
+            WaitForTransactionDepthToClear(cancellationToken, operationLabel);
         }
     }
 
@@ -252,7 +275,7 @@ public class DbWriter
         }
     }
 
-    private void WaitForTransactionDepthToClear()
+    private void WaitForTransactionDepthToClear(CancellationToken cancellationToken, string operation)
     {
         var timeout = GetTransactionStateContentionTimeout();
         var stopwatch = Stopwatch.StartNew();
@@ -260,11 +283,11 @@ public class DbWriter
         {
             while (_transactionDepth > 0)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 var waitMilliseconds = GetTransactionStateContentionWaitMilliseconds(timeout, stopwatch);
                 if (waitMilliseconds <= 0)
                 {
-                    throw new InvalidOperationException(
-                        $"Timed out waiting for DbWriter transaction gate state to clear; transaction_depth={_transactionDepth}.");
+                    throw new InvalidOperationException(BuildTransactionGateTimeoutMessage(operation, stopwatch));
                 }
 
                 Monitor.Wait(_transactionStateLock, waitMilliseconds);
@@ -287,6 +310,30 @@ public class DbWriter
         return Math.Max(1, (int)Math.Ceiling(wait.TotalMilliseconds));
     }
 
+    private string BuildTransactionGateTimeoutMessage(string operation, Stopwatch stopwatch)
+    {
+        lock (_transactionStateLock)
+        {
+            var heldMs = _transactionOwnerAcquiredAtUtc == default
+                ? 0
+                : Math.Max(0, (long)(DateTimeOffset.UtcNow - _transactionOwnerAcquiredAtUtc).TotalMilliseconds);
+            return "Timed out waiting for DbWriter transaction gate"
+                + $"; waiter_operation={FormatTransactionGateDiagnosticValue(operation)}"
+                + $"; waiter_thread_id={Environment.CurrentManagedThreadId}"
+                + $"; owner_thread_id={_transactionOwnerThreadId}"
+                + $"; owner_operation={FormatTransactionGateDiagnosticValue(_transactionOwnerOperation)}"
+                + $"; transaction_depth={_transactionDepth}"
+                + $"; held_ms={heldMs.ToString(System.Globalization.CultureInfo.InvariantCulture)}"
+                + $"; waited_ms={((long)stopwatch.Elapsed.TotalMilliseconds).ToString(System.Globalization.CultureInfo.InvariantCulture)}.";
+        }
+    }
+
+    private static string FormatTransactionGateDiagnosticValue(string? value)
+        => ConsoleUi.FormatBoundedValue(string.IsNullOrWhiteSpace(value) ? "unknown" : value)
+            .Replace("\r", " ", StringComparison.Ordinal)
+            .Replace("\n", " ", StringComparison.Ordinal)
+            .Replace("\t", " ", StringComparison.Ordinal);
+
     private void ExitTransactionGate(Guid token, Guid? previousToken)
     {
         lock (_transactionStateLock)
@@ -295,6 +342,8 @@ public class DbWriter
             {
                 _transactionOwnerThreadId = 0;
                 _transactionOwnerToken = Guid.Empty;
+                _transactionOwnerOperation = null;
+                _transactionOwnerAcquiredAtUtc = default;
             }
         }
         if (_currentTransactionGateToken.Value == token)

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -30,6 +30,7 @@ public class DbWriter
     private readonly Action? _markWriteWork;
     private static readonly AsyncLocal<Action?> ScopedFoldBackfillRowUpdatedForTesting = new();
     private static readonly AsyncLocal<Action<string>?> ScopedBatchRowSkipWarningForTesting = new();
+    private static readonly AsyncLocal<Action<DbWriterBatchProgress>?> ScopedBatchProgressCheckpointForTesting = new();
     internal static Action? FoldBackfillRowUpdatedForTesting
     {
         get => ScopedFoldBackfillRowUpdatedForTesting.Value;
@@ -40,6 +41,12 @@ public class DbWriter
     {
         get => ScopedBatchRowSkipWarningForTesting.Value;
         set => ScopedBatchRowSkipWarningForTesting.Value = value;
+    }
+
+    internal static Action<DbWriterBatchProgress>? BatchProgressCheckpointForTesting
+    {
+        get => ScopedBatchProgressCheckpointForTesting.Value;
+        set => ScopedBatchProgressCheckpointForTesting.Value = value;
     }
 
     private readonly object _transactionStateLock = new();
@@ -89,6 +96,8 @@ public class DbWriter
     private SqliteTransaction? _activeTransaction;
     internal SqliteConnection Connection => _conn;
     public long BatchRowsSkipped => Volatile.Read(ref _batchRowsSkipped);
+
+    internal sealed record DbWriterBatchProgress(string Operation, int RowsProcessed, int RowsTotal);
 
     public DbWriter(SqliteConnection connection)
         : this(connection, commandCache: null, markWriteWork: null)
@@ -1104,26 +1113,31 @@ public class DbWriter
     /// バッチごとにプリペアドステートメントを再利用し、行ごとのコマンド生成コストを回避する。
     /// </summary>
     public void InsertChunks(IReadOnlyList<ChunkRecord> chunks)
+        => InsertChunks(chunks, CancellationToken.None);
+
+    public void InsertChunks(IReadOnlyList<ChunkRecord> chunks, CancellationToken cancellationToken)
     {
         if (chunks.Count == 0) return;
 
         int rowsPerStatement = GetRowsPerInsertStatement(columnCount: 5);
         for (int i = 0; i < chunks.Count; i += rowsPerStatement)
         {
+            CheckBatchCancellationAndReportProgress("insert_chunks", i, chunks.Count, cancellationToken);
             int end = Math.Min(i + rowsPerStatement, chunks.Count);
             try
             {
                 // Only create a batch transaction when not already inside an outer transaction
                 // 外部トランザクション内でない場合のみバッチトランザクションを作成
-                using var transaction = !IsInTransaction() ? BeginTransaction() : null;
+                using var transaction = !IsInTransaction() ? BeginTransaction(cancellationToken, "insert chunks") : null;
                 InsertChunkBatch(chunks, i, end);
                 transaction?.Commit();
             }
             catch (SqliteException batchException) when (IsRowSkippableSqliteException(batchException))
             {
-                InsertChunksWithRowSkip(chunks, i, end, batchException);
+                InsertChunksWithRowSkip(chunks, i, end, batchException, cancellationToken);
             }
         }
+        CheckBatchCancellationAndReportProgress("insert_chunks", chunks.Count, chunks.Count, cancellationToken);
     }
 
     /// <summary>
@@ -1133,34 +1147,40 @@ public class DbWriter
     /// バッチごとにプリペアドステートメントを再利用し、行ごとのコマンド生成コストを回避する。
     /// </summary>
     public void InsertSymbols(IReadOnlyList<SymbolRecord> symbols)
+        => InsertSymbols(symbols, CancellationToken.None);
+
+    public void InsertSymbols(IReadOnlyList<SymbolRecord> symbols, CancellationToken cancellationToken)
     {
         if (symbols.Count == 0) return;
 
         int rowsPerStatement = GetRowsPerInsertStatement(columnCount: 19);
         for (int i = 0; i < symbols.Count; i += rowsPerStatement)
         {
+            CheckBatchCancellationAndReportProgress("insert_symbols", i, symbols.Count, cancellationToken);
             int end = Math.Min(i + rowsPerStatement, symbols.Count);
             var foldedNameCache = new Dictionary<string, string?>(StringComparer.Ordinal);
             try
             {
                 // Only create a batch transaction when not already inside an outer transaction
                 // 外部トランザクション内でない場合のみバッチトランザクションを作成
-                using var transaction = !IsInTransaction() ? BeginTransaction() : null;
+                using var transaction = !IsInTransaction() ? BeginTransaction(cancellationToken, "insert symbols") : null;
                 InsertSymbolBatch(symbols, i, end, foldedNameCache);
                 transaction?.Commit();
             }
             catch (SqliteException batchException) when (IsRowSkippableSqliteException(batchException))
             {
-                InsertSymbolsWithRowSkip(symbols, i, end, batchException);
+                InsertSymbolsWithRowSkip(symbols, i, end, batchException, cancellationToken);
             }
         }
+        CheckBatchCancellationAndReportProgress("insert_symbols", symbols.Count, symbols.Count, cancellationToken);
     }
 
-    private void InsertChunksWithRowSkip(IReadOnlyList<ChunkRecord> chunks, int start, int end, SqliteException batchException)
+    private void InsertChunksWithRowSkip(IReadOnlyList<ChunkRecord> chunks, int start, int end, SqliteException batchException, CancellationToken cancellationToken)
     {
-        using var transaction = !IsInTransaction() ? BeginTransaction() : null;
+        using var transaction = !IsInTransaction() ? BeginTransaction(cancellationToken, "insert chunks row skip") : null;
         for (int i = start; i < end; i++)
         {
+            CheckBatchCancellationAndReportProgress("insert_chunks_row_skip", i, end, cancellationToken);
             var chunk = chunks[i];
             ExecuteWithRowSavepoint(
                 () => InsertChunkBatch(chunks, i, i + 1),
@@ -1170,12 +1190,13 @@ public class DbWriter
         transaction?.Commit();
     }
 
-    private void InsertSymbolsWithRowSkip(IReadOnlyList<SymbolRecord> symbols, int start, int end, SqliteException batchException)
+    private void InsertSymbolsWithRowSkip(IReadOnlyList<SymbolRecord> symbols, int start, int end, SqliteException batchException, CancellationToken cancellationToken)
     {
-        using var transaction = !IsInTransaction() ? BeginTransaction() : null;
+        using var transaction = !IsInTransaction() ? BeginTransaction(cancellationToken, "insert symbols row skip") : null;
         var foldedNameCache = new Dictionary<string, string?>(StringComparer.Ordinal);
         for (int i = start; i < end; i++)
         {
+            CheckBatchCancellationAndReportProgress("insert_symbols_row_skip", i, end, cancellationToken);
             var symbol = symbols[i];
             ExecuteWithRowSavepoint(
                 () => InsertSymbolBatch(symbols, i, i + 1, foldedNameCache),
@@ -1183,6 +1204,25 @@ public class DbWriter
         }
 
         transaction?.Commit();
+    }
+
+    private void CheckBatchCancellationAndReportProgress(
+        string operation,
+        int rowsProcessed,
+        int rowsTotal,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (rowsTotal <= BatchSize && BatchProgressCheckpointForTesting == null)
+            return;
+
+        var progress = new DbWriterBatchProgress(operation, rowsProcessed, rowsTotal);
+        BatchProgressCheckpointForTesting?.Invoke(progress);
+        GlobalToolLog.Info(
+            "db_writer_batch_checkpoint"
+            + $" operation={operation}"
+            + $" rows_processed={rowsProcessed.ToString(System.Globalization.CultureInfo.InvariantCulture)}"
+            + $" rows_total={rowsTotal.ToString(System.Globalization.CultureInfo.InvariantCulture)}");
     }
 
     private void ExecuteWithRowSavepoint(Action insertRow, Action<Exception> onSkip)
@@ -1408,19 +1448,26 @@ public class DbWriter
     /// インデックス済み参照をバッチ挿入する。
     /// </summary>
     public void InsertReferences(IReadOnlyList<ReferenceRecord> references, bool refreshMutualRecursionFlags = true)
+        => InsertReferences(references, refreshMutualRecursionFlags, CancellationToken.None);
+
+    public void InsertReferences(IReadOnlyList<ReferenceRecord> references, CancellationToken cancellationToken)
+        => InsertReferences(references, refreshMutualRecursionFlags: true, cancellationToken);
+
+    public void InsertReferences(IReadOnlyList<ReferenceRecord> references, bool refreshMutualRecursionFlags, CancellationToken cancellationToken)
     {
         if (references.Count == 0) return;
 
         int rowsPerStatement = GetRowsPerInsertStatement(columnCount: 13);
         for (int i = 0; i < references.Count; i += rowsPerStatement)
         {
+            CheckBatchCancellationAndReportProgress("insert_references", i, references.Count, cancellationToken);
             int end = Math.Min(i + rowsPerStatement, references.Count);
             var foldedNameCache = new Dictionary<string, string?>(StringComparer.Ordinal);
             // Always open a chunk-scoped transaction or SAVEPOINT so reference_lines and
             // symbol_references share one rollback boundary; without it a mid-chunk failure
             // under an outer transaction would orphan committed reference_lines (#1518).
-            using var transaction = BeginTransaction();
-            var referenceLineIds = UpsertReferenceLines(references, i, end);
+            using var transaction = BeginTransaction(cancellationToken, "insert references");
+            var referenceLineIds = UpsertReferenceLines(references, i, end, cancellationToken);
 
             using var cmd = _conn.CreateCommand();
             var sql = new StringBuilder();
@@ -1468,8 +1515,12 @@ public class DbWriter
             transaction.Commit();
         }
 
+        CheckBatchCancellationAndReportProgress("insert_references", references.Count, references.Count, cancellationToken);
         if (refreshMutualRecursionFlags)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             RefreshMutualRecursionFlags();
+        }
     }
 
     private static void ValidateSymbolKinds(SymbolRecord symbol)
@@ -1490,11 +1541,12 @@ public class DbWriter
             throw new ArgumentException($"Unknown reference container kind '{reference.ContainerKind}'. Register the kind in {nameof(SymbolKindCatalog)} before writing it.", nameof(reference));
     }
 
-    private Dictionary<(long FileId, int Line, string Context), long> UpsertReferenceLines(IReadOnlyList<ReferenceRecord> references, int start, int end)
+    private Dictionary<(long FileId, int Line, string Context), long> UpsertReferenceLines(IReadOnlyList<ReferenceRecord> references, int start, int end, CancellationToken cancellationToken)
     {
         var contextsByLine = new Dictionary<(long FileId, int Line, string Context), string>();
         for (int i = start; i < end; i++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var reference = references[i];
             contextsByLine[(reference.FileId, reference.Line, reference.Context)] = reference.Context;
         }
@@ -1503,6 +1555,7 @@ public class DbWriter
         int rowsPerStatement = GetRowsPerInsertStatement(columnCount: 3);
         for (int i = 0; i < rows.Length; i += rowsPerStatement)
         {
+            CheckBatchCancellationAndReportProgress("upsert_reference_lines", i, rows.Length, cancellationToken);
             int batchEnd = Math.Min(i + rowsPerStatement, rows.Length);
             using var cmd = _conn.CreateCommand();
             var sql = new StringBuilder();
@@ -1528,6 +1581,7 @@ public class DbWriter
         int keysPerStatement = GetRowsPerInsertStatement(columnCount: 3);
         for (int i = 0; i < rows.Length; i += keysPerStatement)
         {
+            CheckBatchCancellationAndReportProgress("lookup_reference_lines", i, rows.Length, cancellationToken);
             int keyEnd = Math.Min(i + keysPerStatement, rows.Length);
             using var cmd = _conn.CreateCommand();
             var predicates = new List<string>(keyEnd - i);

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -932,6 +932,49 @@ public class DatabaseTests : IDisposable
     }
 
     [Fact]
+    public void RunIncrementalVacuum_CancellationBeforeMetrics_ThrowsOperationCanceled_Issue3811()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"codeindex_vacuum_cancel_test_{Guid.NewGuid():N}.db");
+        try
+        {
+            using var db = new DbContext(dbPath);
+            db.InitializeSchema();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.Throws<OperationCanceledException>(() => db.RunIncrementalVacuum(false, cts.Token));
+        }
+        finally
+        {
+            DeleteDbFiles(dbPath);
+        }
+    }
+
+    [Fact]
+    public void RunIncrementalVacuum_ReportsProgressBoundaries_Issue3811()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"codeindex_vacuum_progress_test_{Guid.NewGuid():N}.db");
+        var progress = new List<string>();
+        try
+        {
+            using var db = new DbContext(dbPath);
+            db.InitializeSchema();
+            DbContext.MaintenanceProgressForTesting = (operation, phase) => progress.Add($"{operation}:{phase}");
+
+            var result = db.RunIncrementalVacuum(dryRun: true);
+
+            Assert.Equal("dry_run", result.Status);
+            Assert.Contains("vacuum:metrics_before", progress);
+            Assert.Contains("vacuum:metrics_after", progress);
+        }
+        finally
+        {
+            DbContext.MaintenanceProgressForTesting = null;
+            DeleteDbFiles(dbPath);
+        }
+    }
+
+    [Fact]
     public void MaintenanceGuidance_HighWalRecommendsCheckpoint_Issue3564()
     {
         var guidance = MaintenanceGuidanceBuilder.Build(new MaintenanceMetrics(

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -754,6 +754,46 @@ public class DatabaseTests : IDisposable
     }
 
     [Fact]
+    public async Task BeginTransaction_CancelledWhileGateHeld_ThrowsOperationCanceled_Issue3772()
+    {
+        using var held = _writer.BeginTransaction(CancellationToken.None, "owner operation");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => Task.Run(() =>
+        {
+            using var waiting = _writer.BeginTransaction(cts.Token, "cancelled operation");
+        }));
+    }
+
+    [Fact]
+    public async Task BeginTransaction_GateTimeoutReportsOwnerAndWaiterDiagnostics_Issue3772()
+    {
+        var originalTimeout = DbWriter.TransactionStateContentionTimeoutForTesting;
+        DbWriter.TransactionStateContentionTimeoutForTesting = TimeSpan.FromMilliseconds(25);
+        try
+        {
+            using var held = _writer.BeginTransaction(CancellationToken.None, "owner operation");
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => Task.Run(() =>
+            {
+                using var waiting = _writer.BeginTransaction(CancellationToken.None, "waiting operation");
+            }));
+
+            Assert.Contains("Timed out waiting for DbWriter transaction gate", ex.Message);
+            Assert.Contains("owner_operation=owner operation", ex.Message);
+            Assert.Contains("waiter_operation=waiting operation", ex.Message);
+            Assert.Contains("owner_thread_id=", ex.Message);
+            Assert.Contains("waiter_thread_id=", ex.Message);
+            Assert.Contains("transaction_depth=1", ex.Message);
+        }
+        finally
+        {
+            DbWriter.TransactionStateContentionTimeoutForTesting = originalTimeout;
+        }
+    }
+
+    [Fact]
     public void TransactionScope_SavepointWithoutConnection_ThrowsExplicitInvalidOperation()
     {
         var scopeType = typeof(DbWriter).GetNestedType("TransactionScope")

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -337,6 +337,63 @@ public class DatabaseTests : IDisposable
         Assert.Contains("Unknown symbol kind", ex.Message);
     }
 
+    [Fact]
+    public void InsertChunks_CancelledBeforeBatch_ThrowsOperationCanceled_Issue3738()
+    {
+        var fileId = UpsertTestFile("src/cancel-chunk.cs", checksum: "cancel-chunk");
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() => _writer.InsertChunks(
+        [
+            new ChunkRecord
+            {
+                FileId = fileId,
+                ChunkIndex = 0,
+                StartLine = 1,
+                EndLine = 1,
+                Content = "class CancelChunk { }",
+            },
+        ], cts.Token));
+    }
+
+    [Fact]
+    public void InsertReferences_ReportsProgressCheckpoints_Issue3738()
+    {
+        var fileId = UpsertTestFile("src/progress-reference.cs", checksum: "progress-reference");
+        var checkpoints = new List<DbWriter.DbWriterBatchProgress>();
+        DbWriter.BatchProgressCheckpointForTesting = checkpoints.Add;
+        try
+        {
+            _writer.InsertReferences(
+            [
+                new ReferenceRecord
+                {
+                    FileId = fileId,
+                    SymbolName = "Target",
+                    ReferenceKind = "call",
+                    Line = 1,
+                    Column = 1,
+                    Context = "Target();",
+                },
+            ], CancellationToken.None);
+        }
+        finally
+        {
+            DbWriter.BatchProgressCheckpointForTesting = null;
+        }
+
+        Assert.Contains(checkpoints, checkpoint =>
+            checkpoint.Operation == "insert_references"
+            && checkpoint.RowsProcessed == 0
+            && checkpoint.RowsTotal == 1);
+        Assert.Contains(checkpoints, checkpoint =>
+            checkpoint.Operation == "insert_references"
+            && checkpoint.RowsProcessed == 1
+            && checkpoint.RowsTotal == 1);
+        Assert.Contains(checkpoints, checkpoint => checkpoint.Operation == "upsert_reference_lines");
+    }
+
     [Theory]
     [InlineData("annotation")]
     [InlineData("bcl_regex_without_timeout")]

--- a/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DbCommandRunnerTests.cs
@@ -290,6 +290,35 @@ public class DbCommandRunnerTests
     }
 
     [Fact]
+    public void Run_IntegrityCheck_JsonCancellationReturnsInterrupted_Issue3811()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_db_integrity_cancel_{Guid.NewGuid():N}.db");
+        try
+        {
+            using (var db = new DbContext(dbPath))
+                db.InitializeSchema();
+            SqliteConnection.ClearAllPools();
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var (exitCode, stdout, stderr) = RunAndCaptureStreams(["--integrity-check", "--db", dbPath, "--json"], cts.Token);
+
+            Assert.Equal(CommandExitCodes.CancelledBySignal, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = JsonDocument.Parse(stdout);
+            var json = document.RootElement;
+            Assert.Equal("error", json.GetProperty("status").GetString());
+            Assert.Equal(CommandErrorCodes.Interrupted, json.GetProperty("error_code").GetString());
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
     public void Run_IntegrityCheck_JsonReportsStableErrorSeverity()
     {
         var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_db_integrity_error_json_{Guid.NewGuid():N}.db");
@@ -439,6 +468,38 @@ public class DbCommandRunnerTests
         finally
         {
             DbContext.WalCheckpointTruncateExecutedForTesting = null;
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void Run_PruneDryRun_ReportsMaintenanceProgress_Issue3811()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_db_prune_progress_{Guid.NewGuid():N}.db");
+        var progress = new List<string>();
+        try
+        {
+            using (var db = new DbContext(dbPath))
+                db.InitializeSchema();
+            SeedOrphans(dbPath);
+            SqliteConnection.ClearAllPools();
+            DbCommandRunner.MaintenanceProgressForTesting = (operation, phase) => progress.Add($"{operation}:{phase}");
+
+            var (exitCode, json) = RunAndCaptureJson(["prune", "--dry-run", "--db", dbPath, "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(4, json.GetProperty("total").GetInt32());
+            Assert.Contains("prune:start", progress);
+            Assert.Contains("prune:count_symbol_references", progress);
+            Assert.Contains("prune:count_reference_lines", progress);
+            Assert.Contains("prune:count_symbols", progress);
+            Assert.Contains("prune:complete", progress);
+        }
+        finally
+        {
+            DbCommandRunner.MaintenanceProgressForTesting = null;
             SqliteConnection.ClearAllPools();
             if (File.Exists(dbPath))
                 File.Delete(dbPath);
@@ -1317,17 +1378,17 @@ public class DbCommandRunnerTests
         }
     }
 
-    private (int ExitCode, string StdOut, string StdErr) RunAndCaptureStreams(string[] args)
+    private (int ExitCode, string StdOut, string StdErr) RunAndCaptureStreams(string[] args, CancellationToken cancellationToken = default)
     {
         using var capture = ConsoleCapture.Start(captureOut: true, captureError: true);
-        var exitCode = DbCommandRunner.RunIntegrityCheck(args, _jsonOptions);
+        var exitCode = DbCommandRunner.Run(args, _jsonOptions, cancellationToken);
         return (exitCode, capture.Out!.ToString()!, capture.Error!.ToString()!);
     }
 
-    private (int ExitCode, JsonElement Json) RunAndCaptureJson(string[] args)
+    private (int ExitCode, JsonElement Json) RunAndCaptureJson(string[] args, CancellationToken cancellationToken = default)
     {
         using var capture = ConsoleCapture.Start(captureOut: true);
-        var exitCode = DbCommandRunner.RunIntegrityCheck(args, _jsonOptions);
+        var exitCode = DbCommandRunner.Run(args, _jsonOptions, cancellationToken);
         using var document = JsonDocument.Parse(capture.Out!.ToString()!);
         return (exitCode, document.RootElement.Clone());
     }

--- a/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/DiffCommandRunnerTests.cs
@@ -183,6 +183,64 @@ public class DiffCommandRunnerTests
     }
 
     [Fact]
+    public void Run_JsonReportsTruncatedDiagnosticWhenSamplesHitLimit_Issue3736()
+    {
+        var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_truncated_left");
+        var rightRoot = TestProjectHelper.CreateTempProject("cdidx_diff_truncated_right");
+        try
+        {
+            var leftDb = TestProjectHelper.CreateProjectDb(leftRoot);
+            var rightDb = TestProjectHelper.CreateProjectDb(rightRoot);
+            TestProjectHelper.InsertIndexedFile(leftDb, "src/Same.cs", "csharp", "public class Same { }");
+            TestProjectHelper.InsertIndexedFile(rightDb, "src/Same.cs", "csharp", "public class Same { }");
+            TestProjectHelper.InsertIndexedFile(rightDb, "src/ExtraA.cs", "csharp", "public class ExtraA { }");
+            TestProjectHelper.InsertIndexedFile(rightDb, "src/ExtraB.cs", "csharp", "public class ExtraB { }");
+
+            var (exitCode, output) = RunWithCapturedOut([leftDb, rightDb, "--json", "--limit", "1"]);
+
+            Assert.Equal(1, exitCode);
+            using var document = JsonDocument.Parse(output);
+            var root = document.RootElement;
+            Assert.Equal("different", root.GetProperty("status").GetString());
+            Assert.True(root.GetProperty("truncated").GetBoolean());
+            Assert.Single(root.GetProperty("files_only_in_right").EnumerateArray());
+            Assert.Contains(
+                root.GetProperty("diagnostics").EnumerateArray(),
+                item => item.GetProperty("code").GetString() == "diff_samples_truncated");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(leftRoot);
+            TestProjectHelper.DeleteDirectory(rightRoot);
+        }
+    }
+
+    [Fact]
+    public void Run_JsonCancellationReturnsInterruptedError_Issue3736()
+    {
+        var root = TestProjectHelper.CreateTempProject("cdidx_diff_cancelled");
+        try
+        {
+            var db = TestProjectHelper.CreateProjectDb(root);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            var (exitCode, stdout, stderr) = RunWithCapturedStreams([db, db, "--json"], cts.Token);
+
+            Assert.Equal(CommandExitCodes.CancelledBySignal, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = JsonDocument.Parse(stdout);
+            var rootElement = document.RootElement;
+            Assert.Equal("error", rootElement.GetProperty("status").GetString());
+            Assert.Equal(CommandErrorCodes.Interrupted, rootElement.GetProperty("error_code").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(root);
+        }
+    }
+
+    [Fact]
     public void Run_StopsWhenDiffRowBudgetIsExceeded_Issue3834()
     {
         var leftRoot = TestProjectHelper.CreateTempProject("cdidx_diff_row_budget_left");
@@ -850,7 +908,7 @@ public class DiffCommandRunnerTests
         command.ExecuteNonQuery();
     }
 
-    private (int ExitCode, string Output) RunWithCapturedOut(string[] args)
+    private (int ExitCode, string Output) RunWithCapturedOut(string[] args, CancellationToken cancellationToken = default)
     {
         var originalOut = Console.Out;
         using var writer = new StringWriter();
@@ -859,7 +917,7 @@ public class DiffCommandRunnerTests
             try
             {
                 Console.SetOut(writer);
-                var exitCode = DiffCommandRunner.Run(args, _jsonOptions);
+                var exitCode = DiffCommandRunner.Run(args, _jsonOptions, cancellationToken);
                 return (exitCode, writer.ToString());
             }
             finally
@@ -869,7 +927,7 @@ public class DiffCommandRunnerTests
         }
     }
 
-    private (int ExitCode, string StdOut, string StdErr) RunWithCapturedStreams(string[] args)
+    private (int ExitCode, string StdOut, string StdErr) RunWithCapturedStreams(string[] args, CancellationToken cancellationToken = default)
     {
         var originalOut = Console.Out;
         var originalErr = Console.Error;
@@ -881,7 +939,7 @@ public class DiffCommandRunnerTests
             {
                 Console.SetOut(stdout);
                 Console.SetError(stderr);
-                var exitCode = DiffCommandRunner.Run(args, _jsonOptions);
+                var exitCode = DiffCommandRunner.Run(args, _jsonOptions, cancellationToken);
                 return (exitCode, stdout.ToString(), stderr.ToString());
             }
             finally

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerIssue3818Tests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerIssue3818Tests.cs
@@ -1,0 +1,120 @@
+using System.Text.Json;
+using CodeIndex.Cli;
+using CodeIndex.Database;
+
+namespace CodeIndex.Tests;
+
+[Collection("SQLite pool sensitive")]
+public class ExportImportCommandRunnerIssue3818Tests
+{
+    [Fact]
+    public void RunImport_JsonCancellationReturnsInterrupted_Issue3818()
+    {
+        var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+            ExportImportCommandRunner.RunImport(["archive.cdidx.zip", "--db", "codeindex.db", "--json"], jsonOptions, cts.Token));
+
+        Assert.Equal(CommandExitCodes.CancelledBySignal, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        AssertImportError(stdout, "open_archive", CommandErrorCodes.Interrupted);
+    }
+
+    [Fact]
+    public void ReplaceImportedDatabase_PostMoveCancellationRollsBackDestination_Issue3818()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_import_cancel_rollback_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+            var tempPath = Path.Combine(workDir, "staged.db");
+            File.WriteAllText(dbPath, "existing db");
+            File.WriteAllText(tempPath, "imported db");
+            ExportImportCommandRunner.ApplyPrivateFileModeForTesting = _ =>
+                throw new OperationCanceledException();
+
+            Assert.Throws<OperationCanceledException>(() =>
+                ExportImportCommandRunner.ReplaceImportedDatabase(tempPath, dbPath));
+
+            Assert.Equal("existing db", File.ReadAllText(dbPath));
+            Assert.False(File.Exists(tempPath));
+        }
+        finally
+        {
+            ExportImportCommandRunner.ApplyPrivateFileModeForTesting = null;
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunImport_JsonReplacementFailureIncludesResidualDiagnostics_Issue3818()
+    {
+        var sourceRoot = TestProjectHelper.CreateTempProject("import_replacement_diag_source");
+        var targetRoot = TestProjectHelper.CreateTempProject("import_replacement_diag_target");
+        try
+        {
+            var sourceDbPath = TestProjectHelper.CreateProjectDb(sourceRoot);
+            var archivePath = ExportArchive(sourceRoot, sourceDbPath);
+            var targetDbPath = TestProjectHelper.CreateProjectDb(targetRoot);
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+            ExportImportCommandRunner.ApplyPrivateFileModeForTesting = _ =>
+                throw new IOException("simulated post-move failure");
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", targetDbPath, "--json"], jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = JsonDocument.Parse(stdout);
+            var root = document.RootElement;
+            Assert.Equal("error", root.GetProperty("status").GetString());
+            Assert.Equal("replace_db", root.GetProperty("phase").GetString());
+            Assert.Equal("import_replacement_failed", root.GetProperty("error_code").GetString());
+            Assert.Contains(
+                root.GetProperty("diagnostics").EnumerateArray(),
+                item => item.GetProperty("code").GetString() == "import_replace_destination_state");
+            Assert.True(DbContext.TryValidateExistingCodeIndexDb(targetDbPath, out _, out _));
+        }
+        finally
+        {
+            ExportImportCommandRunner.ApplyPrivateFileModeForTesting = null;
+            TestProjectHelper.DeleteDirectory(sourceRoot);
+            TestProjectHelper.DeleteDirectory(targetRoot);
+        }
+    }
+
+    [Fact]
+    public void CopyToWithLimit_CancellationBeforeReadThrowsWithoutWriting_Issue3818()
+    {
+        using var source = new MemoryStream([1, 2, 3, 4]);
+        using var target = new MemoryStream();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            ExportImportCommandRunner.CopyToWithLimit(source, target, maxBytes: 4, cts.Token));
+        Assert.Equal(0, target.Length);
+    }
+
+    private static string ExportArchive(string projectRoot, string sourceDbPath)
+    {
+        var archivePath = Path.Combine(projectRoot, "codeindex.cdidx.zip");
+        var (exitCode, _, stderr) = ConsoleCapture.Capture(() =>
+            ExportImportCommandRunner.RunExport([archivePath, "--db", sourceDbPath], new JsonSerializerOptions(), "test"));
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        return archivePath;
+    }
+
+    private static void AssertImportError(string stdout, string expectedPhase, string expectedCode)
+    {
+        using var document = JsonDocument.Parse(stdout);
+        var root = document.RootElement;
+        Assert.Equal("error", root.GetProperty("status").GetString());
+        Assert.Equal(expectedPhase, root.GetProperty("phase").GetString());
+        Assert.Equal(expectedCode, root.GetProperty("error_code").GetString());
+    }
+}

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -25,21 +25,6 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
-    public void RunImport_JsonCancellationReturnsInterrupted_Issue3818()
-    {
-        var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
-        using var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
-            ExportImportCommandRunner.RunImport(["archive.cdidx.zip", "--db", "codeindex.db", "--json"], jsonOptions, cts.Token));
-
-        Assert.Equal(CommandExitCodes.CancelledBySignal, exitCode);
-        Assert.Equal(string.Empty, stderr);
-        AssertExportImportError(stdout, "import", "open_archive", CommandErrorCodes.Interrupted);
-    }
-
-    [Fact]
     public void RunImport_JsonManifestErrorIncludesPhaseAndCode_Issue3548()
     {
         var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_manifest_json_error_{Guid.NewGuid():N}");
@@ -1073,70 +1058,6 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
-    public void ReplaceImportedDatabase_PostMoveCancellationRollsBackDestination_Issue3818()
-    {
-        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_import_cancel_rollback_{Guid.NewGuid():N}");
-        Directory.CreateDirectory(workDir);
-        try
-        {
-            var dbPath = Path.Combine(workDir, "codeindex.db");
-            var tempPath = Path.Combine(workDir, "staged.db");
-            File.WriteAllText(dbPath, "existing db");
-            File.WriteAllText(tempPath, "imported db");
-            ExportImportCommandRunner.ApplyPrivateFileModeForTesting = _ =>
-                throw new OperationCanceledException();
-
-            Assert.Throws<OperationCanceledException>(() =>
-                ExportImportCommandRunner.ReplaceImportedDatabase(tempPath, dbPath));
-
-            Assert.Equal("existing db", File.ReadAllText(dbPath));
-            Assert.False(File.Exists(tempPath));
-        }
-        finally
-        {
-            ExportImportCommandRunner.ApplyPrivateFileModeForTesting = null;
-            Directory.Delete(workDir, recursive: true);
-        }
-    }
-
-    [Fact]
-    public void RunImport_JsonReplacementFailureIncludesResidualDiagnostics_Issue3818()
-    {
-        var sourceRoot = TestProjectHelper.CreateTempProject("import_replacement_diag_source");
-        var targetRoot = TestProjectHelper.CreateTempProject("import_replacement_diag_target");
-        try
-        {
-            var sourceDbPath = TestProjectHelper.CreateProjectDb(sourceRoot);
-            var archivePath = ExportArchive(sourceRoot, sourceDbPath);
-            var targetDbPath = TestProjectHelper.CreateProjectDb(targetRoot);
-            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
-            ExportImportCommandRunner.ApplyPrivateFileModeForTesting = _ =>
-                throw new IOException("simulated post-move failure");
-
-            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
-                ExportImportCommandRunner.RunImport([archivePath, "--db", targetDbPath, "--json"], jsonOptions));
-
-            Assert.Equal(CommandExitCodes.UsageError, exitCode);
-            Assert.Equal(string.Empty, stderr);
-            using var document = JsonDocument.Parse(stdout);
-            var root = document.RootElement;
-            Assert.Equal("error", root.GetProperty("status").GetString());
-            Assert.Equal("replace_db", root.GetProperty("phase").GetString());
-            Assert.Equal("import_replacement_failed", root.GetProperty("error_code").GetString());
-            Assert.Contains(
-                root.GetProperty("diagnostics").EnumerateArray(),
-                item => item.GetProperty("code").GetString() == "import_replace_destination_state");
-            Assert.True(DbContext.TryValidateExistingCodeIndexDb(targetDbPath, out _, out _));
-        }
-        finally
-        {
-            ExportImportCommandRunner.ApplyPrivateFileModeForTesting = null;
-            TestProjectHelper.DeleteDirectory(sourceRoot);
-            TestProjectHelper.DeleteDirectory(targetRoot);
-        }
-    }
-
-    [Fact]
     public void ReplaceImportedDatabase_AppliesPrivateFileMode()
     {
         if (OperatingSystem.IsWindows())
@@ -1209,19 +1130,6 @@ public class ExportImportCommandRunnerTests
 
         Assert.Equal(4, copied);
         Assert.Equal([1, 2, 3, 4], target.ToArray());
-    }
-
-    [Fact]
-    public void CopyToWithLimit_CancellationBeforeReadThrowsWithoutWriting_Issue3818()
-    {
-        using var source = new MemoryStream([1, 2, 3, 4]);
-        using var target = new MemoryStream();
-        using var cts = new CancellationTokenSource();
-        cts.Cancel();
-
-        Assert.Throws<OperationCanceledException>(() =>
-            ExportImportCommandRunner.CopyToWithLimit(source, target, maxBytes: 4, cts.Token));
-        Assert.Equal(0, target.Length);
     }
 
     private static string CreateArchiveWithManifest(string workDir, string manifest)

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -25,6 +25,21 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
+    public void RunImport_JsonCancellationReturnsInterrupted_Issue3818()
+    {
+        var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+            ExportImportCommandRunner.RunImport(["archive.cdidx.zip", "--db", "codeindex.db", "--json"], jsonOptions, cts.Token));
+
+        Assert.Equal(CommandExitCodes.CancelledBySignal, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        AssertExportImportError(stdout, "import", "open_archive", CommandErrorCodes.Interrupted);
+    }
+
+    [Fact]
     public void RunImport_JsonManifestErrorIncludesPhaseAndCode_Issue3548()
     {
         var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_manifest_json_error_{Guid.NewGuid():N}");
@@ -1027,7 +1042,7 @@ public class ExportImportCommandRunnerTests
             ExportImportCommandRunner.ApplyPrivateFileModeForTesting = _ =>
                 throw new IOException("simulated post-move failure");
 
-            var ex = Assert.Throws<IOException>(() =>
+            var ex = Assert.ThrowsAny<IOException>(() =>
                 ExportImportCommandRunner.ReplaceImportedDatabase(tempPath, dbPath));
 
             Assert.Contains("rolled back", ex.Message, StringComparison.Ordinal);
@@ -1040,6 +1055,70 @@ public class ExportImportCommandRunnerTests
         {
             ExportImportCommandRunner.ApplyPrivateFileModeForTesting = null;
             Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ReplaceImportedDatabase_PostMoveCancellationRollsBackDestination_Issue3818()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_import_cancel_rollback_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        try
+        {
+            var dbPath = Path.Combine(workDir, "codeindex.db");
+            var tempPath = Path.Combine(workDir, "staged.db");
+            File.WriteAllText(dbPath, "existing db");
+            File.WriteAllText(tempPath, "imported db");
+            ExportImportCommandRunner.ApplyPrivateFileModeForTesting = _ =>
+                throw new OperationCanceledException();
+
+            Assert.Throws<OperationCanceledException>(() =>
+                ExportImportCommandRunner.ReplaceImportedDatabase(tempPath, dbPath));
+
+            Assert.Equal("existing db", File.ReadAllText(dbPath));
+            Assert.False(File.Exists(tempPath));
+        }
+        finally
+        {
+            ExportImportCommandRunner.ApplyPrivateFileModeForTesting = null;
+            Directory.Delete(workDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void RunImport_JsonReplacementFailureIncludesResidualDiagnostics_Issue3818()
+    {
+        var sourceRoot = TestProjectHelper.CreateTempProject("import_replacement_diag_source");
+        var targetRoot = TestProjectHelper.CreateTempProject("import_replacement_diag_target");
+        try
+        {
+            var sourceDbPath = TestProjectHelper.CreateProjectDb(sourceRoot);
+            var archivePath = ExportArchive(sourceRoot, sourceDbPath);
+            var targetDbPath = TestProjectHelper.CreateProjectDb(targetRoot);
+            var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+            ExportImportCommandRunner.ApplyPrivateFileModeForTesting = _ =>
+                throw new IOException("simulated post-move failure");
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() =>
+                ExportImportCommandRunner.RunImport([archivePath, "--db", targetDbPath, "--json"], jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = JsonDocument.Parse(stdout);
+            var root = document.RootElement;
+            Assert.Equal("error", root.GetProperty("status").GetString());
+            Assert.Equal("replace_db", root.GetProperty("phase").GetString());
+            Assert.Equal("import_replacement_failed", root.GetProperty("error_code").GetString());
+            Assert.Contains(
+                root.GetProperty("diagnostics").EnumerateArray(),
+                item => item.GetProperty("code").GetString() == "import_replace_destination_state");
+            Assert.True(DbContext.TryValidateExistingCodeIndexDb(targetDbPath, out _, out _));
+        }
+        finally
+        {
+            ExportImportCommandRunner.ApplyPrivateFileModeForTesting = null;
+            TestProjectHelper.DeleteDirectory(sourceRoot);
+            TestProjectHelper.DeleteDirectory(targetRoot);
         }
     }
 
@@ -1116,6 +1195,19 @@ public class ExportImportCommandRunnerTests
 
         Assert.Equal(4, copied);
         Assert.Equal([1, 2, 3, 4], target.ToArray());
+    }
+
+    [Fact]
+    public void CopyToWithLimit_CancellationBeforeReadThrowsWithoutWriting_Issue3818()
+    {
+        using var source = new MemoryStream([1, 2, 3, 4]);
+        using var target = new MemoryStream();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            ExportImportCommandRunner.CopyToWithLimit(source, target, maxBytes: 4, cts.Token));
+        Assert.Equal(0, target.Length);
     }
 
     private static string CreateArchiveWithManifest(string workDir, string manifest)


### PR DESCRIPTION
## Summary

- Add cancellation-aware transaction gate diagnostics and batch checkpoints in `DbWriter`.
- Add cancellation/progress boundaries to DB maintenance, diff comparisons, and export/import paths.
- Return structured JSON diagnostics for diff truncation and import replacement failures, including rollback residual state.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~DatabaseTests -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~DbCommandRunnerTests -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~DiffCommandRunnerTests -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~ExportImportCommandRunnerTests -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build src/CodeIndex/CodeIndex.csproj -c Release -p:UseSharedCompilation=false`
- `git diff --check origin/main..HEAD`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files src/CodeIndex/Cli/DbCommandRunner.cs src/CodeIndex/Cli/DiffCommandRunner.cs src/CodeIndex/Cli/ExportImportCommandRunner.cs src/CodeIndex/Cli/JsonOutputContracts.cs src/CodeIndex/Cli/ProgramRunner.Dispatch.cs src/CodeIndex/Cli/QueryCommandRunner.cs src/CodeIndex/Database/DbContext.cs src/CodeIndex/Database/DbWriter.cs tests/CodeIndex.Tests/DatabaseTests.cs tests/CodeIndex.Tests/DbCommandRunnerTests.cs tests/CodeIndex.Tests/DiffCommandRunnerTests.cs tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs --json`

## Documentation / Changelog

- Added `changelog.d/unreleased/3772.fixed.md`
- Added `changelog.d/unreleased/3738.fixed.md`
- Added `changelog.d/unreleased/3736.fixed.md`
- Added `changelog.d/unreleased/3811.fixed.md`
- Added `changelog.d/unreleased/3818.fixed.md`
- No `AGENTS.md`, `CLAUDE.md`, or `AGENT_GUIDE.md` changes.

## Adversarial Review

- Found and fixed import replacement cancellation rollback and DB maintenance connection cleanup issues.
- No blocking/actionable issues found.

## Follow-up Candidates

None.

Fixes #3811
Fixes #3772
Fixes #3738
Fixes #3736
Fixes #3818