### PR TITLE
Fix unused analysis, JSON envelope, config parsing, locks, and recipe coverage

### DIFF
--- a/changelog.d/unreleased/3673.fixed.md
+++ b/changelog.d/unreleased/3673.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3673
+affected:
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSymbolTests.cs
+---
+
+## English
+
+- **`cdidx unused` now respects C# partial-class member use (#3673)** — private members used from sibling `partial` class files are no longer reported as unused when graph references miss the edge, and unused C# constants/fields now report accurate symbol kinds.
+
+## 日本語
+
+- **`cdidx unused` が C# partial class の member 使用を考慮するようになりました (#3673)** — graph reference が edge を取りこぼした場合でも、sibling `partial` class file から使われている private member を未使用として報告しないようにし、未使用 C# constant / field の symbol kind も正確に表示するようになりました。

--- a/changelog.d/unreleased/3687.fixed.md
+++ b/changelog.d/unreleased/3687.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 3687
+affected:
+  - src/CodeIndex/Cli/ExclusiveFileLock.cs
+  - src/CodeIndex/Cli/IndexLock.cs
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - src/CodeIndex/Mcp/McpIndexRunLock.cs
+  - tests/CodeIndex.Tests/ExclusiveFileLockTests.cs
+---
+
+## English
+
+- **File lock handling now shares private lock and holder-info helpers (#3687)** — CLI, MCP, and suggestion-store lock paths now use the same exclusive-open helper, private file-mode application, holder-info reads/writes, and cleanup diagnostics.
+
+## 日本語
+
+- **file lock 処理で private lock / holder-info helper を共有しました (#3687)** — CLI、MCP、suggestion store の lock 経路が、exclusive open、private file mode 適用、holder-info の読み書き、cleanup 診断を同じ helper で扱うようになりました。

--- a/changelog.d/unreleased/3692.internal.md
+++ b/changelog.d/unreleased/3692.internal.md
@@ -1,0 +1,15 @@
+---
+category: internal
+issues:
+  - 3692
+affected:
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+---
+
+## English
+
+- **Search audit recipe coverage now snapshots built-in recipe contracts (#3692)** — tests now pin built-in recipe names, scopes, exclusions, query names, labels, false-positive guidance, and unknown-recipe diagnostics.
+
+## 日本語
+
+- **search audit recipe の組み込み契約をテストで固定しました (#3692)** — 組み込み recipe 名、scope、除外設定、query 名、label、false-positive guidance、unknown recipe 診断をテストで固定するようになりました。

--- a/changelog.d/unreleased/3697.fixed.md
+++ b/changelog.d/unreleased/3697.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3697
+affected:
+  - src/CodeIndex/Cli/CdidxConfigFile.cs
+  - tests/CodeIndex.Tests/CdidxConfigFileTests.cs
+---
+
+## English
+
+- **Config integer parsing no longer depends on exception paths (#3697)** — malformed or out-of-range numeric config values for suggestion limits and watch pending path limits now stay on explicit `TryParse` diagnostics.
+
+## 日本語
+
+- **config の整数解析が例外経路に依存しなくなりました (#3697)** — suggestion の上限値や watch pending path limit に不正または範囲外の数値が指定された場合も、明示的な `TryParse` 診断で扱うようになりました。

--- a/changelog.d/unreleased/3779.fixed.md
+++ b/changelog.d/unreleased/3779.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3779
+affected:
+  - src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
+  - tests/CodeIndex.Tests/JsonEnvelopeWrapperTests.cs
+---
+
+## English
+
+- **`--json-envelope` now bounds raw JSON aggregation (#3779)** — raw NDJSON wrapping now rejects excessive item counts and total JSON node counts with structured envelope errors instead of materializing unbounded arrays.
+
+## 日本語
+
+- **`--json-envelope` の raw JSON 集約に上限を設けました (#3779)** — raw NDJSON のラップ時に item 数と JSON node 総数が過剰な場合は、無制限に配列を materialize せず、構造化された envelope error を返します。

--- a/src/CodeIndex/Cli/CdidxConfigFile.cs
+++ b/src/CodeIndex/Cli/CdidxConfigFile.cs
@@ -232,7 +232,12 @@ internal static class CdidxConfigFile
                 errors.Add(err!);
             else
             {
-                var parsedMaxAgeDays = int.Parse(value!, CultureInfo.InvariantCulture);
+                if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedMaxAgeDays))
+                {
+                    errors.Add($"[cdidx] {path}: `suggestion_max_age_days` must be a positive integer.");
+                    return;
+                }
+
                 if (parsedMaxAgeDays > SuggestionStore.MaximumMaxAgeDays)
                     errors.Add($"[cdidx] {path}: `suggestion_max_age_days` must be <= {SuggestionStore.MaximumMaxAgeDays}.");
                 else
@@ -246,7 +251,12 @@ internal static class CdidxConfigFile
                 errors.Add(err!);
             else
             {
-                var parsedMaxCount = int.Parse(value!, CultureInfo.InvariantCulture);
+                if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedMaxCount))
+                {
+                    errors.Add($"[cdidx] {path}: `suggestion_max_count` must be a positive integer.");
+                    return;
+                }
+
                 if (parsedMaxCount > SuggestionStore.MaximumMaxCount)
                     errors.Add($"[cdidx] {path}: `suggestion_max_count` must be <= {SuggestionStore.MaximumMaxCount}.");
                 else
@@ -298,7 +308,12 @@ internal static class CdidxConfigFile
                 errors.Add(err!);
             else
             {
-                var parsedLimit = int.Parse(value!, CultureInfo.InvariantCulture);
+                if (!int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsedLimit))
+                {
+                    errors.Add($"[cdidx] {path}: `indexing.watchPendingPathLimit` must be a positive integer.");
+                    return;
+                }
+
                 if (parsedLimit > IndexWatchRunner.MaxWatchPendingPathLimit)
                     errors.Add($"[cdidx] {path}: `indexing.watchPendingPathLimit` must be <= {IndexWatchRunner.MaxWatchPendingPathLimit}.");
                 else

--- a/src/CodeIndex/Cli/ExclusiveFileLock.cs
+++ b/src/CodeIndex/Cli/ExclusiveFileLock.cs
@@ -1,0 +1,59 @@
+using System.Text;
+using CodeIndex.Indexer;
+
+namespace CodeIndex.Cli;
+
+internal static class ExclusiveFileLock
+{
+    internal static FileStream Open(string lockPath)
+    {
+        var stream = new FileStream(
+            LongPath.EnsureWindowsPrefix(lockPath),
+            FileMode.OpenOrCreate,
+            FileAccess.ReadWrite,
+            FileShare.None);
+        try
+        {
+            DataDirectorySecurity.ApplyPrivateFileMode(lockPath);
+            return stream;
+        }
+        catch
+        {
+            stream.Dispose();
+            throw;
+        }
+    }
+
+    internal static void WriteHolderInfo(string infoPath, string contents, Encoding? encoding = null)
+        => DataDirectorySecurity.WritePrivateText(infoPath, contents, encoding);
+
+    internal static bool TryReadHolderInfoText(string infoPath, int maxInfoBytes, out string? text)
+    {
+        text = null;
+        var ioInfoPath = LongPath.EnsureWindowsPrefix(infoPath);
+        if (!File.Exists(ioInfoPath))
+            return false;
+
+        text = DataDirectorySecurity.ReadTextWithinLimit(ioInfoPath, maxInfoBytes, FileShare.ReadWrite);
+        return !string.IsNullOrWhiteSpace(text);
+    }
+
+    internal static void TryDeleteCleanupTarget(
+        string path,
+        string component,
+        string target,
+        Action<string> deleteFile,
+        Action<LockCleanupDiagnostic>? cleanupDiagnosticSink)
+    {
+        try
+        {
+            deleteFile(path);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            var diagnostic = LockCleanupDiagnostic.Create(component, target, ex);
+            GlobalToolLog.Error(diagnostic.ToLogMessage());
+            cleanupDiagnosticSink?.Invoke(diagnostic);
+        }
+    }
+}

--- a/src/CodeIndex/Cli/IndexLock.cs
+++ b/src/CodeIndex/Cli/IndexLock.cs
@@ -81,11 +81,7 @@ internal sealed class IndexLock : IDisposable
             // FileShare.None は全プラットフォームでプロセス間の排他を提供する
             // （SuggestionStore と同じ手法）。競合相手向け診断メタデータは隣接
             // .info ファイルに分離されるため、この共有モードを緩める必要はない。
-            stream = new FileStream(
-                lockPath,
-                FileMode.OpenOrCreate,
-                FileAccess.ReadWrite,
-                FileShare.None);
+            stream = ExclusiveFileLock.Open(lockPath);
         }
         catch (IOException ex)
         {
@@ -106,7 +102,7 @@ internal sealed class IndexLock : IDisposable
             var info = new IndexLockInfo(
                 Pid: Environment.ProcessId,
                 StartedAt: GetUtcNow());
-            DataDirectorySecurity.WritePrivateText(infoPath, SerializeInfo(info), Encoding.UTF8);
+            ExclusiveFileLock.WriteHolderInfo(infoPath, SerializeInfo(info), Encoding.UTF8);
         }
         catch (Exception)
         {
@@ -127,18 +123,9 @@ internal sealed class IndexLock : IDisposable
         var infoPath = GetInfoPath(lockPath);
         try
         {
-            var ioInfoPath = LongPath.EnsureWindowsPrefix(infoPath);
-            if (!File.Exists(ioInfoPath))
+            if (!ExclusiveFileLock.TryReadHolderInfoText(infoPath, MaxInfoBytes, out var text))
                 return null;
-            // FileShare.ReadWrite mirrors what a concurrent holder might be doing
-            // (the holder may overwrite the .info on stale recovery), so a
-            // diagnostic read is never rejected for share-mode mismatch.
-            // 保持者が .info を上書きしている可能性があるため FileShare.ReadWrite で
-            // 開き、共有モード不一致で読みを失敗させない。
-            var text = DataDirectorySecurity.ReadTextWithinLimit(ioInfoPath, MaxInfoBytes, FileShare.ReadWrite);
-            if (string.IsNullOrWhiteSpace(text))
-                return null;
-            return ParseInfo(text);
+            return ParseInfo(text!);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
         {
@@ -152,7 +139,7 @@ internal sealed class IndexLock : IDisposable
             return;
         _disposed = true;
 
-        TryDeleteCleanupTarget(_infoPath, "metadata");
+        ExclusiveFileLock.TryDeleteCleanupTarget(_infoPath, "index_lock", "metadata", DeleteFileForTesting, CleanupDiagnosticSinkForTesting);
 
         try
         {
@@ -163,7 +150,7 @@ internal sealed class IndexLock : IDisposable
             // Best-effort. / ベストエフォート。
         }
 
-        TryDeleteCleanupTarget(_lockPath, "lockfile");
+        ExclusiveFileLock.TryDeleteCleanupTarget(_lockPath, "index_lock", "lockfile", DeleteFileForTesting, CleanupDiagnosticSinkForTesting);
     }
 
     // --- Tiny key=value serializer (avoids touching JsonSerializerContext) ---
@@ -236,24 +223,6 @@ internal sealed class IndexLock : IDisposable
         return sb.ToString();
     }
 
-    private static void TryDeleteCleanupTarget(string path, string target)
-    {
-        try
-        {
-            DeleteFileForTesting(path);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
-        {
-            ReportCleanupFailure(target, ex);
-        }
-    }
-
-    private static void ReportCleanupFailure(string target, Exception exception)
-    {
-        var diagnostic = LockCleanupDiagnostic.Create("index_lock", target, exception);
-        GlobalToolLog.Error(diagnostic.ToLogMessage());
-        CleanupDiagnosticSinkForTesting?.Invoke(diagnostic);
-    }
 }
 
 internal sealed record IndexLockInfo(

--- a/src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
+++ b/src/CodeIndex/Cli/JsonEnvelopeWrapper.cs
@@ -20,6 +20,8 @@ internal static class JsonEnvelopeWrapper
     internal const string EnvelopeFlag = "--json-envelope";
     internal const int MaxCapturedOutputChars = 10 * 1024 * 1024;
     internal const int MaxRawJsonItemChars = 1024 * 1024;
+    internal const int MaxRawJsonItems = 10_000;
+    internal const int MaxRawJsonNodes = 16_384;
     internal const int MaxRawJsonItemDepth = 32;
 
     private static readonly HashSet<string> WrappableCommands = new(StringComparer.Ordinal)
@@ -152,6 +154,22 @@ internal static class JsonEnvelopeWrapper
             };
             results = [];
         }
+        catch (JsonEnvelopeRawJsonBudgetExceededException ex)
+        {
+            exitCode = CommandExitCodes.InvalidArgument;
+            var message = $"--json-envelope raw JSON {ex.BudgetName} exceeded {ex.MaxValue}.";
+            var hint = "Run the command with --json for streaming NDJSON output or reduce the result set with --limit/--top.";
+            CommandErrorWriter.WriteStderr($"Error [{CommandErrorCodes.UsageError}]: {message}");
+            CommandErrorWriter.WriteStderr($"Hint: {hint}");
+            parseError = new JsonObject
+            {
+                ["message"] = message,
+                ["hint"] = hint,
+                ["error_code"] = CommandErrorCodes.UsageError,
+                [ex.JsonPropertyName] = ex.MaxValue,
+            };
+            results = [];
+        }
         var envelope = BuildEnvelope(
             command,
             queryNormalized,
@@ -223,6 +241,7 @@ internal static class JsonEnvelopeWrapper
     private static JsonArray ParseRawJsonItems(string raw)
     {
         var array = new JsonArray();
+        var rawJsonNodeCount = 0;
         if (string.IsNullOrEmpty(raw))
             return array;
 
@@ -240,6 +259,8 @@ internal static class JsonEnvelopeWrapper
             }
             catch (JsonException)
             {
+                EnsureRawJsonItemBudget(array.Count);
+                rawJsonNodeCount = AddRawJsonNodeCount(rawJsonNodeCount, 1);
                 array.Add(line);
                 continue;
             }
@@ -249,10 +270,61 @@ internal static class JsonEnvelopeWrapper
             if (IsJsonStreamDoneSentinel(node))
                 continue;
 
+            EnsureRawJsonItemBudget(array.Count);
+            rawJsonNodeCount = AddRawJsonNodeCount(rawJsonNodeCount, CountJsonNodes(node));
             array.Add(node);
         }
 
         return array;
+    }
+
+    private static void EnsureRawJsonItemBudget(int currentItemCount)
+    {
+        if (currentItemCount >= MaxRawJsonItems)
+        {
+            throw new JsonEnvelopeRawJsonBudgetExceededException(
+                "item count",
+                "max_items",
+                MaxRawJsonItems);
+        }
+    }
+
+    private static int AddRawJsonNodeCount(int currentNodeCount, int nodesToAdd)
+    {
+        if (nodesToAdd < 0 || currentNodeCount > MaxRawJsonNodes - nodesToAdd)
+        {
+            throw new JsonEnvelopeRawJsonBudgetExceededException(
+                "node count",
+                "max_nodes",
+                MaxRawJsonNodes);
+        }
+
+        return currentNodeCount + nodesToAdd;
+    }
+
+    private static int CountJsonNodes(JsonNode node)
+    {
+        var count = 0;
+        Count(node);
+        return count;
+
+        void Count(JsonNode? current)
+        {
+            if (current is null)
+                return;
+            count = AddRawJsonNodeCount(count, 1);
+            switch (current)
+            {
+                case JsonArray array:
+                    foreach (var child in array)
+                        Count(child);
+                    break;
+                case JsonObject obj:
+                    foreach (var property in obj)
+                        Count(property.Value);
+                    break;
+            }
+        }
     }
 
     private static IEnumerable<string> EnumerateRawLines(string raw)
@@ -388,5 +460,15 @@ internal static class JsonEnvelopeWrapper
     private sealed class JsonEnvelopeRawJsonItemLimitExceededException(int maxChars) : Exception
     {
         public int MaxChars { get; } = maxChars;
+    }
+
+    private sealed class JsonEnvelopeRawJsonBudgetExceededException(
+        string budgetName,
+        string jsonPropertyName,
+        int maxValue) : Exception
+    {
+        public string BudgetName { get; } = budgetName;
+        public string JsonPropertyName { get; } = jsonPropertyName;
+        public int MaxValue { get; } = maxValue;
     }
 }

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -1177,11 +1177,7 @@ public class SuggestionStore
         // The lock is held for the lifetime of the FileStream (released on Dispose).
         // FileShare.None は全プラットフォームでプロセス間の排他アクセスを提供する。
         // ロックは FileStream の寿命の間保持される（Dispose で解放）。
-        using var lockFile = new FileStream(
-            _lockPath,
-            FileMode.OpenOrCreate,
-            FileAccess.ReadWrite,
-            FileShare.None);
+        using var lockFile = ExclusiveFileLock.Open(_lockPath);
 
         return action();
     }

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -114,6 +114,15 @@ public partial class DbReader
     private const string SymbolLanguageFileIdFilter = " AND s.file_id IN (SELECT id FROM files WHERE lang = @lang)";
     private const int QueryOutputSignatureMaxChars = 512;
     private const string QueryOutputSignatureTruncationSuffix = "...";
+    private static readonly Regex CSharpConstFieldSignatureRegex = new(
+        @"^(?:(?:public|private|protected\s+internal|private\s+protected|protected|internal|static|new|unsafe|readonly|volatile|required)\s+)*const\s+",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CSharpFieldLikeSignatureRegex = new(
+        @"^(?:(?:public|private|protected\s+internal|private\s+protected|protected|internal|static|readonly|volatile|new|unsafe|required)\s+)*(?!event\b|delegate\b|const\b).+\s+@?[\p{L}_][\p{L}\p{Nd}_]*\s*(?:=(?![=>])|;)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    private static readonly Regex CSharpPropertyAccessorSignatureRegex = new(
+        @"\{\s*(?:get|set|init)\b|=>",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private sealed class UnusedCandidateSymbol
     {
@@ -130,6 +139,7 @@ public partial class DbReader
         public string? ReturnType { get; init; }
         public string? ContainerKind { get; init; }
         public string? ContainerName { get; init; }
+        public string? ContainerQualifiedName { get; init; }
         public bool IsPublicOrExported { get; init; }
         public bool IsReflectionOrConfigSuspect { get; init; }
         public int ProvisionalBucketOrder { get; init; }
@@ -235,6 +245,65 @@ public partial class DbReader
                             OR same_file_chunk.start_line > {endLineSql}
                             OR csharp_identifier_occurrence_count(same_file_chunk.content, {symbolAlias}.name) > 1
                         )
+                  )
+              )";
+    }
+
+    private string BuildCSharpPartialContainingTypeUseExclusionSql(string symbolAlias, string fileAlias, string visibilitySql)
+    {
+        var containerKindSql = GetSymbolColumnSql("container_kind", "''", symbolAlias);
+        var containerNameSql = GetSymbolColumnSql("container_name", "''", symbolAlias);
+        var containerQualifiedNameSql = GetSymbolColumnSql("container_qualified_name", containerNameSql, symbolAlias);
+        var ownContainerNameSql = GetSymbolColumnSql("container_name", "''", "partial_own_type");
+        var ownSignatureSql = GetSymbolColumnSql("signature", "''", "partial_own_type");
+        var peerContainerNameSql = GetSymbolColumnSql("container_name", "''", "partial_peer_type");
+        var peerSignatureSql = GetSymbolColumnSql("signature", "''", "partial_peer_type");
+        var ownQualifiedNameSql = $@"CASE
+                            WHEN {ownContainerNameSql} <> '' THEN {ownContainerNameSql} || '.' || partial_own_type.name
+                            ELSE partial_own_type.name
+                        END";
+        var peerQualifiedNameSql = $@"CASE
+                            WHEN {peerContainerNameSql} <> '' THEN {peerContainerNameSql} || '.' || partial_peer_type.name
+                            ELSE partial_peer_type.name
+                        END";
+
+        return $@"
+              AND NOT (
+                  {fileAlias}.lang = 'csharp'
+                  AND {visibilitySql} IN ('private', 'fileprivate')
+                  AND {symbolAlias}.name <> ''
+                  AND {containerKindSql} IN ('class', 'struct', 'interface')
+                  AND {containerNameSql} <> ''
+                  AND EXISTS (
+                      SELECT 1
+                      FROM symbols partial_own_type
+                      WHERE partial_own_type.file_id = {symbolAlias}.file_id
+                        AND partial_own_type.kind = {containerKindSql}
+                        AND partial_own_type.name = {containerNameSql}
+                        AND lower({ownSignatureSql}) LIKE '%partial%'
+                        AND (
+                            {containerQualifiedNameSql} = ''
+                            OR {containerQualifiedNameSql} = partial_own_type.name
+                            OR {containerQualifiedNameSql} = {ownQualifiedNameSql}
+                        )
+                  )
+                  AND EXISTS (
+                      SELECT 1
+                      FROM symbols partial_peer_type
+                      JOIN files partial_peer_file ON partial_peer_file.id = partial_peer_type.file_id
+                      JOIN chunks partial_peer_chunk ON partial_peer_chunk.file_id = partial_peer_type.file_id
+                      WHERE partial_peer_file.lang = 'csharp'
+                        AND partial_peer_type.file_id <> {symbolAlias}.file_id
+                        AND partial_peer_type.kind = {containerKindSql}
+                        AND partial_peer_type.name = {containerNameSql}
+                        AND lower({peerSignatureSql}) LIKE '%partial%'
+                        AND (
+                            {containerQualifiedNameSql} = ''
+                            OR {containerQualifiedNameSql} = partial_peer_type.name
+                            OR {containerQualifiedNameSql} = {peerQualifiedNameSql}
+                        )
+                        AND csharp_identifier_occurrence_count(partial_peer_chunk.content, {symbolAlias}.name) > 0
+                      LIMIT 1
                   )
               )";
     }
@@ -3286,7 +3355,7 @@ public partial class DbReader
                 offset += batch.Count;
                 foreach (var candidate in batch)
                 {
-                    if (HasSameFilePrivateUse(candidate, fileContentByFileId))
+                    if (HasPrivateCSharpUse(candidate, fileContentByFileId))
                         continue;
 
                     var result = CreateUnusedSymbolResult(candidate);
@@ -3321,7 +3390,7 @@ public partial class DbReader
             offset += batch.Count;
             foreach (var candidate in batch)
             {
-                if (HasSameFilePrivateUse(candidate, fileContentByFileId))
+                if (HasPrivateCSharpUse(candidate, fileContentByFileId))
                     continue;
 
                 results.Add(CreateUnusedSymbolResult(candidate));
@@ -3355,7 +3424,7 @@ public partial class DbReader
             offset += batch.Count;
             foreach (var candidate in batch)
             {
-                if (HasSameFilePrivateUse(candidate, fileContentByFileId))
+                if (HasPrivateCSharpUse(candidate, fileContentByFileId))
                     continue;
 
                 candidatesFetched++;
@@ -3380,6 +3449,10 @@ public partial class DbReader
         }
     }
 
+    private bool HasPrivateCSharpUse(UnusedCandidateSymbol candidate, Dictionary<long, string> fileContentByFileId)
+        => HasSameFilePrivateUse(candidate, fileContentByFileId)
+           || HasCSharpPartialContainingTypeUse(candidate);
+
     private bool HasSameFilePrivateUse(UnusedCandidateSymbol candidate, Dictionary<long, string> fileContentByFileId)
     {
         if (!string.Equals(candidate.Lang, "csharp", StringComparison.Ordinal)
@@ -3396,6 +3469,73 @@ public partial class DbReader
             candidate.StartLine,
             candidate.EndLine);
     }
+
+    private bool HasCSharpPartialContainingTypeUse(UnusedCandidateSymbol candidate)
+    {
+        if (!string.Equals(candidate.Lang, "csharp", StringComparison.Ordinal)
+            || !IsPrivateLikeVisibility(candidate.Visibility)
+            || candidate.Name.Length == 0
+            || !IsCSharpPartialContainerKind(candidate.ContainerKind)
+            || string.IsNullOrWhiteSpace(candidate.ContainerName)
+            || !_hasChunksTable
+            || !HasTable("chunks"))
+        {
+            return false;
+        }
+
+        var ownContainerNameSql = GetSymbolColumnSql("container_name", "''", "own_type");
+        var ownSignatureSql = GetSymbolColumnSql("signature", "''", "own_type");
+        var peerContainerNameSql = GetSymbolColumnSql("container_name", "''", "peer_type");
+        var peerSignatureSql = GetSymbolColumnSql("signature", "''", "peer_type");
+        var ownQualifiedNameSql = $@"CASE
+                WHEN {ownContainerNameSql} <> '' THEN {ownContainerNameSql} || '.' || own_type.name
+                ELSE own_type.name
+            END";
+        var peerQualifiedNameSql = $@"CASE
+                WHEN {peerContainerNameSql} <> '' THEN {peerContainerNameSql} || '.' || peer_type.name
+                ELSE peer_type.name
+            END";
+
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = $@"
+            SELECT 1
+            FROM symbols own_type
+            JOIN symbols peer_type
+              ON peer_type.file_id <> own_type.file_id
+             AND peer_type.kind = own_type.kind
+             AND peer_type.name = own_type.name
+            JOIN files peer_file ON peer_file.id = peer_type.file_id
+            JOIN chunks peer_chunk ON peer_chunk.file_id = peer_type.file_id
+            WHERE own_type.file_id = @fileId
+              AND own_type.kind = @containerKind
+              AND own_type.name = @containerName
+              AND lower({ownSignatureSql}) LIKE '%partial%'
+              AND lower({peerSignatureSql}) LIKE '%partial%'
+              AND peer_file.lang = 'csharp'
+              AND (
+                  @containerQualifiedName = ''
+                  OR @containerQualifiedName = own_type.name
+                  OR @containerQualifiedName = {ownQualifiedNameSql}
+              )
+              AND (
+                  @containerQualifiedName = ''
+                  OR @containerQualifiedName = peer_type.name
+                  OR @containerQualifiedName = {peerQualifiedNameSql}
+              )
+              AND csharp_identifier_occurrence_count(peer_chunk.content, @symbolName) > 0
+            LIMIT 1";
+        cmd.Parameters.AddWithValue("@fileId", candidate.FileId);
+        cmd.Parameters.AddWithValue("@containerKind", candidate.ContainerKind);
+        cmd.Parameters.AddWithValue("@containerName", candidate.ContainerName);
+        cmd.Parameters.AddWithValue("@containerQualifiedName", candidate.ContainerQualifiedName ?? string.Empty);
+        cmd.Parameters.AddWithValue("@symbolName", candidate.Name);
+
+        using var reader = cmd.ExecuteTrackedReader();
+        return reader.TrackedRead();
+    }
+
+    private static bool IsCSharpPartialContainerKind(string? kind)
+        => kind is "class" or "struct" or "interface";
 
     private string GetUnusedCandidateFileContent(long fileId, Dictionary<long, string> fileContentByFileId)
     {
@@ -3508,6 +3648,7 @@ public partial class DbReader
                    {GetSymbolColumnSql("return_type")} AS return_type,
                    {GetSymbolColumnSql("container_kind")} AS container_kind,
                    {GetSymbolColumnSql("container_name")} AS container_name,
+                   {GetSymbolColumnSql("container_qualified_name", GetSymbolColumnSql("container_name", "''"))} AS container_qualified_name,
                    CASE WHEN {isPublicOrExportedSql} THEN 1 ELSE 0 END AS is_public_or_exported,
                    CASE WHEN {isReflectionOrConfigSuspectSql} THEN 1 ELSE 0 END AS is_reflection_or_config_suspect,
                    {provisionalBucketOrderSql} AS provisional_bucket_order
@@ -3574,25 +3715,27 @@ public partial class DbReader
                 ReturnType = GetNullableString(reader, 10),
                 ContainerKind = GetNullableString(reader, 11),
                 ContainerName = GetNullableString(reader, 12),
-                IsPublicOrExported = reader.GetInt32(13) != 0,
-                IsReflectionOrConfigSuspect = reader.GetInt32(14) != 0,
-                ProvisionalBucketOrder = reader.GetInt32(15),
+                ContainerQualifiedName = GetNullableString(reader, 13),
+                IsPublicOrExported = reader.GetInt32(14) != 0,
+                IsReflectionOrConfigSuspect = reader.GetInt32(15) != 0,
+                ProvisionalBucketOrder = reader.GetInt32(16),
             };
         }
     }
 
     private UnusedSymbolResult CreateUnusedSymbolResult(UnusedCandidateSymbol candidate)
     {
+        var kind = NormalizeUnusedSymbolKind(candidate);
         var isReflectionOrConfigSuspect = candidate.IsReflectionOrConfigSuspect;
         if (!isReflectionOrConfigSuspect && candidate.IsPublicOrExported)
-            isReflectionOrConfigSuspect = HasReflectionAttributeContext(candidate.Kind, candidate.Path, candidate.StartLine);
+            isReflectionOrConfigSuspect = HasReflectionAttributeContext(kind, candidate.Path, candidate.StartLine);
 
         var classification = ClassifyUnusedSymbol(candidate.IsPublicOrExported, isReflectionOrConfigSuspect, candidate.Visibility);
         return new UnusedSymbolResult
         {
             Path = candidate.Path,
             Lang = candidate.Lang,
-            Kind = candidate.Kind,
+            Kind = kind,
             Name = candidate.Name,
             Line = candidate.Line,
             StartLine = candidate.StartLine,
@@ -3607,6 +3750,31 @@ public partial class DbReader
             UnusedReason = classification.Reason,
             UnusedReasonTags = BuildUnusedReasonTags(candidate.IsPublicOrExported, isReflectionOrConfigSuspect, candidate.Visibility),
         };
+    }
+
+    private static string NormalizeUnusedSymbolKind(UnusedCandidateSymbol candidate)
+        => NormalizeUnusedSymbolKind(candidate.Lang, candidate.Kind, candidate.Signature);
+
+    private static string NormalizeUnusedSymbolKind(string? lang, string kind, string? signature)
+    {
+        if (!string.Equals(lang, "csharp", StringComparison.Ordinal)
+            || string.IsNullOrWhiteSpace(signature))
+        {
+            return kind;
+        }
+
+        var trimmed = signature.TrimStart();
+        if (CSharpConstFieldSignatureRegex.IsMatch(trimmed))
+            return "constant";
+
+        if ((kind is "function" or "property")
+            && !CSharpPropertyAccessorSignatureRegex.IsMatch(trimmed)
+            && CSharpFieldLikeSignatureRegex.IsMatch(trimmed))
+        {
+            return "field";
+        }
+
+        return kind;
     }
 
     private List<UnusedSymbolResult> FetchUnusedCandidates(int fetchLimit, int provisionalBucketOrder, int offset, string? kind, string? lang,
@@ -3687,6 +3855,7 @@ public partial class DbReader
                 visibilitySql,
                 GetSymbolColumnSql("start_line", "s.line"),
                 GetSymbolColumnSql("end_line", "s.line"));
+            sql += BuildCSharpPartialContainingTypeUseExclusionSql("s", "f", visibilitySql);
         }
         sql += $"\n              AND {BuildAmbiguousCSharpEnumMemberExclusionSql("s", "f", pathPatterns, excludePathPatterns, excludeTests)}";
 
@@ -3733,7 +3902,10 @@ public partial class DbReader
         while (reader.TrackedRead())
         {
             var path = reader.GetString(0);
-            var kindValue = reader.GetString(2);
+            var langValue = GetNullableString(reader, 1);
+            var rawKindValue = reader.GetString(2);
+            var signature = GetNullableString(reader, 7);
+            var kindValue = NormalizeUnusedSymbolKind(langValue, rawKindValue, signature);
             var startLine = GetInt32OrFallback(reader, 5, 4);
             var isPublicOrExported = reader.GetInt32(12) != 0;
             var isReflectionOrConfigSuspect = reader.GetInt32(13) != 0;
@@ -3745,13 +3917,13 @@ public partial class DbReader
             results.Add(new UnusedSymbolResult
             {
                 Path = path,
-                Lang = GetNullableString(reader, 1),
+                Lang = langValue,
                 Kind = kindValue,
                 Name = reader.GetString(3),
                 Line = reader.GetInt32(4),
                 StartLine = startLine,
                 EndLine = GetInt32OrFallback(reader, 6, 4),
-                Signature = GetNullableString(reader, 7),
+                Signature = signature,
                 Visibility = visibility,
                 ReturnType = GetNullableString(reader, 9),
                 ContainerKind = GetNullableString(reader, 10),
@@ -3936,6 +4108,10 @@ public partial class DbReader
                 $"lower({GetSymbolColumnSql("visibility", "''")})",
                 GetSymbolColumnSql("start_line", "s.line"),
                 GetSymbolColumnSql("end_line", "s.line"));
+            sql += BuildCSharpPartialContainingTypeUseExclusionSql(
+                "s",
+                "f",
+                $"lower({GetSymbolColumnSql("visibility", "''")})");
         }
         sql += $"\n              AND {BuildAmbiguousCSharpEnumMemberExclusionSql("s", "f", pathPatterns, excludePathPatterns, excludeTests)}";
 
@@ -4036,7 +4212,7 @@ public partial class DbReader
                 offset += batch.Count;
                 foreach (var candidate in batch)
                 {
-                    if (HasSameFilePrivateUse(candidate, fileContentByFileId))
+                    if (HasPrivateCSharpUse(candidate, fileContentByFileId))
                         continue;
 
                     var result = CreateUnusedSymbolResult(candidate);
@@ -4075,7 +4251,7 @@ public partial class DbReader
                 offset += batch.Count;
                 foreach (var candidate in batch)
                 {
-                    if (HasSameFilePrivateUse(candidate, fileContentByFileId))
+                    if (HasPrivateCSharpUse(candidate, fileContentByFileId))
                         continue;
 
                     count++;

--- a/src/CodeIndex/Mcp/McpIndexRunLock.cs
+++ b/src/CodeIndex/Mcp/McpIndexRunLock.cs
@@ -41,7 +41,7 @@ internal sealed class McpIndexRunLock : IDisposable
         var infoPath = lockPath + ".info";
         try
         {
-            var stream = new FileStream(lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+            var stream = ExclusiveFileLock.Open(lockPath);
             var acquired = new McpIndexRunLock(stream, infoPath);
             acquired.WriteHolderInfo();
             runLock = acquired;
@@ -75,7 +75,7 @@ internal sealed class McpIndexRunLock : IDisposable
         var since = DateTimeOffset.UtcNow.ToString("o", System.Globalization.CultureInfo.InvariantCulture);
         try
         {
-            DataDirectorySecurity.WritePrivateText(_infoPath, $$"""{"pid":{{Environment.ProcessId}},"since":"{{since}}"}""");
+            ExclusiveFileLock.WriteHolderInfo(_infoPath, $$"""{"pid":{{Environment.ProcessId}},"since":"{{since}}"}""");
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {
@@ -98,14 +98,10 @@ internal sealed class McpIndexRunLock : IDisposable
     {
         try
         {
-            if (!File.Exists(infoPath))
+            if (!ExclusiveFileLock.TryReadHolderInfoText(infoPath, MaxInfoBytes, out var text))
                 return null;
 
-            var text = DataDirectorySecurity.ReadTextWithinLimit(infoPath, MaxInfoBytes, FileShare.ReadWrite);
-            if (string.IsNullOrWhiteSpace(text))
-                return null;
-
-            using var document = JsonDocument.Parse(text, InfoJsonDocumentOptions);
+            using var document = JsonDocument.Parse(text!, InfoJsonDocumentOptions);
             var root = document.RootElement;
             if (!root.TryGetProperty("pid", out var pidElement) || !pidElement.TryGetInt32(out var pid))
                 return null;
@@ -149,16 +145,7 @@ internal sealed class McpIndexRunLock : IDisposable
             return;
 
         _disposed = true;
-        try
-        {
-            DeleteFileForTesting(_infoPath);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
-        {
-            var diagnostic = LockCleanupDiagnostic.Create("mcp_index_lock", "metadata", ex);
-            GlobalToolLog.Error(diagnostic.ToLogMessage());
-            CleanupDiagnosticSinkForTesting?.Invoke(diagnostic);
-        }
+        ExclusiveFileLock.TryDeleteCleanupTarget(_infoPath, "mcp_index_lock", "metadata", DeleteFileForTesting, CleanupDiagnosticSinkForTesting);
         _stream.Dispose();
     }
 

--- a/tests/CodeIndex.Tests/CdidxConfigFileTests.cs
+++ b/tests/CodeIndex.Tests/CdidxConfigFileTests.cs
@@ -258,6 +258,7 @@ public class CdidxConfigFileTests
     [Theory]
     [InlineData("""{ "indexing": { "watchPendingPathLimit": 0 } }""", "positive integer")]
     [InlineData("""{ "indexing": { "watchPendingPathLimit": 262145 } }""", "<= 262144")]
+    [InlineData("""{ "indexing": { "watchPendingPathLimit": 1.5 } }""", "positive integer")]
     public void LoadAndApply_ProjectConfigJsonRejectsInvalidWatchPendingPathLimit(string json, string expectedError)
     {
         var dir = CreateTempDir();
@@ -270,6 +271,28 @@ public class CdidxConfigFileTests
             var result = CdidxConfigFile.Load(dir, env.Read);
 
             Assert.True(result.Failed);
+            Assert.Contains(expectedError, result.Error);
+            Assert.Empty(result.Settings);
+        }
+        finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    [Theory]
+    [InlineData("""{ "suggestion_max_age_days": 1.5 }""", "suggestion_max_age_days", "positive integer")]
+    [InlineData("""{ "suggestion_max_age_days": 2147483648 }""", "suggestion_max_age_days", "positive integer")]
+    [InlineData("""{ "suggestion_max_count": 1.5 }""", "suggestion_max_count", "positive integer")]
+    public void LoadAndApply_InvalidSuggestionIntegerConfig_ReturnsError_Issue3697(string json, string expectedKey, string expectedError)
+    {
+        var dir = CreateTempDir();
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, ".cdidxrc.json"), json);
+
+            var env = new TestEnvironment();
+            var result = CdidxConfigFile.Load(dir, env.Read);
+
+            Assert.True(result.Failed);
+            Assert.Contains(expectedKey, result.Error);
             Assert.Contains(expectedError, result.Error);
             Assert.Empty(result.Settings);
         }

--- a/tests/CodeIndex.Tests/ExclusiveFileLockTests.cs
+++ b/tests/CodeIndex.Tests/ExclusiveFileLockTests.cs
@@ -1,0 +1,94 @@
+using System.Globalization;
+using CodeIndex.Cli;
+using CodeIndex.Mcp;
+
+namespace CodeIndex.Tests;
+
+public class ExclusiveFileLockTests
+{
+    [Fact]
+    public void Open_AppliesPrivateFileModeOnUnix_Issue3687()
+    {
+        var dir = TestProjectHelper.CreateTempProject("cdidx_exclusive_file_lock");
+        try
+        {
+            var lockPath = Path.Combine(dir, "codeindex.db.lock");
+
+            using var stream = ExclusiveFileLock.Open(lockPath);
+
+            Assert.True(stream.CanRead);
+            AssertPrivateFileMode(lockPath);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(dir);
+        }
+    }
+
+    [Fact]
+    public void IndexLock_AcquireWritesPrivateHolderInfoAndReportsContender_Issue3687()
+    {
+        var dir = TestProjectHelper.CreateTempProject("cdidx_index_lock_contended");
+        try
+        {
+            var dbPath = Path.Combine(dir, "codeindex.db");
+            var lockPath = IndexLock.GetLockPath(dbPath);
+            using var held = IndexLock.Acquire(lockPath, dir);
+
+            var infoPath = IndexLock.GetInfoPath(lockPath);
+            AssertPrivateFileMode(lockPath);
+            AssertPrivateFileMode(infoPath);
+            var holder = IndexLock.TryReadHolderInfo(lockPath);
+            Assert.NotNull(holder);
+            Assert.Equal(Environment.ProcessId, holder!.Pid);
+
+            var ex = Assert.Throws<IndexLockConflictException>(() => IndexLock.Acquire(lockPath, dir));
+            Assert.NotNull(ex.Holder);
+            Assert.Equal(Environment.ProcessId, ex.Holder!.Pid);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(dir);
+        }
+    }
+
+    [Fact]
+    public void McpIndexRunLock_TryAcquireWritesPrivateHolderInfoAndReportsContender_Issue3687()
+    {
+        var dir = TestProjectHelper.CreateTempProject("cdidx_mcp_index_lock_contended");
+        try
+        {
+            var dbPath = Path.Combine(dir, "codeindex.db");
+
+            Assert.True(McpIndexRunLock.TryAcquire(dbPath, out var held, out var error));
+            Assert.NotNull(held);
+            Assert.Null(error);
+            using (held)
+            {
+                var lockPath = McpIndexRunLock.ResolveLockPath(dbPath);
+                var infoPath = lockPath + ".info";
+                AssertPrivateFileMode(lockPath);
+                AssertPrivateFileMode(infoPath);
+
+                Assert.False(McpIndexRunLock.TryAcquire(dbPath, out var contender, out var busy));
+                Assert.Null(contender);
+                Assert.NotNull(busy);
+                Assert.Contains("index already running on this DB", busy);
+                Assert.Contains(Environment.ProcessId.ToString(CultureInfo.InvariantCulture), busy);
+            }
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(dir);
+        }
+    }
+
+    private static void AssertPrivateFileMode(string path)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var mode = File.GetUnixFileMode(path) & DataDirectorySecurity.PermissionBits;
+        Assert.Equal(DataDirectorySecurity.PrivateFileMode, mode);
+    }
+}

--- a/tests/CodeIndex.Tests/JsonEnvelopeWrapperTests.cs
+++ b/tests/CodeIndex.Tests/JsonEnvelopeWrapperTests.cs
@@ -343,6 +343,60 @@ public class JsonEnvelopeWrapperTests
     }
 
     [Fact]
+    public void RunWrapped_ManyRawJsonItems_ReturnsStructuredEnvelopeError_Issue3779()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => JsonEnvelopeWrapper.RunWrapped(
+            "search",
+            ["Needle", "--json-envelope"],
+            "1.0.0",
+            _jsonOptions,
+            _ =>
+            {
+                for (var i = 0; i <= JsonEnvelopeWrapper.MaxRawJsonItems; i++)
+                    Console.WriteLine("0");
+                return CommandExitCodes.Success;
+            }));
+
+        Assert.Equal(CommandExitCodes.InvalidArgument, exitCode);
+        Assert.Contains("--json-envelope raw JSON item count exceeded", stderr);
+        using var document = JsonDocument.Parse(stdout);
+        var metadata = document.RootElement.GetProperty("metadata");
+        Assert.Equal(CommandExitCodes.InvalidArgument, metadata.GetProperty("exit_code").GetInt32());
+        Assert.Equal(0, metadata.GetProperty("result_count").GetInt32());
+        var error = metadata.GetProperty("error");
+        Assert.Equal(CommandErrorCodes.UsageError, error.GetProperty("error_code").GetString());
+        Assert.Equal(JsonEnvelopeWrapper.MaxRawJsonItems, error.GetProperty("max_items").GetInt32());
+        Assert.Equal(0, document.RootElement.GetProperty("results").GetArrayLength());
+    }
+
+    [Fact]
+    public void RunWrapped_NestedRawJsonNodes_ReturnsStructuredEnvelopeError_Issue3779()
+    {
+        var rawLine = BuildWideRawJsonArray(JsonEnvelopeWrapper.MaxRawJsonNodes);
+        var (exitCode, stdout, stderr) = CaptureConsole(() => JsonEnvelopeWrapper.RunWrapped(
+            "search",
+            ["Needle", "--json-envelope"],
+            "1.0.0",
+            _jsonOptions,
+            _ =>
+            {
+                Console.WriteLine(rawLine);
+                return CommandExitCodes.Success;
+            }));
+
+        Assert.Equal(CommandExitCodes.InvalidArgument, exitCode);
+        Assert.Contains("--json-envelope raw JSON node count exceeded", stderr);
+        using var document = JsonDocument.Parse(stdout);
+        var metadata = document.RootElement.GetProperty("metadata");
+        Assert.Equal(CommandExitCodes.InvalidArgument, metadata.GetProperty("exit_code").GetInt32());
+        Assert.Equal(0, metadata.GetProperty("result_count").GetInt32());
+        var error = metadata.GetProperty("error");
+        Assert.Equal(CommandErrorCodes.UsageError, error.GetProperty("error_code").GetString());
+        Assert.Equal(JsonEnvelopeWrapper.MaxRawJsonNodes, error.GetProperty("max_nodes").GetInt32());
+        Assert.Equal(0, document.RootElement.GetProperty("results").GetArrayLength());
+    }
+
+    [Fact]
     public void RunWrapped_MixedRawLines_ParsesWithoutMaterializingSplitArray_Issue3015()
     {
         var (exitCode, stdout, stderr) = CaptureConsole(() => JsonEnvelopeWrapper.RunWrapped(
@@ -410,6 +464,20 @@ public class JsonEnvelopeWrapperTests
         for (var i = 0; i < nestedObjectCount; i++)
             builder.Append('}');
         builder.Append('}');
+        return builder.ToString();
+    }
+
+    private static string BuildWideRawJsonArray(int itemCount)
+    {
+        var builder = new StringBuilder(itemCount * 2 + 2);
+        builder.Append('[');
+        for (var i = 0; i < itemCount; i++)
+        {
+            if (i > 0)
+                builder.Append(',');
+            builder.Append('0');
+        }
+        builder.Append(']');
         return builder.ToString();
     }
 }

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -1131,6 +1131,134 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunSearch_BuiltInRecipeSnapshotCoversNamesScopesAndQueries_Issue3692()
+    {
+        using var env = EnvironmentVariableScope.Capture(SearchAuditRecipes.RecipePathsEnvironmentVariable);
+        env.Set(SearchAuditRecipes.RecipePathsEnvironmentVariable, null);
+
+        var recipes = SearchAuditRecipes.All;
+        var expectedSourceExcludes = new[]
+        {
+            "src/CodeIndex/Cli/SearchAuditRecipes.cs",
+            "tests/**",
+            "docs/**",
+            "CHANGELOG.md",
+            "changelog.d/**",
+            "README.md",
+            "USER_GUIDE.md",
+            "DEVELOPER_GUIDE.md",
+            "TESTING_GUIDE.md",
+            "AGENT_GUIDE.md",
+            ".codex/**",
+            ".github/**"
+        };
+
+        Assert.Equal(
+            ["risky-code", "json-parse-apis", "dotnet-risk-patterns", "xml-parser-security", "filesystem-traversal", "broad-token-audit"],
+            recipes.Select(recipe => recipe.Name).ToArray());
+
+        AssertRecipe(
+            "risky-code",
+            SearchAuditRecipes.DefaultAuditScope,
+            ["src/**"],
+            expectedSourceExcludes,
+            [
+                "unbounded-json-parse",
+                "full-materialization",
+                "file-read-all-text",
+                "file-read-all-bytes",
+                "max-value-probe",
+                "raw-diagnostic-echo",
+                "cancellation-gap",
+                "empty-catch-review",
+                "broad-exception-catch",
+                "process-start-info",
+                "process-start-direct",
+                "recursive-delete",
+                "infinite-timeout",
+                "thread-sleep",
+                "path-case-heuristic",
+                "regex-construction",
+                "regex-timeout-handling",
+                "environment-secret-source",
+                "authorization-handling",
+                "http-client-construction",
+                "bearer-token-handling",
+                "credential-term",
+                "secret-term",
+                "token-term"
+            ]);
+        AssertRecipe(
+            "json-parse-apis",
+            SearchAuditRecipes.DefaultAuditScope,
+            ["src/**"],
+            expectedSourceExcludes,
+            ["json-document-parse", "json-node-parse", "json-serializer-deserialize", "json-async-deserialize"]);
+        AssertRecipe(
+            "dotnet-risk-patterns",
+            SearchAuditRecipes.DefaultAuditScope,
+            ["src/**"],
+            expectedSourceExcludes,
+            ["sqlite-addwithvalue", "regex-construction", "cancellation-token-none", "sync-over-async"]);
+        AssertRecipe(
+            "xml-parser-security",
+            SearchAuditRecipes.DefaultAuditScope,
+            ["src/**"],
+            expectedSourceExcludes,
+            ["xml-reader-settings", "dtd-processing", "xml-resolver"]);
+        AssertRecipe(
+            "filesystem-traversal",
+            SearchAuditRecipes.DefaultAuditScope,
+            ["src/**"],
+            expectedSourceExcludes,
+            ["enumerate-files", "enumerate-directories", "enumerate-file-system-entries", "enumeration-options"]);
+        AssertRecipe(
+            "broad-token-audit",
+            SearchAuditRecipes.AllAuditScope,
+            [],
+            [],
+            ["token-term-broad"]);
+
+        void AssertRecipe(
+            string name,
+            string expectedScope,
+            string[] expectedPathPatterns,
+            string[] expectedExcludePaths,
+            string[] expectedQueries)
+        {
+            var recipe = recipes.Single(item => item.Name == name);
+            Assert.Equal(expectedScope, recipe.DefaultScope);
+            Assert.Equal(expectedPathPatterns, recipe.DefaultPathPatterns);
+            Assert.Equal(expectedExcludePaths, recipe.DefaultExcludePaths);
+            Assert.Equal(expectedQueries, recipe.Queries.Select(query => query.Name).ToArray());
+            Assert.All(recipe.Queries, query =>
+            {
+                Assert.NotEmpty(query.RecommendedLabels);
+                Assert.All(query.RecommendedLabels, label => Assert.False(string.IsNullOrWhiteSpace(label)));
+                Assert.False(string.IsNullOrWhiteSpace(query.FalsePositiveGuidance));
+            });
+        }
+    }
+
+    [Fact]
+    public void RunSearch_UnknownRecipeErrorListsBuiltInNames_Issue3692()
+    {
+        using var env = EnvironmentVariableScope.Capture(SearchAuditRecipes.RecipePathsEnvironmentVariable);
+        env.Set(SearchAuditRecipes.RecipePathsEnvironmentVariable, null);
+
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+            ["--recipe", "missing-audit-recipe", "--json"],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(string.Empty, stdout);
+        Assert.Contains("unknown search recipe 'missing-audit-recipe'", stderr);
+        Assert.Contains("Available recipes:", stderr);
+        foreach (var recipeName in new[] { "risky-code", "json-parse-apis", "dotnet-risk-patterns", "xml-parser-security", "filesystem-traversal", "broad-token-audit" })
+            Assert.Contains(recipeName, stderr);
+    }
+
+    [Fact]
     public void RunSearch_CatchRecipeFiltersCommentOnlyCatchMatches_Issue3709()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_recipe_catch_origin_filter");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSymbolTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSymbolTests.cs
@@ -1228,6 +1228,130 @@ public partial class QueryCommandRunnerTests
         }
     }
 
+    [Fact]
+    public void RunUnused_CSharpPartialClassReferencesDoNotReportPrivateHandlers_Issue3673()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_unused_csharp_partial_handlers_3673");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/Server.Tools.cs",
+                "csharp",
+                """
+                namespace Demo;
+
+                public partial class Server
+                {
+                    private object HandleToolsList(object id) => id;
+                    private object ExecuteBatchQuery(object id) => id;
+                    private object ActuallyUnused(object id) => id;
+                }
+                """);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/Server.Dispatch.cs",
+                "csharp",
+                """
+                namespace Demo;
+
+                public partial class Server
+                {
+                    public object Dispatch(string method, object id)
+                    {
+                        return method switch
+                        {
+                            "tools/list" => HandleToolsList(id),
+                            "batch/query" => ExecuteBatchQuery(id),
+                            _ => id,
+                        };
+                    }
+                }
+                """);
+            using (var db = new DbContext(dbPath))
+            {
+                using var cmd = db.Connection.CreateCommand();
+                cmd.CommandText = """
+                    DELETE FROM symbol_references
+                    WHERE symbol_name IN ('HandleToolsList', 'ExecuteBatchQuery')
+                    """;
+                cmd.ExecuteNonQuery();
+
+                var writer = new DbWriter(db.Connection);
+                writer.MarkGraphReady();
+            }
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunUnused(
+                ["--db", dbPath, "--json", "--lang", "csharp", "--visibility", "private", "--limit", "20"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var symbols = document.RootElement.GetProperty("symbols").EnumerateArray()
+                .ToDictionary(symbol => symbol.GetProperty("name").GetString()!, StringComparer.Ordinal);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.DoesNotContain("HandleToolsList", symbols.Keys);
+            Assert.DoesNotContain("ExecuteBatchQuery", symbols.Keys);
+            Assert.Equal("function", symbols["ActuallyUnused"].GetProperty("kind").GetString());
+            Assert.Equal("likely_unused_private", symbols["ActuallyUnused"].GetProperty("unused_bucket").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunUnused_CSharpFieldsAndConstantsUseSpecificKinds_Issue3673()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_unused_csharp_field_kinds_3673");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/Limits.cs",
+                "csharp",
+                """
+                namespace Demo;
+
+                public class Limits
+                {
+                    private const int MaxLimit = 200;
+                    private static readonly string Token = "value";
+                    private int Count;
+                    private string Name { get; } = "demo";
+                }
+                """);
+            using (var db = new DbContext(dbPath))
+            {
+                var writer = new DbWriter(db.Connection);
+                writer.MarkGraphReady();
+            }
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunUnused(
+                ["--db", dbPath, "--json", "--lang", "csharp", "--visibility", "private", "--limit", "20"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var symbols = document.RootElement.GetProperty("symbols").EnumerateArray()
+                .ToDictionary(symbol => symbol.GetProperty("name").GetString()!, StringComparer.Ordinal);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal("constant", symbols["MaxLimit"].GetProperty("kind").GetString());
+            Assert.Equal("field", symbols["Token"].GetProperty("kind").GetString());
+            Assert.Equal("field", symbols["Count"].GetProperty("kind").GetString());
+            Assert.Equal("property", symbols["Name"].GetProperty("kind").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
     [Theory]
     [InlineData("--bucket", "missing_bucket", "invalid --bucket value")]
     [InlineData("--min-confidence", "high", "invalid --min-confidence value")]


### PR DESCRIPTION
## Summary
- Fix `cdidx unused` C# partial-class private member handling and unused kind output for constants/fields.
- Bound `--json-envelope` raw JSON aggregation by item and node budgets.
- Replace exception-based config integer parsing with explicit `TryParse` diagnostics.
- Share exclusive file lock helpers across CLI, MCP, and suggestion store lock paths.
- Add built-in search audit recipe snapshot and unknown-recipe diagnostics coverage.

## Scope Notes
- No requested issue was excluded; all five listed issues had no prior work-start comment when checked.
- No unrelated follow-up issue was filed.
- AGENT.md, CLAUDE.md, and AGENT_GUIDE.md were not modified.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~CdidxConfigFileTests|FullyQualifiedName~JsonEnvelopeWrapperTests|FullyQualifiedName~RunSearch_BuiltInRecipeSnapshotCoversNamesScopesAndQueries_Issue3692|FullyQualifiedName~RunSearch_UnknownRecipeErrorListsBuiltInNames_Issue3692|FullyQualifiedName~ExclusiveFileLockTests|FullyQualifiedName~RunUnused_CSharpPartialClassReferencesDoNotReportPrivateHandlers_Issue3673|FullyQualifiedName~RunUnused_CSharpFieldsAndConstantsUseSpecificKinds_Issue3673" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- Codex adversarial review: No blocking/actionable issues found.

Fixes #3673
Fixes #3687
Fixes #3692
Fixes #3697
Fixes #3779