### PR TITLE
Fix cancellation and timeout handling across CLI flows

### DIFF
--- a/changelog.d/unreleased/3684.fixed.md
+++ b/changelog.d/unreleased/3684.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 3684
+affected:
+  - src/CodeIndex/Cli/GitHubHttpClientFactory.cs
+  - src/CodeIndex/Cli/GitHubIssueReporter.cs
+  - src/CodeIndex/Cli/IssueDuplicatePreflight.cs
+  - src/CodeIndex/Cli/UpdateChecker.cs
+  - tests/CodeIndex.Tests/GitHubHttpCancellationTests.cs
+---
+
+## English
+
+- **Centralized GitHub/update HTTP cancellation policy (#3684)** — Shared request timeout scoping now drives update checks, GitHub issue submission, and open-issues duplicate preflight calls, with async tests covering timeout and caller cancellation behavior.
+
+## 日本語
+
+- **GitHub/update HTTP のキャンセル方針を共通化 (#3684)** — 更新確認、GitHub Issue 投稿、open-issues 重複 preflight のリクエストタイムアウト処理を共通化し、タイムアウトと呼び出し元キャンセルの挙動を async テストで検証しました。

--- a/changelog.d/unreleased/3704.fixed.md
+++ b/changelog.d/unreleased/3704.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 3704
+affected:
+  - tests/CodeIndex.Tests/GitHelperTests.cs
+---
+
+## English
+
+- **Git helper stderr capture now has explicit over-limit coverage (#3704)** — added a regression test that verifies bounded stderr capture surfaces `CaptureLimitExceeded` and bounded diagnostics.
+
+## 日本語
+
+- **Git helper の stderr capture 上限に明示的な coverage を追加しました (#3704)** — bounded stderr capture が `CaptureLimitExceeded` と bounded diagnostics を返すことを確認する回帰テストを追加しました。

--- a/changelog.d/unreleased/3761.fixed.md
+++ b/changelog.d/unreleased/3761.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3761
+affected:
+  - src/CodeIndex/Cli/GitHelper.cs
+  - tests/CodeIndex.Tests/GitHelperTests.cs
+---
+
+## English
+
+- **Git helper process capture now uses an async exit/read pipeline (#3761)** — process exit, stdout/stderr drains, timeout cleanup, and cancellation cleanup are coordinated with async waits.
+
+## 日本語
+
+- **Git helper の process capture が async の exit/read pipeline になりました (#3761)** — process exit、stdout/stderr drain、timeout cleanup、cancellation cleanup を async wait で調停するようにしました。

--- a/changelog.d/unreleased/3769.fixed.md
+++ b/changelog.d/unreleased/3769.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3769
+affected:
+  - src/CodeIndex/Lsp/LspServer.cs
+  - tests/CodeIndex.Tests/LspServerTests.cs
+---
+
+## English
+
+- **LSP transport reads now use async cancellation-aware paths (#3769)** — the server exposes async run/read helpers and no longer blocks pending reads through synchronous waits.
+
+## 日本語
+
+- **LSP transport の読み取りが async cancellation-aware な経路になりました (#3769)** — server は async の run/read helper を公開し、保留中 read を同期待機で詰まらせないようにしました。

--- a/changelog.d/unreleased/3773.fixed.md
+++ b/changelog.d/unreleased/3773.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3773
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
+  - src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
+  - src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
+  - tests/CodeIndex.Tests/PostExtractionHookTests.cs
+---
+
+## English
+
+- **Isolated extraction waits now honor cancellation without synchronous `Task.Wait` (#3773)** — symbol extraction and post-extraction hook workers use cancellation-aware waits, and hook callbacks receive the caller token while waiting for worker responses.
+
+## 日本語
+
+- **分離抽出の待機処理が同期 `Task.Wait` なしでキャンセルを尊重するようになりました (#3773)** — symbol extraction と post-extraction hook の worker 待機が cancellation-aware になり、hook callback は worker response 待機中に呼び出し元 token を受け取ります。

--- a/changelog.d/unreleased/3784.fixed.md
+++ b/changelog.d/unreleased/3784.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3784
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileContentLoader.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **File checksum computation now honors cancellation while reading (#3784)** — checksum reads check the caller token during the read loop so indexing can stop promptly instead of continuing through large files after cancellation.
+
+## 日本語
+
+- **ファイル checksum 計算が読み込み中のキャンセルを尊重するようになりました (#3784)** — checksum の read loop が呼び出し元の token を確認するため、キャンセル後に大きなファイルを読み続けず、indexing を速やかに停止できます。

--- a/changelog.d/unreleased/3797.fixed.md
+++ b/changelog.d/unreleased/3797.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 3797
+affected:
+  - src/CodeIndex/Cli/Sha256StreamHasher.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+---
+
+## English
+
+- **Installer and archive checksum verification now honors cancellation (#3797)** — upgrade, export, and import SHA-256 verification use a cancellation-aware stream loop instead of `SHA256.HashData(stream)`, and human upgrade output now reports checksum verification progress.
+
+## 日本語
+
+- **installer と archive の checksum 検証がキャンセルを尊重するようになりました (#3797)** — upgrade / export / import の SHA-256 検証は `SHA256.HashData(stream)` ではなく cancellation-aware な stream loop を使い、人間向け upgrade 出力では checksum 検証の進捗を表示します。

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -1,6 +1,5 @@
 using System.IO.Compression;
 using System.Globalization;
-using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -35,15 +34,22 @@ internal static class ExportImportCommandRunner
     private const string ImportUsage = "cdidx import <archive> [--db <path>] [--prune-paths] [--dry-run|--check] [--json]";
     private const string CtagsExportUsage = "cdidx export ctags [--output <path>] [--db <path>] [--json] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests]";
 
-    public static int RunExport(string[] args, JsonSerializerOptions jsonOptions, string appVersion)
+    public static int RunExport(
+        string[] args,
+        JsonSerializerOptions jsonOptions,
+        string appVersion,
+        CancellationToken cancellationToken = default)
     {
         if (args.Length > 0 && args[0] == "ctags")
             return RunExportCtags(args[1..], jsonOptions);
 
-        return RunExportArchive(args, jsonOptions, appVersion);
+        return RunExportArchive(args, jsonOptions, appVersion, cancellationToken);
     }
 
-    public static int RunImport(string[] args, JsonSerializerOptions jsonOptions)
+    public static int RunImport(
+        string[] args,
+        JsonSerializerOptions jsonOptions,
+        CancellationToken cancellationToken = default)
     {
         string? archivePath = null;
         string? dbPath = null;
@@ -135,11 +141,11 @@ internal static class ExportImportCommandRunner
                 if (!TryValidateDatabaseEntrySize(dbEntry.Length, dbEntry.CompressedLength, out var sizeValidationMessage))
                     return WriteImportError(wantsJson, jsonOptions, PhaseDatabaseEntry, "import_database_entry_too_large", sizeValidationMessage, "re-export a smaller CodeIndex database or rebuild a smaller index.", ImportUsage);
 
-                ExtractDatabaseEntryToFile(dbEntry, tempPath);
+                ExtractDatabaseEntryToFile(dbEntry, tempPath, cancellationToken);
                 AddImportValidationPhase(validationPhases, PhaseDatabaseEntry);
 
                 phase = PhaseSha256;
-                if (!TryValidateImportedManifest(manifest, tempPath, out var manifestValidationMessage, out var manifestValidationPhase))
+                if (!TryValidateImportedManifest(manifest, tempPath, out var manifestValidationMessage, out var manifestValidationPhase, cancellationToken))
                     return WriteImportError(wantsJson, jsonOptions, manifestValidationPhase, "import_manifest_mismatch", $"archive manifest mismatch: {manifestValidationMessage}.", "re-export from a compatible CodeIndex database.", ImportUsage);
                 AddImportValidationPhase(validationPhases, PhaseSha256);
             }
@@ -240,7 +246,11 @@ internal static class ExportImportCommandRunner
         }
     }
 
-    private static int RunExportArchive(string[] args, JsonSerializerOptions jsonOptions, string appVersion)
+    private static int RunExportArchive(
+        string[] args,
+        JsonSerializerOptions jsonOptions,
+        string appVersion,
+        CancellationToken cancellationToken)
     {
         string? outputPath = null;
         string? dbPath = null;
@@ -307,7 +317,7 @@ internal static class ExportImportCommandRunner
             }
             SqliteConnection.ClearAllPools();
             phase = PhaseSha256;
-            manifest = manifest with { DatabaseSha256 = ComputeSha256(snapshotPath) };
+            manifest = manifest with { DatabaseSha256 = ComputeSha256(snapshotPath, cancellationToken) };
             phase = PhaseWriteArchive;
             WriteExportArchiveFile(fullOutputPath, snapshotPath, manifest, jsonOptions);
 
@@ -316,6 +326,10 @@ internal static class ExportImportCommandRunner
             else
                 Console.WriteLine($"Exported CodeIndex archive to {fullOutputPath}");
             return CommandExitCodes.Success;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -646,10 +660,10 @@ internal static class ExportImportCommandRunner
             });
     }
 
-    private static string ComputeSha256(string path)
+    private static string ComputeSha256(string path, CancellationToken cancellationToken = default)
     {
         using var stream = File.OpenRead(path);
-        return Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
+        return Sha256StreamHasher.ComputeHex(stream, cancellationToken);
     }
 
     private static bool TryReadManifest(ZipArchiveEntry manifestEntry, JsonSerializerOptions jsonOptions, out ExportManifest manifest, out string message)
@@ -810,10 +824,15 @@ internal static class ExportImportCommandRunner
         return true;
     }
 
-    private static bool TryValidateImportedManifest(ExportManifest manifest, string dbPath, out string message, out string phase)
+    private static bool TryValidateImportedManifest(
+        ExportManifest manifest,
+        string dbPath,
+        out string message,
+        out string phase,
+        CancellationToken cancellationToken = default)
     {
         phase = PhaseSha256;
-        var actualSha256 = ComputeSha256(dbPath);
+        var actualSha256 = ComputeSha256(dbPath, cancellationToken);
         if (!string.Equals(manifest.DatabaseSha256, actualSha256, StringComparison.OrdinalIgnoreCase))
         {
             message = "database_sha256 does not match codeindex.db";
@@ -1017,23 +1036,40 @@ internal static class ExportImportCommandRunner
         return true;
     }
 
-    private static void ExtractDatabaseEntryToFile(ZipArchiveEntry dbEntry, string destinationPath)
+    private static void ExtractDatabaseEntryToFile(
+        ZipArchiveEntry dbEntry,
+        string destinationPath,
+        CancellationToken cancellationToken = default)
     {
         using var source = dbEntry.Open();
         using var target = File.Open(destinationPath, FileMode.Create, FileAccess.Write, FileShare.None);
-        CopyToWithLimit(source, target, MaxImportDatabaseBytes);
+        CopyToWithLimit(source, target, MaxImportDatabaseBytes, cancellationToken);
     }
 
-    internal static long CopyToWithLimit(Stream source, Stream target, long maxBytes)
-        => CopyToWithLimit(source, target, maxBytes, DatabaseEntryName);
+    internal static long CopyToWithLimit(
+        Stream source,
+        Stream target,
+        long maxBytes,
+        CancellationToken cancellationToken = default)
+        => CopyToWithLimit(source, target, maxBytes, DatabaseEntryName, cancellationToken);
 
-    private static long CopyToWithLimit(Stream source, Stream target, long maxBytes, string entryName)
+    private static long CopyToWithLimit(
+        Stream source,
+        Stream target,
+        long maxBytes,
+        string entryName,
+        CancellationToken cancellationToken = default)
     {
         var buffer = new byte[ImportCopyBufferSize];
         long totalBytes = 0;
         int bytesRead;
-        while ((bytesRead = source.Read(buffer, 0, buffer.Length)) > 0)
+        while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+            bytesRead = source.Read(buffer, 0, buffer.Length);
+            if (bytesRead == 0)
+                break;
+
             if (totalBytes > maxBytes - bytesRead)
                 throw new InvalidDataException($"archive {entryName} exceeds the import limit of {ConsoleUi.FormatBytes(maxBytes)}.");
 

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -952,6 +952,11 @@ public static class GitHelper
     private static GitProcessCaptureResult? RunProcessCapturingResult(
         ProcessStartInfo psi,
         CancellationToken cancellationToken = default)
+        => RunProcessCapturingResultAsync(psi, cancellationToken).GetAwaiter().GetResult();
+
+    private static async Task<GitProcessCaptureResult?> RunProcessCapturingResultAsync(
+        ProcessStartInfo psi,
+        CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
         using var process = new Process { StartInfo = psi };
@@ -997,9 +1002,11 @@ public static class GitHelper
                 diagnostic);
         }
 
-        var stdoutTask = Task.Run(() => ReadCapturedStream(process.StandardOutput, stdout, "stdout", MarkFailure));
-        var stderrTask = Task.Run(() => ReadCapturedStream(process.StandardError, stderr, "stderr", MarkFailure));
-        var exited = WaitForGitExit(process, GitCommandTimeout, cancellationToken, out var cancelled);
+        var stdoutTask = ReadCapturedStreamAsync(process.StandardOutput, stdout, "stdout", MarkFailure);
+        var stderrTask = ReadCapturedStreamAsync(process.StandardError, stderr, "stderr", MarkFailure);
+        var waitResult = await WaitForGitExitAsync(process, GitCommandTimeout, cancellationToken).ConfigureAwait(false);
+        var cancelled = waitResult.Cancelled;
+        var exited = waitResult.Exited;
         if (!exited)
         {
             MarkFailure(
@@ -1007,7 +1014,7 @@ public static class GitHelper
                 cancelled
                 ? "git command cancelled."
                 : $"git command timed out after {FormatDuration(GitCommandTimeout)}.");
-            if (!process.WaitForExit(ToWaitMilliseconds(GitKillWaitTimeout)))
+            if (!await WaitForGitExitAfterKillAsync(process, GitKillWaitTimeout).ConfigureAwait(false))
             {
                 if (cancelled)
                     cancellationToken.ThrowIfCancellationRequested();
@@ -1019,11 +1026,8 @@ public static class GitHelper
                     failureDiagnostic);
             }
         }
-        else
-        {
-            _ = process.WaitForExit(0);
-        }
-        if (!WaitForCaptureReaders(stdoutTask, stderrTask))
+
+        if (!await WaitForCaptureReadersAsync(stdoutTask, stderrTask).ConfigureAwait(false))
             MarkFailure(GitCommandFailureKind.OutputCaptureIncomplete, "git command output capture did not finish.");
 
         var output = ReadCaptured(stdout);
@@ -1055,35 +1059,23 @@ public static class GitHelper
         return new GitProcessCaptureResult(exitCode, output, error, GitCommandFailureKind.None, null);
     }
 
-    private static bool WaitForGitExit(
+    private readonly record struct GitExitWaitResult(bool Exited, bool Cancelled);
+
+    private static async Task<GitExitWaitResult> WaitForGitExitAsync(
         Process process,
         TimeSpan timeout,
-        CancellationToken cancellationToken,
-        out bool cancelled)
+        CancellationToken cancellationToken)
     {
-        var timeoutMilliseconds = ToWaitMilliseconds(timeout);
-        var waitSliceMilliseconds = Math.Min(50, timeoutMilliseconds);
-        var stopwatch = Stopwatch.StartNew();
-        while (true)
+        var exitTask = process.WaitForExitAsync(CancellationToken.None);
+        var delayTask = Task.Delay(NormalizePositiveTimeout(timeout), cancellationToken);
+        var completed = await Task.WhenAny(exitTask, delayTask).ConfigureAwait(false);
+        if (completed == exitTask)
         {
-            if (process.WaitForExit(waitSliceMilliseconds))
-            {
-                cancelled = false;
-                return true;
-            }
-
-            if (cancellationToken.IsCancellationRequested)
-            {
-                cancelled = true;
-                return false;
-            }
-
-            if (stopwatch.ElapsedMilliseconds >= timeoutMilliseconds)
-            {
-                cancelled = false;
-                return false;
-            }
+            await exitTask.ConfigureAwait(false);
+            return new GitExitWaitResult(true, false);
         }
+
+        return new GitExitWaitResult(false, cancellationToken.IsCancellationRequested);
     }
 
     private static string ReadCaptured(StringBuilder builder)
@@ -1092,19 +1084,41 @@ public static class GitHelper
             return builder.ToString();
     }
 
-    private static bool WaitForCaptureReaders(Task stdoutTask, Task stderrTask)
+    private static async Task<bool> WaitForGitExitAfterKillAsync(Process process, TimeSpan timeout)
     {
         try
         {
-            return Task.WaitAll([stdoutTask, stderrTask], ToWaitMilliseconds(GitKillWaitTimeout));
+            await process.WaitForExitAsync(CancellationToken.None)
+                .WaitAsync(NormalizePositiveTimeout(timeout))
+                .ConfigureAwait(false);
+            return true;
         }
-        catch (AggregateException)
+        catch (InvalidOperationException)
+        {
+            return true;
+        }
+        catch (TimeoutException)
         {
             return false;
         }
     }
 
-    private static void ReadCapturedStream(
+    private static async Task<bool> WaitForCaptureReadersAsync(Task stdoutTask, Task stderrTask)
+    {
+        try
+        {
+            await Task.WhenAll(stdoutTask, stderrTask)
+                .WaitAsync(NormalizePositiveTimeout(GitKillWaitTimeout))
+                .ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or TimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task ReadCapturedStreamAsync(
         TextReader reader,
         StringBuilder builder,
         string streamName,
@@ -1115,7 +1129,7 @@ public static class GitHelper
         {
             while (true)
             {
-                var read = reader.Read(buffer, 0, buffer.Length);
+                var read = await reader.ReadAsync(buffer.AsMemory(0, buffer.Length)).ConfigureAwait(false);
                 if (read == 0)
                     return;
                 if (!AppendBoundedCapturedChars(builder, buffer.AsSpan(0, read), streamName, markFailure))
@@ -1180,13 +1194,11 @@ public static class GitHelper
             ? diagnostic
             : diagnostic + "\n" + stderr.TrimEnd('\r', '\n'));
 
-    private static int ToWaitMilliseconds(TimeSpan timeout)
+    private static TimeSpan NormalizePositiveTimeout(TimeSpan timeout)
     {
         if (timeout <= TimeSpan.Zero)
-            return 1;
-        if (timeout.TotalMilliseconds >= int.MaxValue)
-            return int.MaxValue;
-        return Math.Max(1, (int)Math.Ceiling(timeout.TotalMilliseconds));
+            return TimeSpan.FromMilliseconds(1);
+        return timeout;
     }
 
     private static string FormatDuration(TimeSpan timeout)

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -81,6 +81,7 @@ public static class GitHelper
 
     internal const int MaxCapturedGitOutputChars = 1024 * 1024;
     internal const int MaxGitFailureDiagnosticChars = 512;
+    private const int MaxGitDiagnosticRedactionInputChars = 4096;
     private const int GitCaptureReadBufferChars = 8192;
     private static readonly TimeSpan DefaultGitCommandTimeout = TimeSpan.FromSeconds(60);
     private static readonly AsyncLocal<TimeSpan?> GitCommandTimeoutOverride = new();
@@ -1165,14 +1166,19 @@ public static class GitHelper
         => $"git command captured {streamName} exceeded {MaxCapturedGitOutputChars.ToString(CultureInfo.InvariantCulture)} characters.";
 
     private static string FormatGitDiagnostic(string diagnostic)
-        => DiagnosticRedactor.BoundDiagnosticText(
-            DiagnosticRedactor.RedactSensitiveText(diagnostic, "[redacted]", redactPaths: true),
+    {
+        var boundedBeforeRedaction = DiagnosticRedactor.BoundDiagnosticText(
+            diagnostic,
+            MaxGitDiagnosticRedactionInputChars);
+        return DiagnosticRedactor.BoundDiagnosticText(
+            DiagnosticRedactor.RedactSensitiveText(boundedBeforeRedaction, "[redacted]", redactPaths: true),
             MaxGitFailureDiagnosticChars);
+    }
 
     private static string CombineCapturedError(string stderr, string diagnostic)
         => FormatGitDiagnostic(string.IsNullOrWhiteSpace(stderr)
             ? diagnostic
-            : stderr.TrimEnd('\r', '\n') + "\n" + diagnostic);
+            : diagnostic + "\n" + stderr.TrimEnd('\r', '\n'));
 
     private static int ToWaitMilliseconds(TimeSpan timeout)
     {

--- a/src/CodeIndex/Cli/GitHubHttpClientFactory.cs
+++ b/src/CodeIndex/Cli/GitHubHttpClientFactory.cs
@@ -28,6 +28,36 @@ internal static class GitHubHttpClientFactory
         return client;
     }
 
+    internal static RequestCancellationScope CreateRequestCancellationScope(
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+        => new(timeout, cancellationToken);
+
+    internal sealed class RequestCancellationScope : IDisposable
+    {
+        private readonly CancellationTokenSource timeoutCts;
+        private readonly CancellationTokenSource linkedCts;
+
+        internal RequestCancellationScope(TimeSpan timeout, CancellationToken cancellationToken)
+        {
+            timeoutCts = new CancellationTokenSource();
+            if (timeout > TimeSpan.Zero && timeout != Timeout.InfiniteTimeSpan)
+                timeoutCts.CancelAfter(timeout);
+
+            linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        }
+
+        internal CancellationToken Token => linkedCts.Token;
+
+        internal bool IsTimeoutCancellationRequested => timeoutCts.IsCancellationRequested;
+
+        public void Dispose()
+        {
+            linkedCts.Dispose();
+            timeoutCts.Dispose();
+        }
+    }
+
     internal static void ApplyDefaultHeaders(HttpRequestHeaders headers)
     {
         if (headers.UserAgent.Count == 0)

--- a/src/CodeIndex/Cli/GitHubIssueReporter.cs
+++ b/src/CodeIndex/Cli/GitHubIssueReporter.cs
@@ -119,8 +119,8 @@ internal static class GitHubIssueReporter
         if (token == null)
             return SuggestionStore.SubmitAttemptResult.Skipped();
 
-        using var timeoutCts = CreateTimeoutCancellationSource();
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var timeout = ResolveSubmitTimeout();
+        using var requestCancellation = GitHubHttpClientFactory.CreateRequestCancellationScope(timeout, cancellationToken);
 
         try
         {
@@ -137,7 +137,7 @@ internal static class GitHubIssueReporter
                 record.Hash,
                 token,
                 BuildExistingSuggestionLookupLabels(record),
-                linkedCts.Token);
+                requestCancellation.Token);
             if (existingLookup.Error != null)
             {
                 CommandErrorWriter.WriteStderr(BuildSubmissionFailureMessage(existingLookup.Error));
@@ -147,11 +147,11 @@ internal static class GitHubIssueReporter
             if (existingLookup.IssueUrl != null)
                 return SuggestionStore.SubmitAttemptResult.Success(existingLookup.IssueUrl);
 
-            return await CreateIssueAsync(record, version, token, linkedCts.Token);
+            return await CreateIssueAsync(record, version, token, requestCancellation.Token);
         }
-        catch (OperationCanceledException ex) when (timeoutCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+        catch (OperationCanceledException ex) when (requestCancellation.IsTimeoutCancellationRequested && !cancellationToken.IsCancellationRequested)
         {
-            var detail = $"{ex.GetType().Name}: GitHub submission timed out after {ResolveSubmitTimeout().TotalSeconds:0} seconds";
+            var detail = $"{ex.GetType().Name}: GitHub submission timed out after {timeout.TotalSeconds:0} seconds";
             CommandErrorWriter.WriteStderr(BuildSubmissionFailureMessage(detail));
             return SuggestionStore.SubmitAttemptResult.Failure(detail);
         }
@@ -174,14 +174,6 @@ internal static class GitHubIssueReporter
             return !taskCanceled.CancellationToken.IsCancellationRequested || IsTimeoutCancellation(taskCanceled);
 
         return ex is not OperationCanceledException;
-    }
-
-    private static CancellationTokenSource CreateTimeoutCancellationSource()
-    {
-        var timeout = ResolveSubmitTimeout();
-        return timeout <= TimeSpan.Zero
-            ? new CancellationTokenSource()
-            : new CancellationTokenSource(timeout);
     }
 
     internal static TimeSpan ResolveSubmitTimeout()

--- a/src/CodeIndex/Cli/IssueDuplicatePreflight.cs
+++ b/src/CodeIndex/Cli/IssueDuplicatePreflight.cs
@@ -383,8 +383,8 @@ internal sealed class IssueDuplicatePreflight
         var owner = repository[..slash];
         var name = repository[(slash + 1)..];
         var url = $"{GitHubApiBase}/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(name)}/issues?state=open&per_page={GitHubOpenIssuesPerPage.ToString(CultureInfo.InvariantCulture)}&page={page.ToString(CultureInfo.InvariantCulture)}";
-        using var timeoutCts = new CancellationTokenSource(GitHubIssueReporter.ResolveSubmitTimeout());
-        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCts.Token);
+        var timeout = GitHubIssueReporter.ResolveSubmitTimeout();
+        using var requestCancellation = GitHubHttpClientFactory.CreateRequestCancellationScope(timeout, cancellationToken);
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
         GitHubHttpClientFactory.ApplyDefaultHeaders(request.Headers);
         var token = Environment.GetEnvironmentVariable(GitHubTokenEnvironmentVariable);
@@ -397,12 +397,12 @@ internal sealed class IssueDuplicatePreflight
             response = await HttpClient.SendAsync(
                 request,
                 HttpCompletionOption.ResponseHeadersRead,
-                linkedCts.Token).ConfigureAwait(false);
+                requestCancellation.Token).ConfigureAwait(false);
         }
-        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested && timeoutCts.IsCancellationRequested)
+        catch (OperationCanceledException ex) when (!cancellationToken.IsCancellationRequested && requestCancellation.IsTimeoutCancellationRequested)
         {
             throw new TimeoutException(
-                $"GitHub open-issues preflight timed out after {GitHubIssueReporter.ResolveSubmitTimeout().TotalSeconds:0} seconds.",
+                $"GitHub open-issues preflight timed out after {timeout.TotalSeconds:0} seconds.",
                 ex);
         }
 
@@ -410,9 +410,9 @@ internal sealed class IssueDuplicatePreflight
         {
             if (!response.IsSuccessStatusCode)
                 throw new GitHubPreflightException(
-                    await BuildGitHubApiErrorDetailAsync(response, linkedCts.Token).ConfigureAwait(false));
+                    await BuildGitHubApiErrorDetailAsync(response, requestCancellation.Token).ConfigureAwait(false));
 
-            var json = await ReadContentWithinLimitAsync(response.Content, MaxOpenIssuesJsonBytes, linkedCts.Token)
+            var json = await ReadContentWithinLimitAsync(response.Content, MaxOpenIssuesJsonBytes, requestCancellation.Token)
                 .ConfigureAwait(false)
                 ?? throw new IOException($"GitHub open-issues response exceeds maximum supported size of {MaxOpenIssuesJsonBytes} bytes.");
             var root = JsonNode.Parse(json, documentOptions: new JsonDocumentOptions { MaxDepth = MaxOpenIssuesJsonDepth });

--- a/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
@@ -248,8 +248,8 @@ internal static partial class ProgramRunner
         {
             "upgrade" => RunUpgrade(subArgs, context.JsonOptions, context.AppVersion, context.CancellationToken),
             "index" => IndexCommandRunner.Run(subArgs, context.JsonOptions),
-            "export" => ExportImportCommandRunner.RunExport(subArgs, context.JsonOptions, context.AppVersion),
-            "import" => ExportImportCommandRunner.RunImport(subArgs, context.JsonOptions),
+            "export" => ExportImportCommandRunner.RunExport(subArgs, context.JsonOptions, context.AppVersion, context.CancellationToken),
+            "import" => ExportImportCommandRunner.RunImport(subArgs, context.JsonOptions, context.CancellationToken),
             "diff" => DiffCommandRunner.Run(subArgs, context.JsonOptions),
             "hooks" => HookCommandRunner.Run(subArgs, context.JsonOptions),
             "backfill-fold" => IndexCommandRunner.RunBackfillFold(subArgs, context.JsonOptions),

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -3082,7 +3082,11 @@ internal static partial class ProgramRunner
                         cancellationToken)
                     .GetAwaiter()
                     .GetResult();
-                VerifyFileSha256(scriptPath, expectedInstallerSha256, InstallerScriptAssetName);
+                if (!wantsJson)
+                    CommandErrorWriter.WriteStderr($"Verifying {InstallerScriptAssetName} checksum...");
+                VerifyFileSha256(scriptPath, expectedInstallerSha256, InstallerScriptAssetName, cancellationToken);
+                if (!wantsJson)
+                    CommandErrorWriter.WriteStderr($"Verified {InstallerScriptAssetName} checksum.");
             }
 
             var startInfo = CreateInstallerProcessStartInfo(scriptPath, selectedReleaseTag, installDir);
@@ -3609,13 +3613,17 @@ internal static partial class ProgramRunner
         throw new InvalidDataException($"Release checksum manifest does not contain {assetName}.");
     }
 
-    internal static void VerifyFileSha256(string path, string expectedSha256Hex, string assetName)
+    internal static void VerifyFileSha256(
+        string path,
+        string expectedSha256Hex,
+        string assetName,
+        CancellationToken cancellationToken = default)
     {
         if (!IsSha256Hex(expectedSha256Hex))
             throw new InvalidDataException($"Release checksum for {assetName} is not a valid SHA-256 digest.");
 
         using var stream = File.OpenRead(path);
-        var actual = Convert.ToHexString(SHA256.HashData(stream)).ToLowerInvariant();
+        var actual = Sha256StreamHasher.ComputeHex(stream, cancellationToken);
         if (!string.Equals(actual, expectedSha256Hex, StringComparison.OrdinalIgnoreCase))
             throw new InvalidDataException(
                 $"Downloaded {assetName} checksum mismatch: expected {expectedSha256Hex}, got {actual}.");

--- a/src/CodeIndex/Cli/Sha256StreamHasher.cs
+++ b/src/CodeIndex/Cli/Sha256StreamHasher.cs
@@ -1,0 +1,33 @@
+using System.Security.Cryptography;
+
+namespace CodeIndex.Cli;
+
+internal static class Sha256StreamHasher
+{
+    internal const int DefaultBufferSize = 81920;
+
+    internal static string ComputeHex(
+        Stream stream,
+        CancellationToken cancellationToken = default,
+        Action<long>? progressBytesRead = null)
+    {
+        using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        var buffer = new byte[DefaultBufferSize];
+        long totalBytes = 0;
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var read = stream.Read(buffer, 0, buffer.Length);
+            if (read == 0)
+                break;
+
+            hasher.AppendData(buffer.AsSpan(0, read));
+            totalBytes += read;
+            progressBytesRead?.Invoke(totalBytes);
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        return Convert.ToHexString(hasher.GetHashAndReset()).ToLowerInvariant();
+    }
+}

--- a/src/CodeIndex/Cli/UpdateChecker.cs
+++ b/src/CodeIndex/Cli/UpdateChecker.cs
@@ -219,22 +219,21 @@ internal static class UpdateChecker
         TimeSpan timeout,
         CancellationToken cancellationToken)
     {
-        using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        requestCts.CancelAfter(timeout);
+        using var requestCancellation = GitHubHttpClientFactory.CreateRequestCancellationScope(timeout, cancellationToken);
         using var request = new HttpRequestMessage(HttpMethod.Get, LatestReleaseUrl);
         GitHubHttpClientFactory.ApplyDefaultHeaders(request.Headers);
 
         using var response = await client.SendAsync(
             request,
             HttpCompletionOption.ResponseHeadersRead,
-            requestCts.Token).ConfigureAwait(false);
+            requestCancellation.Token).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
-            await ThrowIfRateLimitedAsync(response, requestCts.Token).ConfigureAwait(false);
+            await ThrowIfRateLimitedAsync(response, requestCancellation.Token).ConfigureAwait(false);
             return null;
         }
 
-        return await ReadLatestReleaseTagAsync(response.Content, requestCts.Token).ConfigureAwait(false);
+        return await ReadLatestReleaseTagAsync(response.Content, requestCancellation.Token).ConfigureAwait(false);
     }
 
     internal static async Task<string?> FetchLatestPrereleaseTagAsync(
@@ -242,22 +241,21 @@ internal static class UpdateChecker
         TimeSpan timeout,
         CancellationToken cancellationToken)
     {
-        using var requestCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-        requestCts.CancelAfter(timeout);
+        using var requestCancellation = GitHubHttpClientFactory.CreateRequestCancellationScope(timeout, cancellationToken);
         using var request = new HttpRequestMessage(HttpMethod.Get, ReleasesUrl);
         GitHubHttpClientFactory.ApplyDefaultHeaders(request.Headers);
 
         using var response = await client.SendAsync(
             request,
             HttpCompletionOption.ResponseHeadersRead,
-            requestCts.Token).ConfigureAwait(false);
+            requestCancellation.Token).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
         {
-            await ThrowIfRateLimitedAsync(response, requestCts.Token).ConfigureAwait(false);
+            await ThrowIfRateLimitedAsync(response, requestCancellation.Token).ConfigureAwait(false);
             return null;
         }
 
-        return await ReadLatestPrereleaseTagAsync(response.Content, requestCts.Token).ConfigureAwait(false);
+        return await ReadLatestPrereleaseTagAsync(response.Content, requestCancellation.Token).ConfigureAwait(false);
     }
 
     private static async Task ThrowIfRateLimitedAsync(HttpResponseMessage response, CancellationToken cancellationToken)

--- a/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
+++ b/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
@@ -48,11 +48,13 @@ internal sealed class PostExtractionHookCallbackWorkerClient : IDisposable
         FileContext context,
         IReadOnlyList<SymbolRecord>? symbols,
         IReadOnlyList<ReferenceRecord>? references,
-        TimeSpan callbackBudget)
+        TimeSpan callbackBudget,
+        CancellationToken cancellationToken = default)
     {
         lock (gate)
         {
             ObjectDisposedException.ThrowIf(disposed, this);
+            cancellationToken.ThrowIfCancellationRequested();
             var stopwatch = Stopwatch.StartNew();
             if (!EnsureStarted(out var startError))
             {
@@ -80,7 +82,7 @@ internal sealed class PostExtractionHookCallbackWorkerClient : IDisposable
                     process!.StandardOutput,
                     maxProtocolLineBytes,
                     maxProtocolLineBytes,
-                    CancellationToken.None);
+                    cancellationToken);
                 sendTask = SendRequestAsync(process.StandardInput, requestJson);
             }
             catch (Exception ex)
@@ -90,7 +92,7 @@ internal sealed class PostExtractionHookCallbackWorkerClient : IDisposable
                     stopwatch);
             }
 
-            if (!WaitForTask(sendTask, waitMilliseconds, out var sendException))
+            if (!WaitForTask(sendTask, waitMilliseconds, cancellationToken, out var sendException))
             {
                 return TimedOutAfterKill(stopwatch);
             }
@@ -103,7 +105,7 @@ internal sealed class PostExtractionHookCallbackWorkerClient : IDisposable
             }
 
             waitMilliseconds = GetRemainingWaitMilliseconds(stopwatch, callbackBudget);
-            if (waitMilliseconds <= 0 || !WaitForTask(responseTask, waitMilliseconds, out var responseException))
+            if (waitMilliseconds <= 0 || !WaitForTask(responseTask, waitMilliseconds, cancellationToken, out var responseException))
             {
                 return TimedOutAfterKill(stopwatch);
             }
@@ -299,23 +301,28 @@ internal sealed class PostExtractionHookCallbackWorkerClient : IDisposable
         await input.FlushAsync().ConfigureAwait(false);
     }
 
-    private static bool WaitForTask(Task task, int milliseconds, out Exception? exception)
+    private bool WaitForTask(Task task, int milliseconds, CancellationToken cancellationToken, out Exception? exception)
     {
         try
         {
-            if (!task.Wait(milliseconds))
-            {
-                exception = null;
-                return false;
-            }
-
+            task.WaitAsync(TimeSpan.FromMilliseconds(milliseconds), cancellationToken).GetAwaiter().GetResult();
             exception = null;
             return true;
+        }
+        catch (TimeoutException)
+        {
+            exception = null;
+            return false;
         }
         catch (AggregateException ex)
         {
             exception = ex.GetBaseException();
             return true;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _ = KillWorker();
+            throw;
         }
         catch (Exception ex)
         {

--- a/src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
+++ b/src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
@@ -325,12 +325,14 @@ public sealed class PostExtractionHookRunner : IDisposable
 
     public TimeSpan CallbackBudget => callbackBudget;
 
-    public void OnSymbolsExtracted(FileContext context, IList<SymbolRecord> symbols)
+    public void OnSymbolsExtracted(FileContext context, IList<SymbolRecord> symbols, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(disposed, this);
+        cancellationToken.ThrowIfCancellationRequested();
 
         foreach (var hook in hooks)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var workingSymbols = CloneSymbols(symbols);
             if (InvokeHookWithBudget(
                     hook,
@@ -338,19 +340,22 @@ public sealed class PostExtractionHookRunner : IDisposable
                     nameof(IPostExtractionHook.OnSymbolsExtracted),
                     context,
                     workingSymbols,
-                    null))
+                    null,
+                    cancellationToken))
             {
                 ReplaceList(symbols, workingSymbols);
             }
         }
     }
 
-    public void OnReferencesExtracted(FileContext context, IList<ReferenceRecord> references)
+    public void OnReferencesExtracted(FileContext context, IList<ReferenceRecord> references, CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(disposed, this);
+        cancellationToken.ThrowIfCancellationRequested();
 
         foreach (var hook in hooks)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var workingReferences = CloneReferences(references);
             if (InvokeHookWithBudget(
                     hook,
@@ -358,7 +363,8 @@ public sealed class PostExtractionHookRunner : IDisposable
                     nameof(IPostExtractionHook.OnReferencesExtracted),
                     context,
                     null,
-                    workingReferences))
+                    workingReferences,
+                    cancellationToken))
             {
                 ReplaceList(references, workingReferences);
             }
@@ -371,18 +377,21 @@ public sealed class PostExtractionHookRunner : IDisposable
         string callback,
         FileContext context,
         List<SymbolRecord>? symbols,
-        List<ReferenceRecord>? references)
+        List<ReferenceRecord>? references,
+        CancellationToken cancellationToken)
     {
         if (disabledHooks.ContainsKey(hook.Info.TypeName))
             return false;
 
+        cancellationToken.ThrowIfCancellationRequested();
         var result = hook.Worker.Invoke(
             kind,
             callback,
             context,
             symbols,
             references,
-            callbackBudget);
+            callbackBudget,
+            cancellationToken);
         if (result.TimedOut)
         {
             disabledHooks.TryAdd(hook.Info.TypeName, 0);

--- a/src/CodeIndex/Indexer/Scanning/FileContentLoader.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileContentLoader.cs
@@ -382,13 +382,16 @@ internal sealed class FileContentLoader(long maxFileSizeBytes)
         return FinishChecksum(hasher);
     }
 
-    internal static bool TryComputeChecksum(string filePath, long maxBytes, out string checksum)
+    internal static bool TryComputeChecksum(
+        string filePath,
+        long maxBytes,
+        out string checksum,
+        CancellationToken cancellationToken = default)
     {
         if (maxBytes < 0)
             throw new ArgumentOutOfRangeException(nameof(maxBytes), maxBytes, "Maximum byte count must be non-negative.");
 
         checksum = string.Empty;
-        using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         using var stream = new FileStream(
             filePath,
             FileMode.Open,
@@ -396,12 +399,26 @@ internal sealed class FileContentLoader(long maxFileSizeBytes)
             FileShare.Read,
             bufferSize: 81920,
             options: FileOptions.SequentialScan);
+        return TryComputeChecksum(stream, maxBytes, out checksum, cancellationToken);
+    }
 
+    internal static bool TryComputeChecksum(
+        Stream stream,
+        long maxBytes,
+        out string checksum,
+        CancellationToken cancellationToken = default)
+    {
+        if (maxBytes < 0)
+            throw new ArgumentOutOfRangeException(nameof(maxBytes), maxBytes, "Maximum byte count must be non-negative.");
+
+        checksum = string.Empty;
+        using var hasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         var buffer = new byte[81920];
         var pendingCarriageReturn = false;
         long total = 0;
         while (true)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             var read = stream.Read(buffer, 0, buffer.Length);
             if (read == 0)
                 break;

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
@@ -285,14 +285,14 @@ internal sealed class SymbolExtractionWorkerClient : IDisposable
     {
         try
         {
-            if (!task.Wait(milliseconds, cancellationToken))
-            {
-                exception = null;
-                return false;
-            }
-
+            task.WaitAsync(TimeSpan.FromMilliseconds(milliseconds), cancellationToken).GetAwaiter().GetResult();
             exception = null;
             return true;
+        }
+        catch (TimeoutException)
+        {
+            exception = null;
+            return false;
         }
         catch (AggregateException ex)
         {

--- a/src/CodeIndex/Lsp/LspServer.cs
+++ b/src/CodeIndex/Lsp/LspServer.cs
@@ -118,6 +118,7 @@ internal sealed class LspServer : IDisposable
     private readonly record struct PositionTokenContext(string Token, string IndexedPath, string? WorkspaceRoot, int Line, int StartCharacter, int EndCharacter);
     private readonly record struct DocumentSymbolNode(SymbolResult Symbol, JsonObject Item);
     private readonly record struct IndexedDocumentContext(string DocumentPath, string ResolvedPath, string IndexedPath, string? WorkspaceRoot);
+    internal readonly record struct MessageReadResult(bool Success, string Payload);
 
     public LspServer(DbReader reader, string version, JsonSerializerOptions jsonOptions, string? projectRoot = null)
     {
@@ -135,22 +136,29 @@ internal sealed class LspServer : IDisposable
     }
 
     /// <summary>
-    /// Compatibility wrapper that runs without caller cancellation. Prefer the overload that
-    /// accepts <see cref="CancellationToken"/> when the caller has a shutdown or disconnect token.
+    /// Compatibility wrapper that runs without caller cancellation. Prefer <see cref="RunAsync"/>
+    /// when the caller has a shutdown or disconnect token.
     /// caller cancellation を持たない互換 wrapper。shutdown / disconnect token がある場合は
-    /// <see cref="Run(Stream, Stream, CancellationToken)"/> を使う。
+    /// <see cref="RunAsync"/> を使う。
     /// </summary>
-    public int Run(Stream input, Stream output) => Run(input, output, CancellationToken.None);
+    public int Run(Stream input, Stream output) => RunAsync(input, output, CancellationToken.None).GetAwaiter().GetResult();
 
     public int Run(Stream input, Stream output, CancellationToken cancellationToken)
+        => RunAsync(input, output, cancellationToken).GetAwaiter().GetResult();
+
+    public async Task<int> RunAsync(Stream input, Stream output, CancellationToken cancellationToken = default)
     {
-        while (TryReadMessage(input, out var payload, cancellationToken))
+        while (true)
         {
+            var read = await TryReadMessageAsync(input, cancellationToken).ConfigureAwait(false);
+            if (!read.Success)
+                break;
+
             cancellationToken.ThrowIfCancellationRequested();
-            var response = HandleMessage(payload);
+            var response = HandleMessage(read.Payload);
             cancellationToken.ThrowIfCancellationRequested();
             if (response != null)
-                WriteMessage(output, response.ToJsonString(_jsonOptions));
+                await WriteMessageAsync(output, response.ToJsonString(_jsonOptions), cancellationToken).ConfigureAwait(false);
             if (_exitRequested)
                 break;
         }
@@ -1776,17 +1784,25 @@ internal sealed class LspServer : IDisposable
     };
 
     /// <summary>
-    /// Compatibility wrapper that reads without caller cancellation. Prefer the overload that
-    /// accepts <see cref="CancellationToken"/> for cancellable transports.
+    /// Compatibility wrapper that reads without caller cancellation. Prefer <see cref="TryReadMessageAsync"/>
+    /// for cancellable transports.
     /// caller cancellation を持たない互換 wrapper。キャンセル可能な transport では
-    /// token を受け取る overload を使う。
+    /// <see cref="TryReadMessageAsync"/> を使う。
     /// </summary>
     internal static bool TryReadMessage(Stream input, out string payload) =>
         TryReadMessage(input, out payload, CancellationToken.None);
 
     internal static bool TryReadMessage(Stream input, out string payload, CancellationToken cancellationToken)
     {
-        payload = string.Empty;
+        var result = TryReadMessageAsync(input, cancellationToken).AsTask().GetAwaiter().GetResult();
+        payload = result.Payload;
+        return result.Success;
+    }
+
+    internal static async ValueTask<MessageReadResult> TryReadMessageAsync(
+        Stream input,
+        CancellationToken cancellationToken = default)
+    {
         var contentLength = -1;
         var hasContentLength = false;
         var headerCount = 0;
@@ -1794,15 +1810,15 @@ internal sealed class LspServer : IDisposable
         while (true)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var line = ReadAsciiLine(input, cancellationToken);
+            var line = await ReadAsciiLineAsync(input, cancellationToken).ConfigureAwait(false);
             if (line == null)
-                return false;
+                return new MessageReadResult(false, string.Empty);
             if (line.Length == 0)
                 break;
             headerCount++;
             headerBytes += line.Length;
             if (headerCount > MaxLspHeaderCount || headerBytes > MaxLspHeaderBytes)
-                return false;
+                return new MessageReadResult(false, string.Empty);
             var colon = line.IndexOf(':');
             if (colon <= 0)
                 continue;
@@ -1811,12 +1827,12 @@ internal sealed class LspServer : IDisposable
             if (string.Equals(name, "Content-Length", StringComparison.OrdinalIgnoreCase))
             {
                 if (hasContentLength)
-                    return false;
+                    return new MessageReadResult(false, string.Empty);
                 if (!int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var parsed)
                     || parsed < 0
                     || parsed > MaxLspFrameBytes)
                 {
-                    return false;
+                    return new MessageReadResult(false, string.Empty);
                 }
 
                 hasContentLength = true;
@@ -1825,7 +1841,7 @@ internal sealed class LspServer : IDisposable
         }
 
         if (contentLength < 0)
-            return false;
+            return new MessageReadResult(false, string.Empty);
 
         var buffer = ArrayPool<byte>.Shared.Rent(contentLength);
         try
@@ -1833,13 +1849,12 @@ internal sealed class LspServer : IDisposable
             var offset = 0;
             while (offset < contentLength)
             {
-                var read = Read(input, buffer, offset, contentLength - offset, cancellationToken);
+                var read = await ReadAsync(input, buffer, offset, contentLength - offset, cancellationToken).ConfigureAwait(false);
                 if (read == 0)
-                    return false;
+                    return new MessageReadResult(false, string.Empty);
                 offset += read;
             }
-            payload = Encoding.UTF8.GetString(buffer, 0, contentLength);
-            return true;
+            return new MessageReadResult(true, Encoding.UTF8.GetString(buffer, 0, contentLength));
         }
         finally
         {
@@ -1856,7 +1871,16 @@ internal sealed class LspServer : IDisposable
         output.Flush();
     }
 
-    private static string? ReadAsciiLine(Stream input, CancellationToken cancellationToken)
+    private static async Task WriteMessageAsync(Stream output, string payload, CancellationToken cancellationToken)
+    {
+        var body = Encoding.UTF8.GetBytes(payload);
+        var header = Encoding.ASCII.GetBytes($"Content-Length: {body.Length}\r\n\r\n");
+        await output.WriteAsync(header, cancellationToken).ConfigureAwait(false);
+        await output.WriteAsync(body, cancellationToken).ConfigureAwait(false);
+        await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static async ValueTask<string?> ReadAsciiLineAsync(Stream input, CancellationToken cancellationToken)
     {
         var buffer = ArrayPool<byte>.Shared.Rent(MaxLspHeaderLineBytes + 1);
         var length = 0;
@@ -1864,7 +1888,7 @@ internal sealed class LspServer : IDisposable
         {
             while (true)
             {
-                var read = Read(input, buffer, length, 1, cancellationToken);
+                var read = await ReadAsync(input, buffer, length, 1, cancellationToken).ConfigureAwait(false);
                 if (read == 0)
                     return length == 0 ? null : Encoding.ASCII.GetString(buffer, 0, length);
 
@@ -1887,10 +1911,10 @@ internal sealed class LspServer : IDisposable
         }
     }
 
-    private static int Read(Stream input, byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+    private static ValueTask<int> ReadAsync(Stream input, byte[] buffer, int offset, int count, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
-        return input.ReadAsync(buffer.AsMemory(offset, count), cancellationToken).AsTask().GetAwaiter().GetResult();
+        return input.ReadAsync(buffer.AsMemory(offset, count), cancellationToken);
     }
 
     public void Dispose()

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -1118,6 +1118,27 @@ public class ExportImportCommandRunnerTests
         Assert.Equal([1, 2, 3, 4], target.ToArray());
     }
 
+    [Fact]
+    public void Sha256StreamHasher_CancellationDuringRead_ThrowsOperationCanceled_Issue3797()
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var stream = new CancelAfterFirstReadStream([1, 2, 3, 4], cancellation);
+
+        Assert.Throws<OperationCanceledException>(() =>
+            Sha256StreamHasher.ComputeHex(stream, cancellation.Token));
+    }
+
+    [Fact]
+    public void CopyToWithLimit_CancellationDuringRead_ThrowsOperationCanceled_Issue3797()
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var source = new CancelAfterFirstReadStream([1, 2, 3, 4], cancellation);
+        using var target = new MemoryStream();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            ExportImportCommandRunner.CopyToWithLimit(source, target, maxBytes: 8, cancellationToken: cancellation.Token));
+    }
+
     private static string CreateArchiveWithManifest(string workDir, string manifest)
     {
         var archivePath = Path.Combine(workDir, "codeindex.cdidx.zip");
@@ -1199,5 +1220,42 @@ public class ExportImportCommandRunnerTests
         command.CommandText = "SELECT value FROM codeindex_meta WHERE key = @key";
         command.Parameters.AddWithValue("@key", key);
         return command.ExecuteScalar() as string;
+    }
+
+    private sealed class CancelAfterFirstReadStream(byte[] data, CancellationTokenSource cancellation) : Stream
+    {
+        private int offset;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => data.Length;
+        public override long Position
+        {
+            get => offset;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int bufferOffset, int count)
+        {
+            if (offset >= data.Length)
+                return 0;
+
+            var read = Math.Min(count, data.Length - offset);
+            Array.Copy(data, offset, buffer, bufferOffset, read);
+            offset += read;
+            cancellation.Cancel();
+            return read;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long seekOffset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int bufferOffset, int count) => throw new NotSupportedException();
     }
 }

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -5994,6 +5994,16 @@ public class FileIndexerTests
         Assert.False(FileIndexer.IsGeneratedCodeFile("src/Foo.cs", "// This file is not auto-generated.\nclass Foo { }\n"));
     }
 
+    [Fact]
+    public void TryComputeChecksum_CancellationDuringRead_ThrowsOperationCanceled_Issue3784()
+    {
+        using var cancellation = new CancellationTokenSource();
+        using var stream = new CancelAfterFirstReadStream(Encoding.UTF8.GetBytes("first\nsecond\n"), cancellation);
+
+        Assert.Throws<OperationCanceledException>(() =>
+            FileContentLoader.TryComputeChecksum(stream, long.MaxValue, out _, cancellation.Token));
+    }
+
     private static void WriteFileIndexerPatternConfig(string projectRoot, string fileName, string content)
     {
         var path = Path.Combine(projectRoot, ".cdidx", "patterns", fileName);
@@ -6046,5 +6056,42 @@ public class FileIndexerTests
         cmd.Parameters.AddWithValue("@path", filePath);
         cmd.Parameters.AddWithValue("@kind", kind);
         return cmd.ExecuteScalar() != null;
+    }
+
+    private sealed class CancelAfterFirstReadStream(byte[] data, CancellationTokenSource cancellation) : Stream
+    {
+        private int offset;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => data.Length;
+        public override long Position
+        {
+            get => offset;
+            set => throw new NotSupportedException();
+        }
+
+        public override int Read(byte[] buffer, int bufferOffset, int count)
+        {
+            if (offset >= data.Length)
+                return 0;
+
+            var read = Math.Min(count, data.Length - offset);
+            Array.Copy(data, offset, buffer, bufferOffset, read);
+            offset += read;
+            cancellation.Cancel();
+            return read;
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override long Seek(long seekOffset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int bufferOffset, int count) => throw new NotSupportedException();
     }
 }

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -458,6 +458,43 @@ public class GitHelperTests : IDisposable
     }
 
     [Fact]
+    public void RunGitCapturingResult_FailsWhenCapturedStderrExceedsLimit_Issue3704()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var repoDir = Path.Combine(_tempDir, "repo-stderr-cap");
+        Directory.CreateDirectory(repoDir);
+        var fakeGitDir = Path.Combine(_tempDir, "fake-git-stderr-cap");
+        Directory.CreateDirectory(fakeGitDir);
+        WriteFakeGitThatExceedsStderrLimit(fakeGitDir);
+
+        var oldGitExecutablePath = GitHelper.GitExecutablePathOverride;
+        GitHelper.GitExecutablePathOverride = Path.Combine(fakeGitDir, "git");
+        try
+        {
+            var result = GitHelper.RunGitCapturingResultForTests(
+                repoDir,
+                gitEnvironmentOverrides: null,
+                CancellationToken.None,
+                "status");
+
+            Assert.True(
+                result.FailureKind == GitCommandFailureKind.CaptureLimitExceeded,
+                $"Expected CaptureLimitExceeded, got {result.FailureKind}: {result.Diagnostic ?? result.Error}");
+            Assert.Equal(-1, result.ExitCode);
+            Assert.NotNull(result.Diagnostic);
+            Assert.Contains("captured stderr exceeded", result.Diagnostic);
+            Assert.Contains("captured stderr exceeded", result.Error);
+            Assert.True(result.Error!.Length <= GitHelper.MaxGitFailureDiagnosticChars);
+        }
+        finally
+        {
+            GitHelper.GitExecutablePathOverride = oldGitExecutablePath;
+        }
+    }
+
+    [Fact]
     public void GetChangedFilesFromCommit_FailsWhenGitCommandTimesOut()
     {
         if (OperatingSystem.IsWindows())
@@ -1317,6 +1354,18 @@ if [ "$1" = "diff-tree" ]; then
   exit 0
 fi
 exit 1
+""");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+
+    private static void WriteFakeGitThatExceedsStderrLimit(string directory)
+    {
+        var script = Path.Combine(directory, "git");
+        File.WriteAllText(script, """
+#!/bin/sh
+perl -e 'print STDERR "e" x 1048577'
+exit 0
 """);
         if (!OperatingSystem.IsWindows())
             File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -708,6 +708,43 @@ public class GitHelperTests : IDisposable
     }
 
     [Fact]
+    public void RunGitCapturingResult_CancelDuringOutputCapture_ThrowsOperationCanceled_Issue3761()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var repoDir = Path.Combine(_tempDir, "repo-output-cancel");
+        Directory.CreateDirectory(repoDir);
+        var fakeGitDir = Path.Combine(_tempDir, "fake-git-output-cancel");
+        Directory.CreateDirectory(fakeGitDir);
+        WriteFakeGitThatStreamsStdoutUntilKilled(fakeGitDir);
+
+        var oldGitExecutablePath = GitHelper.GitExecutablePathOverride;
+        GitHelper.GitExecutablePathOverride = Path.Combine(fakeGitDir, "git");
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+            var stopwatch = Stopwatch.StartNew();
+
+            Assert.Throws<OperationCanceledException>(() =>
+                GitHelper.RunGitCapturingResultForTests(
+                    repoDir,
+                    gitEnvironmentOverrides: null,
+                    cts.Token,
+                    "status"));
+
+            stopwatch.Stop();
+            Assert.True(
+                stopwatch.Elapsed < GitCancellationWallClockLimit,
+                $"Cancellation during output capture took {stopwatch.Elapsed}, expected less than {GitCancellationWallClockLimit}.");
+        }
+        finally
+        {
+            GitHelper.GitExecutablePathOverride = oldGitExecutablePath;
+        }
+    }
+
+    [Fact]
     public void TrustedGitExecutableCandidates_OnMacOS_ExcludeDeveloperToolsShim_Issue3433()
     {
         if (!OperatingSystem.IsMacOS())
@@ -1438,6 +1475,17 @@ if [ "$1" = "rev-parse" ]; then
   exit 0
 fi
 exit 1
+""");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+
+    private static void WriteFakeGitThatStreamsStdoutUntilKilled(string directory)
+    {
+        var script = Path.Combine(directory, "git");
+        File.WriteAllText(script, """
+#!/bin/sh
+perl -e '$|=1; while (1) { print "x" x 4096; select undef, undef, undef, 0.01 }'
 """);
         if (!OperatingSystem.IsWindows())
             File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);

--- a/tests/CodeIndex.Tests/GitHubHttpCancellationTests.cs
+++ b/tests/CodeIndex.Tests/GitHubHttpCancellationTests.cs
@@ -1,0 +1,101 @@
+using System.Net;
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+[Collection("SQLite pool sensitive")]
+public sealed class GitHubHttpCancellationTests : IDisposable
+{
+    private readonly EnvironmentVariableScope env = EnvironmentVariableScope.Capture(
+        "CDIDX_GITHUB_TOKEN",
+        "CDIDX_GITHUB_SUBMIT_TIMEOUT_SECONDS",
+        GitHubHttpClientFactory.ProxyDefaultCredentialsEnvironmentVariable);
+
+    public GitHubHttpCancellationTests()
+    {
+        env.Set("CDIDX_GITHUB_TOKEN", null);
+        env.Set("CDIDX_GITHUB_SUBMIT_TIMEOUT_SECONDS", null);
+        env.Set(GitHubHttpClientFactory.ProxyDefaultCredentialsEnvironmentVariable, null);
+    }
+
+    [Fact]
+    public async Task UpdateChecker_FetchLatestReleaseTagAsync_RequestTimeoutCancelsPendingSend_Issue3684()
+    {
+        var handler = new BlockingHttpMessageHandler();
+        using var client = new HttpClient(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+
+        var fetchTask = UpdateChecker.FetchLatestReleaseTagAsync(
+            client,
+            TimeSpan.FromMilliseconds(50),
+            CancellationToken.None);
+
+        await handler.SendStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await fetchTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        await handler.CancellationObserved.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task IssueDuplicatePreflight_TryLoadAsync_CallerCancellationCancelsPendingSend_Issue3684()
+    {
+        var handler = new BlockingHttpMessageHandler();
+        using var client = new HttpClient(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        IssueDuplicatePreflight.s_httpClientOverride = client;
+        using var cts = new CancellationTokenSource();
+
+        var loadTask = IssueDuplicatePreflight.TryLoadAsync("github", "Widthdom/CodeIndex", cts.Token);
+
+        await handler.SendStarted.WaitAsync(TimeSpan.FromSeconds(5));
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await loadTask.WaitAsync(TimeSpan.FromSeconds(5)));
+        await handler.CancellationObserved.WaitAsync(TimeSpan.FromSeconds(5));
+    }
+
+    public void Dispose()
+    {
+        IssueDuplicatePreflight.s_httpClientOverride = null;
+        env.Dispose();
+    }
+
+    private sealed class BlockingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly TaskCompletionSource<HttpResponseMessage> responseSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object?> sendStartedSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TaskCompletionSource<object?> cancellationObservedSource =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal Task SendStarted => sendStartedSource.Task;
+
+        internal Task CancellationObserved => cancellationObservedSource.Task;
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            sendStartedSource.TrySetResult(null);
+            using var registration = cancellationToken.Register(
+                static state => ((TaskCompletionSource<object?>)state!).TrySetResult(null),
+                cancellationObservedSource);
+            try
+            {
+                return await responseSource.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                cancellationObservedSource.TrySetResult(null);
+                throw;
+            }
+        }
+    }
+}

--- a/tests/CodeIndex.Tests/LspServerTests.cs
+++ b/tests/CodeIndex.Tests/LspServerTests.cs
@@ -132,6 +132,44 @@ public class LspServerTests
     }
 
     [Fact]
+    public async Task TryReadMessageAsync_CancellationDuringPendingRead_ThrowsOperationCanceled_Issue3769()
+    {
+        using var stream = new PendingReadStream();
+        using var cts = new CancellationTokenSource();
+
+        var readTask = LspServer.TryReadMessageAsync(stream, cts.Token).AsTask();
+        await stream.WaitForReadAsync().WaitAsync(TimeSpan.FromSeconds(5));
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await readTask);
+    }
+
+    [Fact]
+    public async Task RunAsync_CancellationDuringPendingRead_ThrowsOperationCanceled_Issue3769()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_lsp_pending_cancel");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            using var db = new DbContext(dbPath);
+            using var server = new LspServer(new DbReader(db), "1.2.3", ProgramRunner.CreateDefaultJsonOptions(), projectRoot);
+            using var input = new PendingReadStream();
+            using var output = new MemoryStream();
+            using var cts = new CancellationTokenSource();
+
+            var runTask = server.RunAsync(input, output, cts.Token);
+            await input.WaitForReadAsync().WaitAsync(TimeSpan.FromSeconds(5));
+            cts.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await runTask);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void HandleMessage_Initialize_AdvertisesCoreCapabilities()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_lsp_initialize");
@@ -2179,5 +2217,50 @@ public class LspServerTests
         using var db = new DbContext(dbPath);
         var writer = new DbWriter(db.Connection);
         writer.MarkGraphReady();
+    }
+
+    private sealed class PendingReadStream : Stream
+    {
+        private readonly TaskCompletionSource readStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        internal Task WaitForReadAsync() => readStarted.Task;
+
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            readStarted.TrySetResult();
+            return new ValueTask<int>(WaitForCancellationAsync(cancellationToken));
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        private static async Task<int> WaitForCancellationAsync(CancellationToken cancellationToken)
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            return 0;
+        }
     }
 }

--- a/tests/CodeIndex.Tests/PostExtractionHookTests.cs
+++ b/tests/CodeIndex.Tests/PostExtractionHookTests.cs
@@ -11,6 +11,8 @@ public class PostExtractionHookTests
 {
     internal const string SlowHookDelayEnvironmentVariable = "CDIDX_TEST_SLOW_POST_EXTRACTION_HOOK_MS";
     internal const string SlowHookCompletionPathEnvironmentVariable = "CDIDX_TEST_SLOW_POST_EXTRACTION_HOOK_DONE_PATH";
+    internal const string CancellableHookDelayEnvironmentVariable = "CDIDX_TEST_CANCELLABLE_POST_EXTRACTION_HOOK_MS";
+    internal const string CancellableHookCompletionPathEnvironmentVariable = "CDIDX_TEST_CANCELLABLE_POST_EXTRACTION_HOOK_DONE_PATH";
     internal const string SlowConstructorHookDelayEnvironmentVariable = "CDIDX_TEST_SLOW_CTOR_POST_EXTRACTION_HOOK_MS";
     internal const string StatefulHookEnvironmentVariable = "CDIDX_TEST_STATEFUL_POST_EXTRACTION_HOOK";
     internal const string ThrowingConstructorHookEnvironmentVariable = "CDIDX_TEST_THROWING_CTOR_POST_EXTRACTION_HOOK";
@@ -316,6 +318,47 @@ public class PostExtractionHookTests
     }
 
     [Fact]
+    public void OnSymbolsExtracted_CancellationWhileWaitingForCallback_KillsWorker_Issue3773()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("post-extraction-hook-cancel");
+        lock (TestConsoleLock.Gate)
+        {
+            using var env = EnvironmentVariableScope.Capture(
+                CancellableHookDelayEnvironmentVariable,
+                CancellableHookCompletionPathEnvironmentVariable);
+            var originalBudget = PostExtractionHookRunner.CallbackBudgetForTesting;
+            try
+            {
+                env.Set(CancellableHookDelayEnvironmentVariable, "500");
+                PostExtractionHookRunner.CallbackBudgetForTesting = () => TimeSpan.FromSeconds(5);
+                var hooksDir = Path.Combine(projectRoot, "hooks");
+                var completionPath = Path.Combine(projectRoot, "cancellable-hook.done");
+                env.Set(CancellableHookCompletionPathEnvironmentVariable, completionPath);
+                Directory.CreateDirectory(hooksDir);
+                File.Copy(Assembly.GetExecutingAssembly().Location, Path.Combine(hooksDir, "CodeIndex.Tests.dll"));
+
+                using (var runner = PostExtractionHookRunner.Discover(hooksDir))
+                using (var cancellation = new CancellationTokenSource())
+                {
+                    var context = new FileContext(projectRoot, "src/App.cs", Path.Combine(projectRoot, "src", "App.cs"), "csharp");
+                    var symbols = new List<SymbolRecord>();
+                    cancellation.CancelAfter(50);
+
+                    Assert.ThrowsAny<OperationCanceledException>(() =>
+                        runner.OnSymbolsExtracted(context, symbols, cancellation.Token));
+                    AssertFileDoesNotAppear(completionPath, TimeSpan.FromMilliseconds(1000));
+                }
+                CollectUnloadedHookAssemblies();
+            }
+            finally
+            {
+                PostExtractionHookRunner.CallbackBudgetForTesting = originalBudget;
+                TestProjectHelper.DeleteDirectory(projectRoot);
+            }
+        }
+    }
+
+    [Fact]
     public void CallbackBudget_NormalizesInvalidAndTooLargeValues()
     {
         lock (TestConsoleLock.Gate)
@@ -513,6 +556,31 @@ public class PostExtractionHookTests
 
             Thread.Sleep(25);
         }
+    }
+}
+
+public sealed class AWaitingPostExtractionHook : IPostExtractionHook
+{
+    public void OnSymbolsExtracted(FileContext context, IList<SymbolRecord> symbols)
+    {
+        DelayAndSignalWhenRequested();
+    }
+
+    public void OnReferencesExtracted(FileContext context, IList<ReferenceRecord> references)
+    {
+        DelayAndSignalWhenRequested();
+    }
+
+    private static void DelayAndSignalWhenRequested()
+    {
+        var raw = Environment.GetEnvironmentVariable(PostExtractionHookTests.CancellableHookDelayEnvironmentVariable);
+        if (!int.TryParse(raw, out var milliseconds) || milliseconds <= 0)
+            return;
+
+        Thread.Sleep(milliseconds);
+        var completionPath = Environment.GetEnvironmentVariable(PostExtractionHookTests.CancellableHookCompletionPathEnvironmentVariable);
+        if (!string.IsNullOrWhiteSpace(completionPath))
+            File.WriteAllText(completionPath, "done");
     }
 }
 

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -1693,7 +1693,9 @@ exit 7
 
                 Assert.Equal(CommandExitCodes.Success, exitCode);
                 Assert.Empty(stdout);
-                Assert.Empty(stderr);
+                Assert.Equal(
+                    $"Verifying install.sh checksum...{Environment.NewLine}Verified install.sh checksum.{Environment.NewLine}",
+                    stderr.ToString());
                 Assert.Equal([true, true], observedCanBeCanceled);
             }
             finally


### PR DESCRIPTION
## Summary
- Made checksum reads, export/import checksum verification, isolated worker waits, LSP stream reads, git capture, and GitHub/update HTTP calls respect cancellation or bounded diagnostics.
- Added focused regression tests and one changelog fragment per issue.
- Merged latest `origin/main` into the PR branch with a merge commit, preserving both upstream hardening and the cancellation fixes.
- No target issue was excluded for prior work-started comments.

## Validation
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net9.0 --no-restore -p:UseSharedCompilation=false -p:BuildInParallel=false /nr:false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net9.0 --filter FullyQualifiedName~ProgramRunnerTests.RunUpgrade_PassesCallerCancellationToReleaseDownloads -p:UseSharedCompilation=false -p:BuildInParallel=false /nr:false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net9.0 --filter "FullyQualifiedName~LspServer|FullyQualifiedName~PostExtractionHook|FullyQualifiedName~GitHelper|FullyQualifiedName~ExportImportCommandRunner|FullyQualifiedName~FileIndexer" -p:UseSharedCompilation=false -p:BuildInParallel=false /nr:false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `codex exec review --ignore-user-config --base origin/main` (no blocking/actionable regressions)

Fixes #3797
Fixes #3784
Fixes #3773
Fixes #3769
Fixes #3761
Fixes #3704
Fixes #3684