### PR TITLE
Fix workspace and path hardening issues

### DIFF
--- a/changelog.d/unreleased/3682.fixed.md
+++ b/changelog.d/unreleased/3682.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 3682
+affected:
+  - src/CodeIndex/Cli/PathCasing.cs
+  - src/CodeIndex/Cli/ActiveWorkspace.cs
+  - src/CodeIndex/Cli/WorkspaceManifest.cs
+  - src/CodeIndex/Cli/CdidxConfigFile.cs
+  - src/CodeIndex/Cli/DbCommandRunner.cs
+  - tests/CodeIndex.Tests/PathCasingTests.cs
+---
+
+## English
+
+- **Path boundary normalization is centralized for case-aware checks (#3682)** - shared `PathCasing` helpers now normalize boundary paths and compare full paths with the probed workspace case-sensitivity, replacing duplicated cleanup/config/workspace logic.
+
+## 日本語
+
+- **case-aware な path boundary 正規化を集約しました (#3682)** - 共有 `PathCasing` helper が boundary path の正規化と、probe 済み workspace case-sensitivity に基づく full path 比較を担い、cleanup/config/workspace の重複処理を置き換えました。

--- a/changelog.d/unreleased/3777.fixed.md
+++ b/changelog.d/unreleased/3777.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3777
+affected:
+  - src/CodeIndex/Indexer/Scanning/FileWriteProbe.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/FileIndexerTests.cs
+---
+
+## English
+
+- **Writable and case-sensitivity probes no longer overwrite existing files (#3777)** - probe creation now uses `CreateNew` with narrow sharing through the shared helper, and failed probes no longer delete pre-existing paths.
+
+## 日本語
+
+- **writable probe と case-sensitivity probe が既存ファイルを上書きしないようにしました (#3777)** - probe 作成は共有 helper 経由で `CreateNew` と狭い sharing を使い、失敗した probe が既存 path を削除しないようにしました。

--- a/changelog.d/unreleased/3805.fixed.md
+++ b/changelog.d/unreleased/3805.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3805
+affected:
+  - src/CodeIndex/Cli/ActiveWorkspace.cs
+  - src/CodeIndex/Cli/WorkspaceManifest.cs
+  - src/CodeIndex/Cli/WorkspaceCommandRunner.cs
+  - tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+---
+
+## English
+
+- **Workspace state and manifest diagnostics are safer (#3805)** - env-sourced active workspace paths now follow the normal state validation path, manifest path diagnostics avoid leaking raw member values, and workspace member selection follows the workspace filesystem's case sensitivity.
+
+## 日本語
+
+- **workspace state と manifest diagnostics を安全化しました (#3805)** - 環境変数由来の active workspace path を通常 state と同じ検証に通し、manifest path 診断は raw member 値を漏らさず、workspace member 選択は workspace filesystem の大小区別に従います。

--- a/changelog.d/unreleased/3813.fixed.md
+++ b/changelog.d/unreleased/3813.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3813
+affected:
+  - src/CodeIndex/Cli/GitHelper.cs
+  - tests/CodeIndex.Tests/GitHelperTests.cs
+---
+
+## English
+
+- **Git worktree metadata is validated before resolving common directories (#3813)** - `.git` and `commondir` metadata must be regular bounded files, resolved targets must exist, and malformed common-dir shapes now return no repository instead of surprising paths.
+
+## 日本語
+
+- **git worktree metadata を common directory 解決前に検証するようにしました (#3813)** - `.git` と `commondir` metadata は bounded な通常ファイルである必要があり、解決先の存在と common-dir 形状が不正な場合は意外な path を使わず repository なしとして扱います。

--- a/changelog.d/unreleased/3825.fixed.md
+++ b/changelog.d/unreleased/3825.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 3825
+affected:
+  - src/CodeIndex/Cli/ActiveWorkspace.cs
+  - src/CodeIndex/Cli/IndexLock.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Index locks and active workspace state are validated more defensively (#3825)** - index lock cleanup no longer deletes the lockfile path after releasing the OS lock, holder metadata is marked as verified/stale/unverified, and active workspace names and environment DB paths now use stricter validation.
+
+## 日本語
+
+- **index lock と active workspace state の検証を強化しました (#3825)** - OS lock 解放後に lockfile path を削除せず、holder metadata に verified/stale/unverified を明示し、active workspace 名と環境変数 DB path の検証を厳格化しました。

--- a/src/CodeIndex/Cli/ActiveWorkspace.cs
+++ b/src/CodeIndex/Cli/ActiveWorkspace.cs
@@ -9,6 +9,7 @@ internal static class ActiveWorkspace
 {
     internal const string EnvironmentVariable = "CDIDX_ACTIVE_WORKSPACE";
     internal const int MaxEnvironmentPathChars = 4096;
+    internal const int MaxWorkspaceNameChars = 128;
     private const int MaxStateBytes = 64 * 1024;
     internal const int MaxStateJsonDepth = 16;
     private static readonly JsonDocumentOptions StateJsonDocumentOptions = new()
@@ -94,8 +95,27 @@ internal static class ActiveWorkspace
 
         try
         {
+            if (!IsFullyQualifiedPath(envPath))
+            {
+                WriteLoadWarning($"environment variable {EnvironmentVariable}", "value must be an absolute database path");
+                return null;
+            }
+
             var fullPath = Path.GetFullPath(envPath);
-            return new ActiveWorkspaceState("env", Path.GetDirectoryName(fullPath) ?? Environment.CurrentDirectory, fullPath);
+            var root = Path.GetDirectoryName(fullPath);
+            if (string.IsNullOrWhiteSpace(root))
+            {
+                WriteLoadWarning($"environment variable {EnvironmentVariable}", "database path parent is unavailable");
+                return null;
+            }
+
+            if (!TryNormalizeState("env", root, fullPath, out var state, out var stateReason))
+            {
+                WriteLoadWarning($"environment variable {EnvironmentVariable}", stateReason);
+                return null;
+            }
+
+            return state;
         }
         catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
         {
@@ -140,7 +160,7 @@ internal static class ActiveWorkspace
 
         try
         {
-            path = Path.Combine(NormalizeBoundaryPath(root), "cdidx", "active.json");
+            path = Path.Combine(PathCasing.NormalizeBoundaryPath(root), "cdidx", "active.json");
             return true;
         }
         catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or PathTooLongException)
@@ -183,6 +203,9 @@ internal static class ActiveWorkspace
             return false;
         }
 
+        if (!TryNormalizeName(name, out var normalizedName, out reason))
+            return false;
+
         if (!IsFullyQualifiedPath(root))
         {
             reason = "`root` must be an absolute path";
@@ -197,8 +220,8 @@ internal static class ActiveWorkspace
 
         try
         {
-            var normalizedRoot = NormalizeBoundaryPath(root);
-            var normalizedDbPath = Path.GetFullPath(dbPath);
+            var normalizedRoot = PathCasing.NormalizeBoundaryPath(root);
+            var normalizedDbPath = PathCasing.NormalizeBoundaryPath(dbPath);
             if (PathCasing.PathsEqual(normalizedRoot, normalizedDbPath)
                 || !PathCasing.IsPathEqualOrParent(normalizedRoot, normalizedDbPath))
             {
@@ -206,7 +229,7 @@ internal static class ActiveWorkspace
                 return false;
             }
 
-            state = new ActiveWorkspaceState(string.IsNullOrWhiteSpace(name) ? "default" : name, normalizedRoot, normalizedDbPath);
+            state = new ActiveWorkspaceState(normalizedName, normalizedRoot, normalizedDbPath);
             return true;
         }
         catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or PathTooLongException)
@@ -216,13 +239,27 @@ internal static class ActiveWorkspace
         }
     }
 
-    private static string NormalizeBoundaryPath(string path)
+    private static bool TryNormalizeName(string? name, out string normalizedName, out string reason)
     {
-        var fullPath = Path.GetFullPath(path);
-        var root = Path.GetPathRoot(fullPath);
-        if (!string.IsNullOrEmpty(root) && string.Equals(fullPath, root, StringComparison.Ordinal))
-            return fullPath;
-        return fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        reason = string.Empty;
+        normalizedName = "default";
+        if (string.IsNullOrWhiteSpace(name))
+            return true;
+
+        normalizedName = name.Trim();
+        if (normalizedName.Length > MaxWorkspaceNameChars)
+        {
+            reason = $"`name` exceeds {MaxWorkspaceNameChars} characters";
+            return false;
+        }
+
+        if (normalizedName.Any(char.IsControl))
+        {
+            reason = "`name` must not contain control characters";
+            return false;
+        }
+
+        return true;
     }
 
     private static bool IsFullyQualifiedPath(string path)

--- a/src/CodeIndex/Cli/CdidxConfigFile.cs
+++ b/src/CodeIndex/Cli/CdidxConfigFile.cs
@@ -670,11 +670,11 @@ internal static class CdidxConfigFile
             pathError = null;
             try
             {
-                var normalizedRoot = NormalizeBoundaryPath(Path.GetFullPath(root));
+                var normalizedRoot = PathCasing.NormalizeBoundaryPath(root);
                 var fullPath = Path.IsPathRooted(rawPath)
                     ? Path.GetFullPath(rawPath)
                     : Path.GetFullPath(Path.Combine(normalizedRoot, rawPath));
-                var normalizedPath = NormalizeBoundaryPath(fullPath);
+                var normalizedPath = PathCasing.NormalizeBoundaryPath(fullPath);
 
                 if (!PathCasing.IsPathEqualOrParent(normalizedRoot, normalizedPath))
                 {
@@ -695,15 +695,6 @@ internal static class CdidxConfigFile
                 return false;
             }
         }
-    }
-
-    private static string NormalizeBoundaryPath(string path)
-    {
-        var fullPath = Path.GetFullPath(path);
-        var root = Path.GetPathRoot(fullPath);
-        if (!string.IsNullOrEmpty(root) && string.Equals(fullPath, root, StringComparison.Ordinal))
-            return fullPath;
-        return fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
     }
 
     private static bool TryReadStringArray(JsonElement element, string key, string path, out string[]? value, out string? error)

--- a/src/CodeIndex/Cli/DbCommandRunner.cs
+++ b/src/CodeIndex/Cli/DbCommandRunner.cs
@@ -1443,8 +1443,8 @@ public static class DbCommandRunner
         failureReason = string.Empty;
         try
         {
-            fullPath = NormalizeBoundaryPath(Path.GetFullPath(path));
-            var normalizedRoot = NormalizeBoundaryPath(Path.GetFullPath(safeRoot));
+            fullPath = PathCasing.NormalizeBoundaryPath(path);
+            var normalizedRoot = PathCasing.NormalizeBoundaryPath(safeRoot);
             if (string.Equals(fullPath, normalizedRoot, PathCasing.ComparisonFor(normalizedRoot))
                 || !PathCasing.IsPathEqualOrParent(normalizedRoot, fullPath))
             {
@@ -1465,15 +1465,6 @@ public static class DbCommandRunner
             failureReason = "target path is invalid";
             return false;
         }
-    }
-
-    private static string NormalizeBoundaryPath(string path)
-    {
-        var fullPath = Path.GetFullPath(path);
-        var root = Path.GetPathRoot(fullPath);
-        if (!string.IsNullOrEmpty(root) && string.Equals(fullPath, root, StringComparison.Ordinal))
-            return fullPath;
-        return fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
     }
 
     internal static DbCommandOptions ParseArgs(string[] args)

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -224,6 +224,9 @@ public static class GitHelper
                 : null;
         }
 
+        if (!IsRegularGitMetadataFile(ioDotGit))
+            return null;
+
         var gitFileContent = DataDirectorySecurity.ReadTextWithinLimit(ioDotGit, MaxGitMetadataFileBytes);
         if (gitFileContent is null)
             return null;
@@ -231,25 +234,112 @@ public static class GitHelper
         gitFileContent = gitFileContent.Trim();
         if (!gitFileContent.StartsWith("gitdir:")) return null;
 
-        var worktreeGitDir = gitFileContent["gitdir:".Length..].Trim();
-        if (!Path.IsPathRooted(worktreeGitDir))
-            worktreeGitDir = Path.GetFullPath(Path.Combine(projectRoot, worktreeGitDir));
+        var worktreeGitDirValue = gitFileContent["gitdir:".Length..].Trim();
+        if (!TryResolveGitMetadataPath(projectRoot, worktreeGitDirValue, out var worktreeGitDir))
+            return null;
+        if (!Directory.Exists(LongPath.EnsureWindowsPrefix(worktreeGitDir)))
+            return null;
 
         // Read commondir to find the shared .git directory / commondirを読んで共有.gitディレクトリを見つける
         var commonDirFile = Path.Combine(worktreeGitDir, "commondir");
         var ioCommonDirFile = LongPath.EnsureWindowsPrefix(commonDirFile);
-        if (File.Exists(ioCommonDirFile))
+        if (GitMetadataPathExists(ioCommonDirFile))
         {
+            if (!IsRegularGitMetadataFile(ioCommonDirFile))
+                return null;
+
             var commonDirRelative = DataDirectorySecurity.ReadTextWithinLimit(ioCommonDirFile, MaxGitMetadataFileBytes);
             if (commonDirRelative is null)
                 return null;
 
             commonDirRelative = commonDirRelative.Trim();
-            return Path.GetFullPath(Path.Combine(worktreeGitDir, commonDirRelative));
+            if (!TryResolveGitMetadataPath(worktreeGitDir, commonDirRelative, out var commonDir))
+                return null;
+            if (!Directory.Exists(LongPath.EnsureWindowsPrefix(commonDir)))
+                return null;
+            if (PathCasing.PathsEqual(commonDir, worktreeGitDir)
+                || !PathCasing.IsPathEqualOrParent(commonDir, worktreeGitDir))
+                return null;
+            return commonDir;
         }
 
-        // Fallback: use worktreeGitDir itself (e.g. submodules) / フォールバック: worktreeGitDir自体を使用
+        // Fallback only for a real git-dir shape (e.g. submodules), not any directory.
+        // 任意のディレクトリではなく、実際の git-dir 形状（例: submodule）の場合だけフォールバックする。
+        if (!IsValidGitDirectoryShape(worktreeGitDir))
+            return null;
         return worktreeGitDir;
+    }
+
+    private static bool GitMetadataPathExists(string path)
+        => File.Exists(path) || Directory.Exists(path);
+
+    private static bool TryResolveGitMetadataPath(string baseDirectory, string value, out string resolvedPath)
+    {
+        resolvedPath = string.Empty;
+        if (string.IsNullOrWhiteSpace(value))
+            return false;
+
+        try
+        {
+            var fullPath = Path.IsPathRooted(value)
+                ? Path.GetFullPath(value)
+                : Path.GetFullPath(Path.Combine(baseDirectory, value));
+            resolvedPath = PathCasing.NormalizeBoundaryPath(fullPath);
+            return true;
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or PathTooLongException or UnauthorizedAccessException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsRegularGitMetadataFile(string path)
+    {
+        try
+        {
+            var attributes = File.GetAttributes(path);
+            return (attributes & FileAttributes.Directory) == 0
+                   && (attributes & FileAttributes.ReparsePoint) == 0;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsValidGitDirectoryShape(string gitDir)
+    {
+        try
+        {
+            var ioGitDir = LongPath.EnsureWindowsPrefix(gitDir);
+            if (!Directory.Exists(ioGitDir))
+                return false;
+
+            var headPath = LongPath.EnsureWindowsPrefix(Path.Combine(gitDir, "HEAD"));
+            if (!IsRegularGitMetadataFile(headPath))
+                return false;
+
+            return IsGitMetadataDirectory(Path.Combine(gitDir, "objects"))
+                   && IsGitMetadataDirectory(Path.Combine(gitDir, "refs"));
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private static bool IsGitMetadataDirectory(string path)
+    {
+        try
+        {
+            var attributes = File.GetAttributes(LongPath.EnsureWindowsPrefix(path));
+            return (attributes & FileAttributes.Directory) != 0
+                   && (attributes & FileAttributes.ReparsePoint) == 0;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -383,7 +383,13 @@ public static partial class IndexCommandRunner
         if (holder == null)
             return string.Empty;
         var startedLocal = holder.StartedAt.ToLocalTime();
-        return $"PID {holder.Pid.ToString(System.Globalization.CultureInfo.InvariantCulture)}, started {startedLocal.ToString("yyyy-MM-dd HH:mm:ss zzz", System.Globalization.CultureInfo.InvariantCulture)}";
+        var verification = holder.Verification switch
+        {
+            IndexLockHolderVerification.Verified => "verified",
+            IndexLockHolderVerification.Stale => "stale",
+            _ => "unverified",
+        };
+        return $"PID {holder.Pid.ToString(System.Globalization.CultureInfo.InvariantCulture)} ({verification}), started {startedLocal.ToString("yyyy-MM-dd HH:mm:ss zzz", System.Globalization.CultureInfo.InvariantCulture)}";
     }
     private static Dictionary<string, string?> GetHotspotFamilyMetaSnapshot(DbContext db, Func<string, string> keyFactory)
     {

--- a/src/CodeIndex/Cli/IndexLock.cs
+++ b/src/CodeIndex/Cli/IndexLock.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using System.Text;
 using CodeIndex.Indexer;
@@ -33,6 +35,8 @@ internal sealed class IndexLock : IDisposable
     internal static Action<string> DeleteFileForTesting { get; set; } = File.Delete;
     internal static Action<LockCleanupDiagnostic>? CleanupDiagnosticSinkForTesting { get; set; }
     internal static TimeProvider TimeProvider { get; set; } = TimeProvider.System;
+
+    private static readonly TimeSpan HolderStartTimeTolerance = TimeSpan.FromSeconds(2);
 
     private static DateTime GetUtcNow() => TimeProvider.GetUtcNow().UtcDateTime;
 
@@ -105,7 +109,8 @@ internal sealed class IndexLock : IDisposable
         {
             var info = new IndexLockInfo(
                 Pid: Environment.ProcessId,
-                StartedAt: GetUtcNow());
+                StartedAt: GetCurrentProcessStartTimeUtc(),
+                Verification: IndexLockHolderVerification.Verified);
             DataDirectorySecurity.WritePrivateText(infoPath, SerializeInfo(info), Encoding.UTF8);
         }
         catch (Exception)
@@ -138,7 +143,10 @@ internal sealed class IndexLock : IDisposable
             var text = DataDirectorySecurity.ReadTextWithinLimit(ioInfoPath, MaxInfoBytes, FileShare.ReadWrite);
             if (string.IsNullOrWhiteSpace(text))
                 return null;
-            return ParseInfo(text);
+            var info = ParseInfo(text);
+            return info is null
+                ? null
+                : info with { Verification = VerifyHolder(info) };
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException)
         {
@@ -163,7 +171,6 @@ internal sealed class IndexLock : IDisposable
             // Best-effort. / ベストエフォート。
         }
 
-        TryDeleteCleanupTarget(_lockPath, "lockfile");
     }
 
     // --- Tiny key=value serializer (avoids touching JsonSerializerContext) ---
@@ -194,7 +201,7 @@ internal sealed class IndexLock : IDisposable
             switch (key)
             {
                 case "pid":
-                    if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var p))
+                    if (int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var p) && p > 0)
                         pid = p;
                     break;
                 case "started_at":
@@ -208,6 +215,50 @@ internal sealed class IndexLock : IDisposable
             return null;
         return new IndexLockInfo(pid.Value, started.Value);
     }
+
+    private static DateTime GetCurrentProcessStartTimeUtc()
+    {
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            return process.StartTime.ToUniversalTime();
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or Win32Exception or NotSupportedException)
+        {
+            return GetUtcNow();
+        }
+    }
+
+    private static IndexLockHolderVerification VerifyHolder(IndexLockInfo info)
+    {
+        try
+        {
+            using var process = Process.GetProcessById(info.Pid);
+            if (process.HasExited)
+                return IndexLockHolderVerification.Stale;
+
+            var processStartedAt = process.StartTime.ToUniversalTime();
+            var holderStartedAt = NormalizeUtc(info.StartedAt);
+            return (processStartedAt - holderStartedAt).Duration() <= HolderStartTimeTolerance
+                ? IndexLockHolderVerification.Verified
+                : IndexLockHolderVerification.Stale;
+        }
+        catch (ArgumentException)
+        {
+            return IndexLockHolderVerification.Stale;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or Win32Exception or NotSupportedException or UnauthorizedAccessException)
+        {
+            return IndexLockHolderVerification.Unverified;
+        }
+    }
+
+    private static DateTime NormalizeUtc(DateTime value) => value.Kind switch
+    {
+        DateTimeKind.Utc => value,
+        DateTimeKind.Local => value.ToUniversalTime(),
+        _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+    };
 
     private static string UnescapeValue(string value)
     {
@@ -258,7 +309,15 @@ internal sealed class IndexLock : IDisposable
 
 internal sealed record IndexLockInfo(
     int Pid,
-    DateTime StartedAt);
+    DateTime StartedAt,
+    IndexLockHolderVerification Verification = IndexLockHolderVerification.Unverified);
+
+internal enum IndexLockHolderVerification
+{
+    Verified,
+    Unverified,
+    Stale,
+}
 
 internal sealed class IndexLockConflictException : Exception
 {

--- a/src/CodeIndex/Cli/PathCasing.cs
+++ b/src/CodeIndex/Cli/PathCasing.cs
@@ -48,6 +48,18 @@ internal static class PathCasing
         return string.Equals(left, right, ComparisonFor(anchor));
     }
 
+    public static string NormalizeBoundaryPath(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var root = Path.GetPathRoot(fullPath);
+        if (!string.IsNullOrEmpty(root) && string.Equals(fullPath, root, StringComparison.Ordinal))
+            return fullPath;
+        return fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    public static bool IsFullPathEqualOrParent(string parent, string child)
+        => IsPathEqualOrParent(NormalizeBoundaryPath(parent), NormalizeBoundaryPath(child));
+
     /// <summary>
     /// Return true when <paramref name="normalizedChild"/> is the same path as
     /// <paramref name="normalizedParent"/> or a descendant of it, using the
@@ -62,6 +74,8 @@ internal static class PathCasing
             return true;
 
         var trimmedParent = normalizedParent.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (trimmedParent.Length == 0)
+            return Path.IsPathFullyQualified(normalizedChild);
         return normalizedChild.StartsWith(trimmedParent + Path.DirectorySeparatorChar, comparison)
             || normalizedChild.StartsWith(trimmedParent + Path.AltDirectorySeparatorChar, comparison);
     }

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -3669,7 +3669,7 @@ internal static partial class ProgramRunner
         {
             Directory.CreateDirectory(directory);
             probe = Path.Combine(directory, $".cdidx-write-test-{Guid.NewGuid():N}");
-            File.WriteAllText(probe, "");
+            FileWriteProbe.WriteEmptyFile(probe, Encoding.UTF8);
             createdProbe = true;
             return true;
         }

--- a/src/CodeIndex/Cli/WorkspaceCommandRunner.cs
+++ b/src/CodeIndex/Cli/WorkspaceCommandRunner.cs
@@ -75,8 +75,9 @@ internal static class WorkspaceCommandRunner
         WorkspaceMember? member = null;
         if (manifest != null && !useDefault)
         {
+            var memberNameComparison = PathCasing.ComparisonFor(manifest.Root);
             var matches = manifest.Members
-                .Where(m => string.Equals(Path.GetFileName(m.Path), name, StringComparison.OrdinalIgnoreCase))
+                .Where(m => string.Equals(Path.GetFileName(m.Path), name, memberNameComparison))
                 .Take(MaxAmbiguousMemberCandidates + 1)
                 .ToArray();
 

--- a/src/CodeIndex/Cli/WorkspaceManifest.cs
+++ b/src/CodeIndex/Cli/WorkspaceManifest.cs
@@ -47,14 +47,14 @@ internal static class WorkspaceManifestLoader
                                       or PathTooLongException
                                       or UnauthorizedAccessException)
         {
-            throw new InvalidDataException($"Workspace manifest discovery start directory is invalid: {startingDirectory}", ex);
+            throw new InvalidDataException($"Workspace manifest discovery start directory is invalid: {ConsoleUi.FormatBoundedValue(startingDirectory)}", ex);
         }
 
         var searchedAncestors = 0;
         while (current is not null)
         {
             if (searchedAncestors >= MaxManifestDiscoveryAncestors)
-                throw new InvalidDataException($"Workspace manifest discovery exceeded the {MaxManifestDiscoveryAncestors} ancestor limit from {startingDirectory}.");
+                throw new InvalidDataException($"Workspace manifest discovery exceeded the {MaxManifestDiscoveryAncestors} ancestor limit from {ConsoleUi.FormatBoundedValue(startingDirectory)}.");
             searchedAncestors++;
 
             foreach (var name in new[] { DotFileName, FileName })
@@ -113,7 +113,7 @@ internal static class WorkspaceManifestLoader
             return strategy;
         }
 
-        throw new InvalidDataException($"Workspace manifest index_strategy must be 'per_member' or 'single': {strategy}");
+        throw new InvalidDataException($"Workspace manifest index_strategy must be 'per_member' or 'single': {ConsoleUi.FormatBoundedValue(strategy)}");
     }
 
     private static string ValidateDefaultDbName(string dbName)
@@ -129,7 +129,7 @@ internal static class WorkspaceManifestLoader
             || dbName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
             || !string.Equals(Path.GetFileName(dbName), dbName, StringComparison.Ordinal))
         {
-            throw new InvalidDataException($"Workspace manifest default_db_name must be a plain file name: {dbName}");
+            throw new InvalidDataException($"Workspace manifest default_db_name must be a plain file name: {ConsoleUi.FormatBoundedValue(dbName)}");
         }
 
         return dbName;
@@ -215,22 +215,13 @@ internal static class WorkspaceManifestLoader
     private static string ResolveMemberPath(string root, string member)
     {
         if (Path.IsPathRooted(member))
-            throw new InvalidDataException($"Workspace manifest member path must be relative: {member}");
+            throw new InvalidDataException("Workspace manifest member path must be relative.");
 
-        var normalizedRoot = NormalizeBoundaryPath(Path.GetFullPath(root));
-        var fullMember = NormalizeBoundaryPath(Path.GetFullPath(Path.Combine(normalizedRoot, member)));
+        var normalizedRoot = PathCasing.NormalizeBoundaryPath(root);
+        var fullMember = PathCasing.NormalizeBoundaryPath(Path.Combine(normalizedRoot, member));
         if (!PathCasing.IsPathEqualOrParent(normalizedRoot, fullMember))
-            throw new InvalidDataException($"Workspace manifest member path escapes the manifest root: {member}");
+            throw new InvalidDataException("Workspace manifest member path escapes the manifest root.");
 
         return fullMember;
-    }
-
-    private static string NormalizeBoundaryPath(string path)
-    {
-        var fullPath = Path.GetFullPath(path);
-        var root = Path.GetPathRoot(fullPath);
-        if (!string.IsNullOrEmpty(root) && string.Equals(fullPath, root, StringComparison.Ordinal))
-            return fullPath;
-        return fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
     }
 }

--- a/src/CodeIndex/Indexer/Scanning/FileWriteProbe.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileWriteProbe.cs
@@ -7,10 +7,12 @@ internal static class FileWriteProbe
     internal static void WriteEmptyFile(string path, Encoding? encoding = null)
     {
         var ioPath = LongPath.EnsureWindowsPrefix(path);
+        using var stream = new FileStream(ioPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
         if (encoding is null)
-            File.WriteAllText(ioPath, string.Empty);
-        else
-            File.WriteAllText(ioPath, string.Empty, encoding);
+            return;
+
+        using var writer = new StreamWriter(stream, encoding);
+        writer.Write(string.Empty);
     }
 
     internal static bool TryWriteAndDeleteEmptyFile(string path, Encoding? encoding = null)
@@ -21,7 +23,6 @@ internal static class FileWriteProbe
         }
         catch (Exception ex) when (IsWriteProbeFailure(ex))
         {
-            TryDeleteFileIfExists(path);
             return false;
         }
 

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -7344,9 +7344,7 @@ public partial class McpServer
         var createdProbe = false;
         try
         {
-            using (new FileStream(probePath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
-            {
-            }
+            FileWriteProbe.WriteEmptyFile(probePath);
             createdProbe = true;
             error = null;
             return true;

--- a/tests/CodeIndex.Tests/FileIndexerTests.cs
+++ b/tests/CodeIndex.Tests/FileIndexerTests.cs
@@ -206,6 +206,28 @@ public class FileIndexerTests
     }
 
     [Fact]
+    public void FileWriteProbe_TryWriteAndDeleteEmptyFile_DoesNotOverwriteOrDeleteExistingProbe_Issue3777()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx-write-probe-existing-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var probePath = Path.Combine(tempDir, ".cdidx-write-probe.tmp");
+            File.WriteAllText(probePath, "existing", Encoding.UTF8);
+
+            var result = FileWriteProbe.TryWriteAndDeleteEmptyFile(probePath, Encoding.UTF8);
+
+            Assert.False(result);
+            Assert.True(File.Exists(probePath));
+            Assert.Equal("existing", File.ReadAllText(probePath, Encoding.UTF8));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(tempDir);
+        }
+    }
+
+    [Fact]
     public void ScanFilesDetailed_CaseInsensitiveChildDirectory_SkipsCaseOnlyDuplicatePathWithWarning()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx-case-dedupe-{Guid.NewGuid():N}");

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -137,11 +137,75 @@ public class GitHelperTests : IDisposable
     }
 
     [Fact]
-    public void WorktreeWithoutCommonDir_FallsBackToWorktreeGitDir()
+    public void WorktreeWithMissingGitDirTarget_ReturnsNull_Issue3813()
     {
-        // Arrange: worktree git dir exists but has no commondir file / commondirファイルがない場合のフォールバック
-        var worktreeGitDir = Path.Combine(_tempDir, "fake-git-dir");
+        var projectRoot = Path.Combine(_tempDir, "project");
+        Directory.CreateDirectory(projectRoot);
+        File.WriteAllText(Path.Combine(projectRoot, ".git"), $"gitdir: {Path.Combine(_tempDir, "missing-git-dir")}");
+
+        var result = GitHelper.ResolveGitCommonDir(projectRoot);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void WorktreeWithEscapingCommonDir_ReturnsNull_Issue3813()
+    {
+        var mainGitDir = Path.Combine(_tempDir, "main_repo", ".git");
+        var worktreeGitDir = Path.Combine(mainGitDir, "worktrees", "escaping");
+        var outside = Path.Combine(_tempDir, "outside");
         Directory.CreateDirectory(worktreeGitDir);
+        Directory.CreateDirectory(outside);
+        File.WriteAllText(Path.Combine(worktreeGitDir, "commondir"), Path.GetRelativePath(worktreeGitDir, outside));
+
+        var projectRoot = Path.Combine(_tempDir, "project");
+        Directory.CreateDirectory(projectRoot);
+        File.WriteAllText(Path.Combine(projectRoot, ".git"), $"gitdir: {worktreeGitDir}");
+
+        var result = GitHelper.ResolveGitCommonDir(projectRoot);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void WorktreeWithDirectoryCommonDir_ReturnsNull_Issue3813()
+    {
+        var worktreeGitDir = Path.Combine(_tempDir, "fake-git-dir");
+        Directory.CreateDirectory(Path.Combine(worktreeGitDir, "commondir"));
+
+        var projectRoot = Path.Combine(_tempDir, "project");
+        Directory.CreateDirectory(projectRoot);
+        File.WriteAllText(Path.Combine(projectRoot, ".git"), $"gitdir: {worktreeGitDir}");
+
+        var result = GitHelper.ResolveGitCommonDir(projectRoot);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void WorktreeWithExistingUnshapedGitDirTarget_ReturnsNull_Issue3813()
+    {
+        var unshapedGitDir = Path.Combine(_tempDir, "writable-target");
+        Directory.CreateDirectory(unshapedGitDir);
+
+        var projectRoot = Path.Combine(_tempDir, "project");
+        Directory.CreateDirectory(projectRoot);
+        File.WriteAllText(Path.Combine(projectRoot, ".git"), $"gitdir: {unshapedGitDir}");
+
+        var result = GitHelper.ResolveGitCommonDir(projectRoot);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void WorktreeWithoutCommonDirAndValidGitDirShape_FallsBackToWorktreeGitDir()
+    {
+        // Arrange: gitdir exists without commondir but has a real git-dir shape.
+        // commondir はないが、実際の git-dir 形状を持つ場合のフォールバック。
+        var worktreeGitDir = Path.Combine(_tempDir, "fake-git-dir");
+        Directory.CreateDirectory(Path.Combine(worktreeGitDir, "objects"));
+        Directory.CreateDirectory(Path.Combine(worktreeGitDir, "refs"));
+        File.WriteAllText(Path.Combine(worktreeGitDir, "HEAD"), "ref: refs/heads/main\n");
 
         var projectRoot = Path.Combine(_tempDir, "project");
         Directory.CreateDirectory(projectRoot);

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -12533,6 +12533,34 @@ public sealed class Caller
     }
 
     [Fact]
+    public void IndexLock_TryReadHolderInfo_WhenProcessDoesNotMatch_MarksMetadataStale_Issue3825()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_stale_holder_{Guid.NewGuid():N}.db");
+        var lockPath = dbPath + ".lock";
+        var infoPath = lockPath + ".info";
+        try
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
+            File.WriteAllText(infoPath, "pid=2147483647\nstarted_at=2020-01-01T00:00:00.000Z\n");
+
+            var holder = IndexLock.TryReadHolderInfo(lockPath);
+
+            Assert.NotNull(holder);
+            Assert.Equal(2147483647, holder.Pid);
+            Assert.Equal(IndexLockHolderVerification.Stale, holder.Verification);
+        }
+        finally
+        {
+            if (File.Exists(infoPath))
+                File.Delete(infoPath);
+            if (File.Exists(lockPath))
+                File.Delete(lockPath);
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
     public void Run_LockHeldByAnotherHolder_RejectedWithHolderInfo()
     {
         var projectRoot = CreateTempProject();
@@ -12680,7 +12708,7 @@ public sealed class Caller
     }
 
     [Fact]
-    public void Run_StaleLockFile_ReclaimedAndCleanedUpAfterSuccess()
+    public void Run_StaleLockFile_ReclaimedWithoutDeletingLockFileAfterSuccess_Issue3825()
     {
         var projectRoot = CreateTempProject();
         var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_lock_stale_{Guid.NewGuid():N}.db");
@@ -12692,14 +12720,15 @@ public sealed class Caller
             Directory.CreateDirectory(Path.GetDirectoryName(lockPath)!);
 
             // Stale on-disk lockfile with no live holder; OS releases handles on
-            // process death so a fresh acquire must succeed and clean up after itself.
+            // process death so a fresh acquire must succeed. The lockfile path is
+            // intentionally left in place after release to avoid racing a later holder.
             File.WriteAllText(lockPath, string.Empty);
             File.WriteAllText(infoPath, "pid=99999\nstarted_at=2020-01-01T00:00:00.000Z\nhost=stale\nproject=/old\n");
 
             var (exitCode, json) = RunAndCaptureJson([projectRoot, "--db", dbPath, "--json"]);
             Assert.Equal(CommandExitCodes.Success, exitCode);
             Assert.Equal("success", json.GetProperty("status").GetString());
-            Assert.False(File.Exists(lockPath), "lock file should be removed after a clean exit");
+            Assert.True(File.Exists(lockPath), "lock file should remain after a clean exit");
             Assert.False(File.Exists(infoPath), "lock metadata sidecar should be removed after a clean exit");
         }
         finally

--- a/tests/CodeIndex.Tests/PathCasingTests.cs
+++ b/tests/CodeIndex.Tests/PathCasingTests.cs
@@ -167,6 +167,52 @@ public class PathCasingTests
     }
 
     [Fact]
+    public void NormalizeBoundaryPath_TrimsTrailingSeparatorsButKeepsRoot_Issue3682()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_pathcasing_normalize_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var withSeparator = tempDir + Path.DirectorySeparatorChar;
+
+            Assert.Equal(Path.GetFullPath(tempDir), PathCasing.NormalizeBoundaryPath(withSeparator));
+
+            var root = Path.GetPathRoot(Path.GetFullPath(tempDir));
+            Assert.False(string.IsNullOrEmpty(root));
+            Assert.Equal(root, PathCasing.NormalizeBoundaryPath(root!));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IsFullPathEqualOrParent_UsesSeededCaseSensitivity_Issue3682()
+    {
+        PathCasing.ResetCacheForTests();
+        var tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_pathcasing_full_parent_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var parent = Path.Combine(tempDir, "Project") + Path.DirectorySeparatorChar;
+            var child = Path.Combine(tempDir, "project", "src", "App.cs");
+
+            PathCasing.SeedFromWorkspace(tempDir, ignoreCase: false);
+            Assert.False(PathCasing.IsFullPathEqualOrParent(parent, child));
+
+            PathCasing.ResetCacheForTests();
+            PathCasing.SeedFromWorkspace(tempDir, ignoreCase: true);
+            Assert.True(PathCasing.IsFullPathEqualOrParent(parent, child));
+        }
+        finally
+        {
+            PathCasing.ResetCacheForTests();
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
     public void PathsEqual_NullEitherSide_IsFalse()
     {
         Assert.False(PathCasing.PathsEqual(null, "/tmp"));

--- a/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
@@ -503,6 +503,36 @@ public class WorkspaceCommandRunnerTests
     }
 
     [Fact]
+    public void ActiveWorkspaceEnvironment_RelativeDbPath_DoesNotOverrideQueryResolution_Issue3825()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_active_workspace_env_relative_project");
+        const string RelativeDbPath = "relative_active_workspace_SENTINEL_3825.db";
+        try
+        {
+            using var env = EnvironmentVariableScope.Capture(ActiveWorkspace.EnvironmentVariable);
+            Environment.SetEnvironmentVariable(ActiveWorkspace.EnvironmentVariable, RelativeDbPath);
+
+            DbPathResolution? query = null;
+            var (_, _, stderr) = ConsoleCapture.Capture(() =>
+            {
+                query = DbPathResolver.ResolveForQuery(projectRoot, explicitDbPath: null, explicitDataDir: null);
+                return 0;
+            });
+
+            Assert.NotNull(query);
+            Assert.Contains(ActiveWorkspace.EnvironmentVariable, stderr);
+            Assert.Contains("value must be an absolute database path", stderr);
+            Assert.DoesNotContain(RelativeDbPath, stderr);
+            Assert.Equal(Path.Combine(projectRoot, ".cdidx", "codeindex.db"), query!.DbPath);
+            Assert.Equal(DbPathResolver.DataDirSourceWorkspace, query.DataDirSource);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void MalformedActiveWorkspaceState_DoesNotOverrideQueryResolution()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_active_workspace_malformed_project");
@@ -528,6 +558,85 @@ public class WorkspaceCommandRunnerTests
             Assert.DoesNotContain(ActiveWorkspace.StatePath, stderr);
             Assert.DoesNotContain("LineNumber", stderr);
             Assert.Contains("invalid JSON", stderr);
+            Assert.Equal(Path.Combine(projectRoot, ".cdidx", "codeindex.db"), query!.DbPath);
+            Assert.Equal(DbPathResolver.DataDirSourceWorkspace, query.DataDirSource);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+            TestProjectHelper.DeleteDirectory(configHome);
+        }
+    }
+
+    [Fact]
+    public void ActiveWorkspaceState_ControlCharacterName_DoesNotOverrideQueryResolution_Issue3825()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_active_workspace_bad_name_project");
+        var configHome = TestProjectHelper.CreateTempProject("cdidx_active_workspace_bad_name_config");
+        try
+        {
+            using var env = EnvironmentVariableScope.Capture(ActiveWorkspace.EnvironmentVariable, "XDG_CONFIG_HOME");
+            Environment.SetEnvironmentVariable(ActiveWorkspace.EnvironmentVariable, null);
+            Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", configHome);
+            Directory.CreateDirectory(Path.GetDirectoryName(ActiveWorkspace.StatePath)!);
+            File.WriteAllText(ActiveWorkspace.StatePath, $$"""
+                {
+                  "name": "bad\nname",
+                  "root": {{JsonSerializer.Serialize(projectRoot)}},
+                  "db_path": {{JsonSerializer.Serialize(Path.Combine(projectRoot, ".cdidx", "codeindex.db"))}}
+                }
+                """);
+
+            DbPathResolution? query = null;
+            var (_, _, stderr) = ConsoleCapture.Capture(() =>
+            {
+                query = DbPathResolver.ResolveForQuery(projectRoot, explicitDbPath: null, explicitDataDir: null);
+                return 0;
+            });
+
+            Assert.NotNull(query);
+            Assert.Contains("Ignoring active workspace state", stderr);
+            Assert.Contains("`name` must not contain control characters", stderr);
+            Assert.DoesNotContain("bad", stderr);
+            Assert.Equal(Path.Combine(projectRoot, ".cdidx", "codeindex.db"), query!.DbPath);
+            Assert.Equal(DbPathResolver.DataDirSourceWorkspace, query.DataDirSource);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+            TestProjectHelper.DeleteDirectory(configHome);
+        }
+    }
+
+    [Fact]
+    public void ActiveWorkspaceState_OversizedName_DoesNotOverrideQueryResolution_Issue3825()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_active_workspace_long_name_project");
+        var configHome = TestProjectHelper.CreateTempProject("cdidx_active_workspace_long_name_config");
+        try
+        {
+            using var env = EnvironmentVariableScope.Capture(ActiveWorkspace.EnvironmentVariable, "XDG_CONFIG_HOME");
+            Environment.SetEnvironmentVariable(ActiveWorkspace.EnvironmentVariable, null);
+            Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", configHome);
+            Directory.CreateDirectory(Path.GetDirectoryName(ActiveWorkspace.StatePath)!);
+            File.WriteAllText(ActiveWorkspace.StatePath, $$"""
+                {
+                  "name": {{JsonSerializer.Serialize(new string('n', ActiveWorkspace.MaxWorkspaceNameChars + 1))}},
+                  "root": {{JsonSerializer.Serialize(projectRoot)}},
+                  "db_path": {{JsonSerializer.Serialize(Path.Combine(projectRoot, ".cdidx", "codeindex.db"))}}
+                }
+                """);
+
+            DbPathResolution? query = null;
+            var (_, _, stderr) = ConsoleCapture.Capture(() =>
+            {
+                query = DbPathResolver.ResolveForQuery(projectRoot, explicitDbPath: null, explicitDataDir: null);
+                return 0;
+            });
+
+            Assert.NotNull(query);
+            Assert.Contains("Ignoring active workspace state", stderr);
+            Assert.Contains($"`name` exceeds {ActiveWorkspace.MaxWorkspaceNameChars} characters", stderr);
             Assert.Equal(Path.Combine(projectRoot, ".cdidx", "codeindex.db"), query!.DbPath);
             Assert.Equal(DbPathResolver.DataDirSourceWorkspace, query.DataDirSource);
         }

--- a/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
@@ -1035,6 +1035,91 @@ public class WorkspaceCommandRunnerTests
     }
 
     [Fact]
+    public void WorkspaceManifest_EscapingMemberDiagnosticDoesNotLeakMemberPath_Issue3805()
+    {
+        var root = TestProjectHelper.CreateTempProject("cdidx_workspace_manifest_escape");
+        const string SentinelMember = "../SECRET_MEMBER_SENTINEL_3805";
+        try
+        {
+            var manifestPath = Path.Combine(root, "cdidx.workspace.json");
+            File.WriteAllText(manifestPath, $$"""{ "members": [{{JsonSerializer.Serialize(SentinelMember)}}] }""");
+
+            var ex = Assert.Throws<InvalidDataException>(() => WorkspaceManifestLoader.Load(manifestPath));
+
+            Assert.Contains("member path escapes the manifest root", ex.Message);
+            Assert.DoesNotContain(SentinelMember, ex.Message);
+            Assert.DoesNotContain("SECRET_MEMBER_SENTINEL_3805", ex.Message);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void WorkspaceManifest_LongMemberPathDiagnosticDoesNotLeakMemberValue_Issue3805()
+    {
+        var root = TestProjectHelper.CreateTempProject("cdidx_workspace_manifest_long_member");
+        try
+        {
+            var longMember = new string('a', WorkspaceManifestLoader.MaxManifestMemberPathChars + 1) + "TAIL_SENTINEL_3805";
+            var manifestPath = Path.Combine(root, "cdidx.workspace.json");
+            File.WriteAllText(manifestPath, $$"""{ "members": [{{JsonSerializer.Serialize(longMember)}}] }""");
+
+            var ex = Assert.Throws<InvalidDataException>(() => WorkspaceManifestLoader.Load(manifestPath));
+
+            Assert.Contains($"exceeds the {WorkspaceManifestLoader.MaxManifestMemberPathChars} character limit", ex.Message);
+            Assert.DoesNotContain("TAIL_SENTINEL_3805", ex.Message);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(root);
+        }
+    }
+
+    [Fact]
+    public void WorkspaceUse_CaseSensitiveMemberSelectionDistinguishesCaseOnlyBasenames_Issue3805()
+    {
+        PathCasing.ResetCacheForTests();
+        var root = TestProjectHelper.CreateTempProject("cdidx_workspace_use_case_sensitive");
+        var configHome = TestProjectHelper.CreateTempProject("cdidx_workspace_use_case_sensitive_config");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(root, "src", "App"));
+            Directory.CreateDirectory(Path.Combine(root, "src", "app"));
+            File.WriteAllText(Path.Combine(root, "cdidx.workspace.json"), """{ "members": ["src/App", "src/app"] }""");
+            using var env = EnvironmentVariableScope.Capture(ActiveWorkspace.EnvironmentVariable, "XDG_CONFIG_HOME");
+            Environment.SetEnvironmentVariable(ActiveWorkspace.EnvironmentVariable, null);
+            Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", configHome);
+            PathCasing.SeedFromWorkspace(root, ignoreCase: false);
+
+            var previous = Environment.CurrentDirectory;
+            try
+            {
+                Environment.CurrentDirectory = root;
+                var (exitCode, _, stderr) = ConsoleCapture.Capture(() => WorkspaceCommandRunner.Run(["use", "App"], _jsonOptions));
+
+                Assert.Equal(CommandExitCodes.Success, exitCode);
+                Assert.Equal(string.Empty, stderr);
+                var state = ActiveWorkspace.Load();
+                Assert.NotNull(state);
+                Assert.Equal("App", state.Name);
+                Assert.Equal(Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, "src", "App")), state.Root);
+            }
+            finally
+            {
+                Environment.CurrentDirectory = previous;
+            }
+        }
+        finally
+        {
+            PathCasing.ResetCacheForTests();
+            TestProjectHelper.DeleteDirectory(root);
+            TestProjectHelper.DeleteDirectory(configHome);
+        }
+    }
+
+    [Fact]
     public void WorkspaceUse_RejectsNamedWorkspaceWithoutManifest()
     {
         var root = TestProjectHelper.CreateTempProject("cdidx_workspace_use_no_manifest");


### PR DESCRIPTION
## Summary
- Centralize path-boundary normalization and use it for config/database containment checks.
- Harden probe-file creation and install/MCP writable checks against overwriting existing files.
- Validate Git worktree metadata, including malformed `commondir` and unshaped `gitdir` fallback targets.
- Harden active workspace state and index-lock holder verification.
- Bound workspace manifest diagnostics and make member-name matching respect filesystem case sensitivity.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-build --filter "FullyQualifiedName~ActiveWorkspaceEnvironment_RelativeDbPath|FullyQualifiedName~ActiveWorkspaceState_ControlCharacterName|FullyQualifiedName~ActiveWorkspaceState_OversizedName|FullyQualifiedName~WorkspaceManifest_EscapingMemberDiagnostic|FullyQualifiedName~WorkspaceManifest_LongMemberPathDiagnostic|FullyQualifiedName~WorkspaceUse_CaseSensitiveMemberSelection|FullyQualifiedName~WorktreeWithMissingGitDirTarget|FullyQualifiedName~WorktreeWithEscapingCommonDir|FullyQualifiedName~WorktreeWithDirectoryCommonDir|FullyQualifiedName~WorktreeWithExistingUnshapedGitDirTarget|FullyQualifiedName~WorktreeWithoutCommonDirAndValidGitDirShape|FullyQualifiedName~WorktreeWithAbsolutePath_ResolvesCommonDir|FullyQualifiedName~WorktreeWithRelativePath_ResolvesCommonDir|FullyQualifiedName~IndexLock_TryReadHolderInfo_WhenProcessDoesNotMatch|FullyQualifiedName~Run_StaleLockFile_ReclaimedWithoutDeletingLockFile|FullyQualifiedName~Run_LockHeldByAnotherHolder_RejectedWithHolderInfo|FullyQualifiedName~NormalizeBoundaryPath_TrimsTrailingSeparators|FullyQualifiedName~IsFullPathEqualOrParent_UsesSeededCaseSensitivity|FullyQualifiedName~FileWriteProbe_TryWriteAndDeleteEmptyFile_DoesNotOverwriteOrDeleteExistingProbe|FullyQualifiedName~FileWriteProbe_TryWriteAndDeleteEmptyFile_RemovesProbeAfterSuccess"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --files ... --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json` reported workspace match; existing graph/fold readiness degradations remain.
- Codex adversarial review found a #3813 `gitdir` fallback gap; fixed with fallback shape validation and regression coverage. A post-fix rerun was attempted, but Codex CLI returned a usage-limit error.

Fixes #3825
Fixes #3805
Fixes #3813
Fixes #3682
Fixes #3777