### PR TITLE
Centralize shared safety policies

### DIFF
--- a/changelog.d/unreleased/3933.security.md
+++ b/changelog.d/unreleased/3933.security.md
@@ -1,0 +1,19 @@
+---
+category: security
+issues:
+  - 3933
+affected:
+  - src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - src/CodeIndex/Cli/GlobalToolLog.cs
+  - tests/CodeIndex.Tests/DiagnosticRedactorTests.cs
+  - tests/CodeIndex.Tests/GlobalToolLogTests.cs
+---
+
+## English
+
+- **Diagnostic redaction policy now backs suggestion and lifecycle log scrubbing (#3933)** — suggestion persistence/GitHub submission redaction and global tool-log argument redaction now share the central sensitive-name and token policy, reducing drift between support diagnostics and locally stored suggestion metadata.
+
+## 日本語
+
+- **診断 redaction policy が suggestion と lifecycle log の秘匿処理を支えるようになりました (#3933)** — suggestion の永続化 / GitHub 投稿前 redaction と global tool log の引数 redaction が中央の sensitive-name / token policy を共有し、サポート診断とローカル suggestion metadata の秘匿ルールのずれを減らします。

--- a/changelog.d/unreleased/3951.security.md
+++ b/changelog.d/unreleased/3951.security.md
@@ -1,0 +1,22 @@
+---
+category: security
+issues:
+  - 3951
+affected:
+  - src/CodeIndex/FileSystemTraversalPolicy.cs
+  - src/CodeIndex/Cli/SolutionProjectResolver.cs
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Cli/DbCommandRunner.cs
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.Discovery.cs
+  - src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
+  - tests/CodeIndex.Tests/FileSystemTraversalPolicyTests.cs
+---
+
+## English
+
+- **Filesystem enumeration now uses an explicit shared traversal policy (#3951)** - solution/project discovery, indexer marker traversal, plugin/hook discovery, checkpoint/backup listing, and import cleanup now route top-directory-only enumeration through one helper with explicit recursion and inaccessible-path behavior.
+
+## 日本語
+
+- **filesystem enumeration が明示的な共有 traversal policy を使うようになりました (#3951)** - solution/project discovery、indexer marker traversal、plugin/hook discovery、checkpoint/backup listing、import cleanup の top-directory-only enumeration が、再帰と inaccessible-path の扱いを明示した単一 helper を経由するようになりました。

--- a/changelog.d/unreleased/3991.security.md
+++ b/changelog.d/unreleased/3991.security.md
@@ -1,0 +1,21 @@
+---
+category: security
+issues:
+  - 3991
+affected:
+  - src/CodeIndex/ProcessLaunchPolicy.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Cli/GitHelper.cs
+  - src/CodeIndex/Indexer/IsolatedWorkerProcessLauncher.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
+  - src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
+  - tests/CodeIndex.Tests/ProcessLaunchPolicyTests.cs
+---
+
+## English
+
+- **Process launch builders now share an explicit no-shell policy (#3991)** — installer, git, symbol-worker, and hook-worker process start info now route through a shared helper for shell use, working directory, redirection, worker UTF-8 encoding, and protocol line-limit arguments.
+
+## 日本語
+
+- **process launch builder が明示的な no-shell policy を共有するようになりました (#3991)** — installer、git、symbol worker、hook worker の process start info が共有 helper を経由し、shell 使用、working directory、redirect、worker の UTF-8 encoding、protocol line-limit 引数の扱いを一箇所に集約しました。

--- a/changelog.d/unreleased/3995.fixed.md
+++ b/changelog.d/unreleased/3995.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 3995
+affected:
+  - src/CodeIndex/FileUriPolicy.cs
+  - src/CodeIndex/Lsp/LspServer.cs
+  - src/CodeIndex/Database/DbConnectionFactory.cs
+  - src/CodeIndex/Cli/DbPathResolver.cs
+  - tests/CodeIndex.Tests/FileUriPolicyTests.cs
+---
+
+## English
+
+- **File URI conversion now uses a shared policy across LSP and SQLite paths (#3995)** — LSP locations, LSP `textDocument.uri` parsing, and SQLite read-only file URI generation now route through one helper so spaces and `#` characters are escaped and decoded consistently.
+
+## 日本語
+
+- **file URI 変換が LSP と SQLite path で共有 policy を使うようになりました (#3995)** — LSP location、LSP `textDocument.uri` の解析、SQLite read-only file URI 生成が同じ helper を経由し、空白や `#` を含む path の escape / decode が一貫するようになりました。

--- a/changelog.d/unreleased/4001.security.md
+++ b/changelog.d/unreleased/4001.security.md
@@ -1,0 +1,20 @@
+---
+category: security
+issues:
+  - 4001
+affected:
+  - src/CodeIndex/Cli/AtomicFileWriter.cs
+  - src/CodeIndex/Cli/PrivateLogFile.cs
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - src/CodeIndex/Cli/DbCommandRunner.cs
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - tests/CodeIndex.Tests/AtomicFileWriterTests.cs
+---
+
+## English
+
+- **Atomic file move, directory publish, and cleanup paths now share explicit policy helpers (#4001)** - log rotation, import replacement rollback, database restore moves, checkpoint publishing, suggestion corrupt-file preservation, and best-effort cleanup now route through shared helpers that make overwrite behavior, long-path normalization, destination mode application, and parent-directory durability checks explicit.
+
+## 日本語
+
+- **atomic file move、directory publish、cleanup 経路が明示的な policy helper を共有するようになりました (#4001)** - log rotation、import replacement rollback、database restore move、checkpoint publishing、suggestion corrupt-file preservation、best-effort cleanup が、overwrite の扱い、long-path normalization、destination mode 適用、parent-directory durability check を明示する共有 helper を経由するようになりました。

--- a/src/CodeIndex/Cli/AtomicFileWriter.cs
+++ b/src/CodeIndex/Cli/AtomicFileWriter.cs
@@ -74,7 +74,6 @@ internal static class AtomicFileWriter
 
         var tempPath = BuildTempPath(path);
         var ioTempPath = LongPath.EnsureWindowsPrefix(tempPath);
-        var ioTargetPath = LongPath.EnsureWindowsPrefix(path);
         var moved = false;
 
         try
@@ -86,14 +85,13 @@ internal static class AtomicFileWriter
                 stream.Flush(flushToDisk: true);
             }
 
-            File.Move(ioTempPath, ioTargetPath, overwrite: true);
+            MoveReplacing(tempPath, path);
             moved = true;
-            FlushParentDirectoryAfterReplace(path);
         }
         catch
         {
             if (!moved)
-                TryDelete(ioTempPath);
+                TryDeleteFile(ioTempPath);
             throw;
         }
     }
@@ -117,7 +115,85 @@ internal static class AtomicFileWriter
     private static Action<string>? ResolveProfileModeCallback(WriteProfile profile)
         => profile == WriteProfile.Sensitive ? DataDirectorySecurity.ApplyPrivateFileMode : null;
 
+    internal static void MoveReplacing(string sourcePath, string destinationPath)
+    {
+        MoveFileCore(sourcePath, destinationPath, overwrite: true, applyDestinationMode: null);
+        FlushParentDirectoryAfterReplace(destinationPath);
+    }
+
+    internal static void MoveFile(
+        string sourcePath,
+        string destinationPath,
+        bool overwrite,
+        Action<string>? applyDestinationMode = null)
+        => MoveFileCore(sourcePath, destinationPath, overwrite, applyDestinationMode);
+
+    internal static void PublishDirectory(string tempDirectoryPath, string destinationDirectoryPath)
+    {
+        Directory.Move(
+            LongPath.EnsureWindowsPrefix(tempDirectoryPath),
+            LongPath.EnsureWindowsPrefix(destinationDirectoryPath));
+        FlushParentDirectoryAfterDirectoryPublish(destinationDirectoryPath);
+    }
+
+    internal static void DeleteFileIfExists(string path)
+    {
+        var ioPath = LongPath.EnsureWindowsPrefix(path);
+        if (File.Exists(ioPath))
+            File.Delete(ioPath);
+    }
+
+    internal static bool TryDeleteFile(
+        string path,
+        Action<Exception>? onCleanupFailure = null,
+        Action<string>? deleteOverride = null)
+    {
+        try
+        {
+            var ioPath = LongPath.EnsureWindowsPrefix(path);
+            if (!File.Exists(ioPath))
+                return false;
+
+            if (deleteOverride != null)
+                deleteOverride(path);
+            else
+                File.Delete(ioPath);
+
+            return true;
+        }
+        catch (Exception ex) when (IsRecoverableFileMutationException(ex))
+        {
+            ReportCleanupFailure(onCleanupFailure, ex);
+            return false;
+        }
+    }
+
+    private static void MoveFileCore(
+        string sourcePath,
+        string destinationPath,
+        bool overwrite,
+        Action<string>? applyDestinationMode)
+    {
+        File.Move(
+            LongPath.EnsureWindowsPrefix(sourcePath),
+            LongPath.EnsureWindowsPrefix(destinationPath),
+            overwrite);
+        applyDestinationMode?.Invoke(destinationPath);
+    }
+
     internal static void FlushParentDirectoryAfterReplace(string path)
+        => FlushParentDirectory(
+            path,
+            "Atomic replace completed",
+            "the target file was already replaced");
+
+    private static void FlushParentDirectoryAfterDirectoryPublish(string path)
+        => FlushParentDirectory(
+            path,
+            "Directory publish completed",
+            "the destination directory was already published");
+
+    private static void FlushParentDirectory(string path, string completedMessage, string completedStateMessage)
     {
         var directory = Path.GetDirectoryName(Path.GetFullPath(path));
         if (string.IsNullOrEmpty(directory))
@@ -131,7 +207,7 @@ internal static class AtomicFileWriter
             }
             catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
             {
-                throw BuildDirectoryFlushException(path, ex);
+                throw BuildDirectoryFlushException(path, completedMessage, completedStateMessage, ex);
             }
             return;
         }
@@ -141,12 +217,12 @@ internal static class AtomicFileWriter
 
         var fd = UnixOpen(directory, flags: 0);
         if (fd < 0)
-            throw BuildDirectoryFlushException(path, Marshal.GetLastPInvokeError());
+            throw BuildDirectoryFlushException(path, completedMessage, completedStateMessage, Marshal.GetLastPInvokeError());
 
         try
         {
             if (UnixFsync(fd) != 0)
-                throw BuildDirectoryFlushException(path, Marshal.GetLastPInvokeError());
+                throw BuildDirectoryFlushException(path, completedMessage, completedStateMessage, Marshal.GetLastPInvokeError());
         }
         finally
         {
@@ -154,11 +230,26 @@ internal static class AtomicFileWriter
         }
     }
 
-    private static IOException BuildDirectoryFlushException(string path, int errno)
-        => new($"Atomic replace completed for {ConsoleUi.FormatBoundedValue(path)}; the target file was already replaced, but the parent directory could not be flushed to disk (errno {errno}).");
+    private static IOException BuildDirectoryFlushException(
+        string path,
+        string completedMessage,
+        string completedStateMessage,
+        int errno)
+        => new($"{completedMessage} for {ConsoleUi.FormatBoundedValue(path)}; {completedStateMessage}, but the parent directory could not be flushed to disk (errno {errno}).");
 
-    private static IOException BuildDirectoryFlushException(string path, Exception inner)
-        => new($"Atomic replace completed for {ConsoleUi.FormatBoundedValue(path)}; the target file was already replaced, but the parent directory could not be flushed to disk ({CommandErrorWriter.FormatSanitizedException(inner)}).", inner);
+    private static IOException BuildDirectoryFlushException(
+        string path,
+        string completedMessage,
+        string completedStateMessage,
+        Exception inner)
+        => new($"{completedMessage} for {ConsoleUi.FormatBoundedValue(path)}; {completedStateMessage}, but the parent directory could not be flushed to disk ({CommandErrorWriter.FormatSanitizedException(inner)}).", inner);
+
+    private static bool IsRecoverableFileMutationException(Exception ex)
+        => ex is IOException
+            or UnauthorizedAccessException
+            or ArgumentException
+            or NotSupportedException
+            or PathTooLongException;
 
     internal static string BuildTempPathForTesting(string path) => BuildTempPath(path);
 
@@ -181,14 +272,18 @@ internal static class AtomicFileWriter
             : Path.Combine(directory, tempFileName);
     }
 
-    private static void TryDelete(string path)
+    private static void ReportCleanupFailure(Action<Exception>? failureSink, Exception exception)
     {
+        if (failureSink is null)
+            return;
+
         try
         {
-            File.Delete(path);
+            failureSink(exception);
         }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        catch
         {
+            // Cleanup diagnostics must not mask the original file mutation result.
         }
     }
 

--- a/src/CodeIndex/Cli/DbCommandRunner.cs
+++ b/src/CodeIndex/Cli/DbCommandRunner.cs
@@ -1173,7 +1173,7 @@ public static class DbCommandRunner
         var directories = new List<string>();
         try
         {
-            foreach (var directory in Directory.EnumerateDirectories(parent, prefix + "*"))
+            foreach (var directory in CodeIndex.FileSystemTraversalPolicy.EnumerateDirectories(parent, prefix + "*"))
             {
                 if (directories.Count >= limit)
                     return (directories, Truncated: true);
@@ -1232,7 +1232,7 @@ public static class DbCommandRunner
         var directories = new List<string>();
         try
         {
-            foreach (var directory in Directory.EnumerateDirectories(root))
+            foreach (var directory in CodeIndex.FileSystemTraversalPolicy.EnumerateDirectories(root))
             {
                 if (directories.Count >= limit)
                     return (directories, Truncated: true);
@@ -1333,7 +1333,7 @@ public static class DbCommandRunner
         var files = new List<string>();
         try
         {
-            foreach (var file in EnumerateCheckpointFilesForTesting?.Invoke(checkpointPath) ?? Directory.EnumerateFiles(checkpointPath))
+            foreach (var file in EnumerateCheckpointFilesForTesting?.Invoke(checkpointPath) ?? CodeIndex.FileSystemTraversalPolicy.EnumerateFiles(checkpointPath))
             {
                 if (files.Count >= limit)
                     return (files, Truncated: true);

--- a/src/CodeIndex/Cli/DbCommandRunner.cs
+++ b/src/CodeIndex/Cli/DbCommandRunner.cs
@@ -1004,7 +1004,7 @@ public static class DbCommandRunner
             CopyIfExists(fullDbPath + "-wal", Path.Combine(tempPath, Path.GetFileName(fullDbPath) + "-wal"), privateDestination: true);
             CopyIfExists(fullDbPath + "-shm", Path.Combine(tempPath, Path.GetFileName(fullDbPath) + "-shm"), privateDestination: true);
             DataDirectorySecurity.WritePrivateText(Path.Combine(tempPath, "manifest.txt"), $"name={name}{Environment.NewLine}created_at_utc={DateTimeOffset.UtcNow:O}{Environment.NewLine}db_file={Path.GetFileName(fullDbPath)}{Environment.NewLine}");
-            Directory.Move(tempPath, checkpointPath);
+            AtomicFileWriter.PublishDirectory(tempPath, checkpointPath);
         }
         catch
         {
@@ -1482,9 +1482,11 @@ public static class DbCommandRunner
         if (!TryGetRegularExistingFile(source, out var normalizedSource))
             return;
 
-        File.Move(normalizedSource, LongPath.EnsureWindowsPrefix(destination), overwrite);
-        if (privateDestination)
-            DataDirectorySecurity.ApplyPrivateFileMode(destination);
+        AtomicFileWriter.MoveFile(
+            normalizedSource,
+            destination,
+            overwrite,
+            privateDestination ? DataDirectorySecurity.ApplyPrivateFileMode : null);
     }
 
     private static bool TryGetRegularExistingFile(string path, out string normalizedPath)

--- a/src/CodeIndex/Cli/DbPathResolver.cs
+++ b/src/CodeIndex/Cli/DbPathResolver.cs
@@ -248,7 +248,7 @@ public static class DbPathResolver
             if (!SqliteFileUri.TryGetPathBeforeQuery(dbPath, out var trimmed, out var boundsError))
                 throw boundsError ?? new FormatException("Invalid SQLite file URI.");
 
-            if (!PathUriNormalizer.TryNormalizeFileUriPath(trimmed, out var normalizedUriPath, out var uriPathError))
+            if (!CodeIndex.FileUriPolicy.TryNormalizeFileUriPath(trimmed, out var normalizedUriPath, out var uriPathError))
                 throw new FormatException(uriPathError ?? "Invalid SQLite file URI path.");
             normalizedDbPath = normalizedUriPath;
             return true;

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -1487,7 +1487,7 @@ internal static class ExportImportCommandRunner
     {
         try
         {
-            if (!Directory.Exists(path) || Directory.EnumerateFileSystemEntries(path).Any())
+            if (!Directory.Exists(path) || CodeIndex.FileSystemTraversalPolicy.HasAnyFileSystemEntry(path))
                 return;
 
             Directory.Delete(path);

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -1320,9 +1320,12 @@ internal static class ExportImportCommandRunner
             AddReplacementBackup(sidecarBackups, fullDbPath + "-shm");
 
             cancellationToken.ThrowIfCancellationRequested();
-            File.Move(tempPath, fullDbPath, overwrite: false);
+            AtomicFileWriter.MoveFile(
+                tempPath,
+                fullDbPath,
+                overwrite: false,
+                applyDestinationMode: ApplyImportedDatabasePrivateFileMode);
             cancellationToken.ThrowIfCancellationRequested();
-            ApplyImportedDatabasePrivateFileMode(fullDbPath);
         }
         catch (OperationCanceledException)
         {
@@ -1421,7 +1424,7 @@ internal static class ExportImportCommandRunner
             return null;
 
         var backupPath = $"{path}.replace-backup-{Guid.NewGuid():N}";
-        File.Move(path, backupPath, overwrite: false);
+        AtomicFileWriter.MoveFile(path, backupPath, overwrite: false);
         return backupPath;
     }
 
@@ -1432,15 +1435,15 @@ internal static class ExportImportCommandRunner
     {
         if (dbBackupPath != null)
         {
-            File.Move(dbBackupPath, fullDbPath, overwrite: true);
+            AtomicFileWriter.MoveReplacing(dbBackupPath, fullDbPath);
         }
         else if (File.Exists(fullDbPath))
         {
-            File.Delete(fullDbPath);
+            AtomicFileWriter.DeleteFileIfExists(fullDbPath);
         }
 
         foreach (var backup in sidecarBackups)
-            File.Move(backup.BackupPath, backup.OriginalPath, overwrite: true);
+            AtomicFileWriter.MoveReplacing(backup.BackupPath, backup.OriginalPath);
     }
 
     private static void DeleteReplacementBackup(string? path, string cleanupDescription, Action<string>? deleteOverride = null)
@@ -1466,15 +1469,14 @@ internal static class ExportImportCommandRunner
     {
         try
         {
-            if (!File.Exists(path))
-                return;
-
-            if (deleteOverride != null)
-                deleteOverride(path);
-            else if (DeleteFileForTesting != null)
-                DeleteFileForTesting(path);
-            else
-                File.Delete(path);
+            _ = AtomicFileWriter.TryDeleteFile(
+                path,
+                ex =>
+                {
+                    if (!string.IsNullOrWhiteSpace(cleanupDescription))
+                        CommandErrorWriter.WriteStderr($"Warning: failed to delete {cleanupDescription} {ConsoleUi.FormatBoundedValue(path)} ({CommandErrorWriter.FormatSanitizedException(ex)}).");
+                },
+                deleteOverride ?? DeleteFileForTesting);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException or PathTooLongException)
         {

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -110,15 +110,12 @@ public static class GitHelper
         if (gitExecutablePath == null)
             return null;
 
-        return new ProcessStartInfo
-        {
-            FileName = gitExecutablePath,
-            WorkingDirectory = projectRoot,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
+        return CodeIndex.ProcessLaunchPolicy.CreateNoShellStartInfo(
+            fileName: gitExecutablePath,
+            workingDirectory: projectRoot,
+            redirectStandardOutput: true,
+            redirectStandardError: true,
+            createNoWindow: true);
     }
 
     private static ProcessStartInfo CreateGitStartInfoOrThrow(string projectRoot)

--- a/src/CodeIndex/Cli/GlobalToolLog.cs
+++ b/src/CodeIndex/Cli/GlobalToolLog.cs
@@ -30,25 +30,8 @@ internal static class GlobalToolLog
     internal const string ExceptionChainTruncationMarker = "...<exception_chain_truncated>";
     private const string RedactedValue = "<redacted>";
     private const int PrivateLogDiagnosticEmitLimit = 16;
-    private static readonly TimeSpan RedactionRegexTimeout = TimeSpan.FromSeconds(1);
     internal static TimeProvider TimeProvider { get; set; } = TimeProvider.System;
     private static readonly AsyncLocal<Session?> CurrentSession = new();
-    private static readonly Regex SensitiveAssignmentPattern = new(
-        @"^(?<name>--?[^=\s]*(?:token|password|passwd|pwd|secret|auth|apikey|api-key|api_key|access-key|access_key|credential)[^=\s]*)=(?<value>.+)$",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
-        RedactionRegexTimeout);
-    private static readonly Regex UriUserInfoPattern = new(
-        @"(?<scheme>[a-z][a-z0-9+\-.]*://)(?<user>[^:@/\s]+):(?<password>[^@/\s]+)@",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
-        RedactionRegexTimeout);
-    private static readonly Regex LongHexPattern = new(
-        @"\b[0-9a-f]{32,}\b",
-        RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
-        RedactionRegexTimeout);
-    private static readonly Regex LongBase64Pattern = new(
-        @"\b[A-Za-z0-9+/]{40,}={0,2}\b",
-        RegexOptions.CultureInvariant | RegexOptions.Compiled,
-        RedactionRegexTimeout);
 
     internal static IDisposable? TryStart(string[] args, string appVersion)
         => TryStart(args, appVersion, createWriter: null, afterWriterCreated: null);
@@ -543,18 +526,7 @@ internal static class GlobalToolLog
         if (!arg.StartsWith('-') || arg.Contains('=', StringComparison.Ordinal))
             return false;
 
-        return arg.Contains("token", StringComparison.OrdinalIgnoreCase)
-            || arg.Contains("password", StringComparison.OrdinalIgnoreCase)
-            || arg.Contains("passwd", StringComparison.OrdinalIgnoreCase)
-            || arg.Contains("pwd", StringComparison.OrdinalIgnoreCase)
-            || arg.Contains("secret", StringComparison.OrdinalIgnoreCase)
-            || arg.Contains("auth", StringComparison.OrdinalIgnoreCase)
-            || arg.Contains("apikey", StringComparison.OrdinalIgnoreCase)
-            || arg.Contains("api-key", StringComparison.OrdinalIgnoreCase)
-            || arg.Contains("api_key", StringComparison.OrdinalIgnoreCase)
-            || arg.Contains("access-key", StringComparison.OrdinalIgnoreCase)
-            || arg.Contains("access_key", StringComparison.OrdinalIgnoreCase)
-            || arg.Contains("credential", StringComparison.OrdinalIgnoreCase);
+        return DiagnosticRedactor.IsSensitiveName(arg);
     }
 
     private static string RedactSensitiveText(string value)
@@ -568,16 +540,7 @@ internal static class GlobalToolLog
 
         try
         {
-            if (value.Contains('=', StringComparison.Ordinal))
-            {
-                var assignment = SensitiveAssignmentPattern.Match(value);
-                if (assignment.Success)
-                    return $"{assignment.Groups["name"].Value}={RedactedValue}";
-            }
-
-            value = UriUserInfoPattern.Replace(value, match => $"{match.Groups["scheme"].Value}{match.Groups["user"].Value}:{RedactedValue}@");
-            value = LongHexPattern.Replace(value, RedactedValue);
-            value = LongBase64Pattern.Replace(value, RedactedValue);
+            value = DiagnosticRedactor.RedactSensitiveText(value, RedactedValue);
         }
         catch (RegexMatchTimeoutException)
         {
@@ -586,8 +549,18 @@ internal static class GlobalToolLog
 
         if (truncated && LooksLikeTruncatedUriUserInfo(value))
             return RedactedValue;
+        if (truncated && IsFullyRedactedSensitiveAssignment(value))
+            return value;
 
         return truncated ? value + RedactionTruncationMarker : value;
+    }
+
+    private static bool IsFullyRedactedSensitiveAssignment(string value)
+    {
+        var separator = value.IndexOf('=');
+        return separator > 0
+            && value[(separator + 1)..].Equals(RedactedValue, StringComparison.Ordinal)
+            && DiagnosticRedactor.IsSensitiveName(value[..separator]);
     }
 
     private static bool LooksLikeTruncatedUriUserInfo(string value)

--- a/src/CodeIndex/Cli/PrivateLogFile.cs
+++ b/src/CodeIndex/Cli/PrivateLogFile.cs
@@ -195,7 +195,7 @@ internal static class PrivateLogFile
     {
         try
         {
-            SafeDelete(SlotPath(path, retainedFileCount - 1), onCleanupFailure);
+            AtomicFileWriter.TryDeleteFile(SlotPath(path, retainedFileCount - 1), onCleanupFailure);
 
             for (var slot = retainedFileCount - 2; slot >= 1; slot--)
             {
@@ -203,14 +203,14 @@ internal static class PrivateLogFile
                 var next = SlotPath(path, slot + 1);
                 if (!File.Exists(LongPath.EnsureWindowsPrefix(current)))
                     continue;
-                MoveReplacing(current, next);
+                AtomicFileWriter.MoveReplacing(current, next);
                 afterMove?.Invoke(next);
             }
 
             if (File.Exists(LongPath.EnsureWindowsPrefix(path)))
             {
                 var first = SlotPath(path, 1);
-                MoveReplacing(path, first);
+                AtomicFileWriter.MoveReplacing(path, first);
                 afterMove?.Invoke(first);
             }
 
@@ -225,26 +225,6 @@ internal static class PrivateLogFile
 
     private static string SlotPath(string path, int slot)
         => slot <= 0 ? path : path + "." + slot.ToString(System.Globalization.CultureInfo.InvariantCulture);
-
-    private static void MoveReplacing(string sourcePath, string destinationPath)
-    {
-        File.Move(LongPath.EnsureWindowsPrefix(sourcePath), LongPath.EnsureWindowsPrefix(destinationPath), overwrite: true);
-        AtomicFileWriter.FlushParentDirectoryAfterReplace(destinationPath);
-    }
-
-    private static void SafeDelete(string path, Action<Exception>? onCleanupFailure = null)
-    {
-        try
-        {
-            if (File.Exists(path))
-                File.Delete(path);
-        }
-        catch (Exception ex)
-        {
-            ReportFailure(onCleanupFailure, ex);
-            // Ignore: rotation is best-effort.
-        }
-    }
 
     private static void ReportFailure(Action<Exception>? failureSink, Exception exception)
     {

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -3318,14 +3318,10 @@ internal static partial class ProgramRunner
     internal static ProcessStartInfo CreateInstallerProcessStartInfo(string scriptPath, string releaseTag, string installDir)
     {
         var fullScriptPath = Path.GetFullPath(scriptPath);
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = ResolveTrustedBashPath(),
-            UseShellExecute = false,
-            WorkingDirectory = Path.GetDirectoryName(fullScriptPath) ?? string.Empty,
-        };
-        startInfo.ArgumentList.Add(fullScriptPath);
-        startInfo.ArgumentList.Add(releaseTag);
+        var startInfo = CodeIndex.ProcessLaunchPolicy.CreateNoShellStartInfo(
+            fileName: ResolveTrustedBashPath(),
+            workingDirectory: Path.GetDirectoryName(fullScriptPath) ?? string.Empty);
+        CodeIndex.ProcessLaunchPolicy.AddArguments(startInfo, fullScriptPath, releaseTag);
         startInfo.Environment["CDIDX_INSTALL_DIR"] = installDir;
         return startInfo;
     }

--- a/src/CodeIndex/Cli/SolutionProjectResolver.cs
+++ b/src/CodeIndex/Cli/SolutionProjectResolver.cs
@@ -219,10 +219,9 @@ internal static class SolutionProjectResolver
         IEnumerable<string> solutionEntries;
         try
         {
-            solutionEntries = Directory.EnumerateFiles(
+            solutionEntries = CodeIndex.FileSystemTraversalPolicy.EnumerateFiles(
                 LongPath.EnsureWindowsPrefix(workspaceRoot),
-                "*.sln",
-                SearchOption.TopDirectoryOnly);
+                "*.sln");
         }
         catch (Exception ex) when (IsExpectedFilesystemDiscoveryException(ex))
         {
@@ -478,7 +477,7 @@ internal static class SolutionProjectResolver
             directory,
             "subdirectories",
             ProjectTraversalEntryKind.Directory,
-            EnumerateDirectoriesForTesting ?? Directory.EnumerateDirectories,
+            EnumerateDirectoriesForTesting ?? (directory => CodeIndex.FileSystemTraversalPolicy.EnumerateDirectories(directory)),
             limits,
             budget,
             traversalDiagnostics);
@@ -494,7 +493,7 @@ internal static class SolutionProjectResolver
             directory,
             "files",
             ProjectTraversalEntryKind.File,
-            EnumerateFilesForTesting ?? Directory.EnumerateFiles,
+            EnumerateFilesForTesting ?? (directory => CodeIndex.FileSystemTraversalPolicy.EnumerateFiles(directory)),
             limits,
             budget,
             traversalDiagnostics);

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -3,7 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
+using CodeIndex.Diagnostics;
 using CodeIndex.Indexer;
 using CodeIndex.Models;
 
@@ -41,18 +41,8 @@ public class SuggestionStore
     internal const int MaximumMaxCount = 100_000;
     internal const int MaxSuggestionStoreRecords = MaximumMaxCount;
     private const int FuzzyDedupRecentLimit = 100;
-    private const string RedactedAwsAccessKey = "[REDACTED:aws_access_key]";
-    private const string RedactedBearerToken = "[REDACTED:bearer_token]";
-    private const string RedactedCredential = "[REDACTED:credential]";
-    private const string RedactedHighEntropyToken = "[REDACTED:high_entropy_token]";
-    private const string RedactedRegexTimeout = "[REDACTED:redaction_timeout]";
-    internal const int RedactionFieldLengthLimit = 32768;
-    internal const string RedactionTruncationMarker = "[REDACTED:truncated]";
-    private static readonly TimeSpan RedactionRegexTimeout = TimeSpan.FromSeconds(1);
-    private static readonly Regex s_awsAccessKeyRegex = new(@"\bAKIA[0-9A-Z]{16}\b", RegexOptions.Compiled | RegexOptions.CultureInvariant, RedactionRegexTimeout);
-    private static readonly Regex s_bearerTokenRegex = new(@"\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b", RegexOptions.Compiled | RegexOptions.CultureInvariant, RedactionRegexTimeout);
-    private static readonly Regex s_namedSecretRegex = new(@"(?i)(^|[^\p{L}\p{N}_-])(?<name>[\p{L}\p{N}_-]*(?:password|passwd|pwd|secret|token|api[-_]?key|access[-_]?key|credential)[\p{L}\p{N}_-]*)=(?<value>[^&\s]+)", RegexOptions.Compiled | RegexOptions.CultureInvariant, RedactionRegexTimeout);
-    private static readonly Regex s_highEntropyTokenRegex = new(@"\b(?=[A-Za-z0-9._~+/=-]{32,}\b)(?=.*[A-Z])(?=.*[a-z])(?=.*\d)[A-Za-z0-9._~+/=-]+\b", RegexOptions.Compiled | RegexOptions.CultureInvariant, RedactionRegexTimeout);
+    internal const int RedactionFieldLengthLimit = DiagnosticRedactor.SuggestionRedactionFieldLengthLimit;
+    internal const string RedactionTruncationMarker = DiagnosticRedactor.SuggestionRedactionTruncationMarker;
 
     internal sealed record ArchiveBuildResult(
         IReadOnlyList<byte[]> Lines,
@@ -1075,51 +1065,7 @@ public class SuggestionStore
     };
 
     internal static string RedactSensitiveText(string text, out IReadOnlyCollection<string> redactedTypes)
-    {
-        var types = new SortedSet<string>(StringComparer.Ordinal);
-        var truncated = false;
-        if (text.Length > RedactionFieldLengthLimit)
-        {
-            text = text[..RedactionFieldLengthLimit];
-            truncated = true;
-            types.Add("truncated");
-        }
-
-        try
-        {
-            var redacted = s_awsAccessKeyRegex.Replace(text, match =>
-            {
-                types.Add("aws_access_key");
-                return RedactedAwsAccessKey;
-            });
-            redacted = s_bearerTokenRegex.Replace(redacted, match =>
-            {
-                types.Add("bearer_token");
-                return RedactedBearerToken;
-            });
-            redacted = s_namedSecretRegex.Replace(redacted, match =>
-            {
-                types.Add("credential");
-                return $"{match.Groups[1].Value}{match.Groups["name"].Value}={RedactedCredential}";
-            });
-            redacted = s_highEntropyTokenRegex.Replace(redacted, match =>
-            {
-                if (match.Value.StartsWith("[REDACTED:", StringComparison.Ordinal))
-                    return match.Value;
-                types.Add("high_entropy_token");
-                return RedactedHighEntropyToken;
-            });
-
-            redactedTypes = types;
-            return truncated ? redacted + RedactionTruncationMarker : redacted;
-        }
-        catch (RegexMatchTimeoutException)
-        {
-            types.Add("redaction_timeout");
-            redactedTypes = types;
-            return RedactedRegexTimeout;
-        }
-    }
+        => DiagnosticRedactor.RedactSuggestionText(text, out redactedTypes);
 
     private static SuggestionRecord RedactRecordForPersistence(SuggestionRecord record)
     {

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -1236,8 +1236,11 @@ public class SuggestionStore
             var backupPath = GetCorruptBackupPath();
             if (File.Exists(LongPath.EnsureWindowsPrefix(_filePath)))
             {
-                File.Move(LongPath.EnsureWindowsPrefix(_filePath), LongPath.EnsureWindowsPrefix(backupPath), overwrite: false);
-                DataDirectorySecurity.ApplyPrivateFileMode(backupPath);
+                AtomicFileWriter.MoveFile(
+                    _filePath,
+                    backupPath,
+                    overwrite: false,
+                    applyDestinationMode: DataDirectorySecurity.ApplyPrivateFileMode);
             }
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)

--- a/src/CodeIndex/Database/DbConnectionFactory.cs
+++ b/src/CodeIndex/Database/DbConnectionFactory.cs
@@ -95,7 +95,7 @@ internal static class DbConnectionFactory
             return AppendReadOnlyQuery(dbPath);
         }
 
-        var fileUri = new Uri(Path.GetFullPath(dbPath)).AbsoluteUri;
+        var fileUri = CodeIndex.FileUriPolicy.PathToFileUri(dbPath);
         return $"{fileUri}?immutable=1&mode=ro";
     }
 
@@ -122,14 +122,19 @@ internal static class DbConnectionFactory
                 return false;
             }
 
-            var uri = new Uri(trimmed);
-            if (!uri.IsFile)
+            if (!Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) || !uri.IsFile)
             {
                 failureReason = FileUriNotLocalFileReason;
                 return false;
             }
 
-            localPath = uri.LocalPath;
+            if (!CodeIndex.FileUriPolicy.TryNormalizeFileUriPath(trimmed, out var normalizedPath, out _))
+            {
+                failureReason = FileUriPathParseFailedReason;
+                return false;
+            }
+
+            localPath = normalizedPath;
             return true;
         }
         catch (UriFormatException)
@@ -194,7 +199,7 @@ internal static class DbConnectionFactory
             // kept explicit so cdidx's intent is visible in logs / traces.
             // builder は DataSource を quote して URI 解釈を壊すため直接組む。
             // Uri.AbsoluteUri が全ての危険文字を %-エンコードするので raw 連結でも injection 安全。
-            var fileUri = new Uri(Path.GetFullPath(dbPath)).AbsoluteUri; // e.g. file:///abs/path.db
+            var fileUri = CodeIndex.FileUriPolicy.PathToFileUri(dbPath); // e.g. file:///abs/path.db
             var rawConnStr = $"Data Source={fileUri}?immutable=1;Mode=ReadOnly";
             var conn = new SqliteConnection(rawConnStr);
             conn.Open();

--- a/src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
+++ b/src/CodeIndex/Diagnostics/DiagnosticRedactor.cs
@@ -10,6 +10,13 @@ internal static class DiagnosticRedactor
 {
     internal const int DefaultDiagnosticValueCharLimit = 120;
     internal const string AngleRedacted = "<redacted>";
+    internal const string SuggestionRedactedAwsAccessKey = "[REDACTED:aws_access_key]";
+    internal const string SuggestionRedactedBearerToken = "[REDACTED:bearer_token]";
+    internal const string SuggestionRedactedCredential = "[REDACTED:credential]";
+    internal const string SuggestionRedactedHighEntropyToken = "[REDACTED:high_entropy_token]";
+    internal const string SuggestionRedactedRegexTimeout = "[REDACTED:redaction_timeout]";
+    internal const int SuggestionRedactionFieldLengthLimit = 32768;
+    internal const string SuggestionRedactionTruncationMarker = "[REDACTED:truncated]";
     internal const int MaxReportLogJsonLineChars = 64 * 1024;
     internal const int MaxReportLogJsonDepth = 32;
 
@@ -29,9 +36,19 @@ internal static class DiagnosticRedactor
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
         RegexTimeout);
 
+    private static readonly Regex SuggestionBearerTokenPattern = new(
+        @"\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
     private static readonly Regex SensitiveAssignmentPattern = new(
         @"(?<![\w.-])(?<name>--?[\w.-]*(?:token|password|passwd|pwd|secret|auth|apikey|api-key|api_key|access-key|access_key|credential)[\w.-]*)(?<sep>=|:)(?<value>[^\s,;]+)",
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
+    private static readonly Regex SuggestionNamedSecretPattern = new(
+        @"(?i)(^|[^\p{L}\p{N}_-])(?<name>[\p{L}\p{N}_-]*(?:password|passwd|pwd|secret|token|api[-_]?key|access[-_]?key|credential)[\p{L}\p{N}_-]*)=(?<value>[^&\s]+)",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant,
         RegexTimeout);
 
     private static readonly Regex SensitiveSeparatedArgumentPattern = new(
@@ -39,8 +56,18 @@ internal static class DiagnosticRedactor
         RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled,
         RegexTimeout);
 
+    private static readonly Regex AwsAccessKeyPattern = new(
+        @"\bAKIA[0-9A-Z]{16}\b",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
     private static readonly Regex GitHubTokenPattern = new(
         @"\b(?:ghp|gho|ghu|ghs|ghr|github_pat)_[A-Za-z0-9_]{20,}\b",
+        RegexOptions.CultureInvariant | RegexOptions.Compiled,
+        RegexTimeout);
+
+    private static readonly Regex HighEntropyTokenPattern = new(
+        @"\b(?=[A-Za-z0-9._~+/=-]{32,}\b)(?=.*[A-Z])(?=.*[a-z])(?=.*\d)[A-Za-z0-9._~+/=-]+\b",
         RegexOptions.CultureInvariant | RegexOptions.Compiled,
         RegexTimeout);
 
@@ -200,6 +227,53 @@ internal static class DiagnosticRedactor
         return redacted;
     }
 
+    internal static string RedactSuggestionText(string text, out IReadOnlyCollection<string> redactedTypes)
+    {
+        var types = new SortedSet<string>(StringComparer.Ordinal);
+        var truncated = false;
+        if (text.Length > SuggestionRedactionFieldLengthLimit)
+        {
+            text = text[..SuggestionRedactionFieldLengthLimit];
+            truncated = true;
+            types.Add("truncated");
+        }
+
+        try
+        {
+            var redacted = AwsAccessKeyPattern.Replace(text, _ =>
+            {
+                types.Add("aws_access_key");
+                return SuggestionRedactedAwsAccessKey;
+            });
+            redacted = SuggestionBearerTokenPattern.Replace(redacted, _ =>
+            {
+                types.Add("bearer_token");
+                return SuggestionRedactedBearerToken;
+            });
+            redacted = SuggestionNamedSecretPattern.Replace(redacted, match =>
+            {
+                types.Add("credential");
+                return $"{match.Groups[1].Value}{match.Groups["name"].Value}={SuggestionRedactedCredential}";
+            });
+            redacted = HighEntropyTokenPattern.Replace(redacted, match =>
+            {
+                if (match.Value.StartsWith("[REDACTED:", StringComparison.Ordinal))
+                    return match.Value;
+                types.Add("high_entropy_token");
+                return SuggestionRedactedHighEntropyToken;
+            });
+
+            redactedTypes = types;
+            return truncated ? redacted + SuggestionRedactionTruncationMarker : redacted;
+        }
+        catch (RegexMatchTimeoutException)
+        {
+            types.Add("redaction_timeout");
+            redactedTypes = types;
+            return SuggestionRedactedRegexTimeout;
+        }
+    }
+
     internal static string BoundDiagnosticText(string? value, int maxChars = DefaultDiagnosticValueCharLimit)
     {
         if (maxChars < 0)
@@ -218,7 +292,7 @@ internal static class DiagnosticRedactor
             : flattened[..maxChars] + marker;
     }
 
-    private static bool IsSensitiveName(string? name) =>
+    internal static bool IsSensitiveName(string? name) =>
         !string.IsNullOrWhiteSpace(name)
         && (name.Contains("token", StringComparison.OrdinalIgnoreCase)
             || name.Contains("password", StringComparison.OrdinalIgnoreCase)

--- a/src/CodeIndex/FileSystemTraversalPolicy.cs
+++ b/src/CodeIndex/FileSystemTraversalPolicy.cs
@@ -1,0 +1,27 @@
+namespace CodeIndex;
+
+internal static class FileSystemTraversalPolicy
+{
+    internal static EnumerationOptions CreateTopDirectoryOnlyOptions() => new()
+    {
+        RecurseSubdirectories = false,
+        IgnoreInaccessible = false,
+        ReturnSpecialDirectories = false,
+        AttributesToSkip = 0,
+    };
+
+    internal static IEnumerable<string> EnumerateFiles(string directory, string searchPattern = "*")
+        => Directory.EnumerateFiles(directory, searchPattern, CreateTopDirectoryOnlyOptions());
+
+    internal static IEnumerable<string> EnumerateDirectories(string directory, string searchPattern = "*")
+        => Directory.EnumerateDirectories(directory, searchPattern, CreateTopDirectoryOnlyOptions());
+
+    internal static IEnumerable<string> EnumerateFileSystemEntries(string directory, string searchPattern = "*")
+        => Directory.EnumerateFileSystemEntries(directory, searchPattern, CreateTopDirectoryOnlyOptions());
+
+    internal static bool HasAnyFileSystemEntry(string directory)
+    {
+        using var enumerator = EnumerateFileSystemEntries(directory).GetEnumerator();
+        return enumerator.MoveNext();
+    }
+}

--- a/src/CodeIndex/FileUriPolicy.cs
+++ b/src/CodeIndex/FileUriPolicy.cs
@@ -1,0 +1,46 @@
+namespace CodeIndex;
+
+internal static class FileUriPolicy
+{
+    internal const string AbsoluteFileUriRequiredMessage = "textDocument.uri must be an absolute file URI.";
+
+    internal static string PathToFileUri(string path, string? baseDirectory = null)
+    {
+        var fullPath = Path.IsPathRooted(path)
+            ? Path.GetFullPath(path)
+            : Path.GetFullPath(path, baseDirectory ?? Environment.CurrentDirectory);
+        return new Uri(fullPath).AbsoluteUri;
+    }
+
+    internal static string AbsoluteFileUriToPath(string uriText, string errorMessage = AbsoluteFileUriRequiredMessage)
+    {
+        if (TryGetAbsoluteFileUriPath(uriText, out var localPath, out var error))
+            return localPath;
+
+        throw new ArgumentException(error ?? errorMessage);
+    }
+
+    internal static bool TryGetAbsoluteFileUriPath(string uriText, out string localPath, out string? error)
+    {
+        localPath = string.Empty;
+        error = null;
+        if (!uriText.StartsWith("file://", StringComparison.OrdinalIgnoreCase) ||
+            !Uri.TryCreate(uriText, UriKind.Absolute, out var parsed) ||
+            !parsed.IsFile)
+        {
+            error = AbsoluteFileUriRequiredMessage;
+            return false;
+        }
+
+        if (!PathUriNormalizer.TryNormalizeFileUriPath(uriText, out localPath, out error))
+        {
+            error ??= AbsoluteFileUriRequiredMessage;
+            return false;
+        }
+
+        return true;
+    }
+
+    internal static bool TryNormalizeFileUriPath(string fileUri, out string normalizedPath, out string? error)
+        => PathUriNormalizer.TryNormalizeFileUriPath(fileUri, out normalizedPath, out error);
+}

--- a/src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.Discovery.cs
+++ b/src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.Discovery.cs
@@ -51,7 +51,7 @@ public static partial class ExtractorPluginRegistry
     {
         try
         {
-            return Directory.EnumerateFiles(directory, "*.dll", SearchOption.TopDirectoryOnly).GetEnumerator();
+            return CodeIndex.FileSystemTraversalPolicy.EnumerateFiles(directory, "*.dll").GetEnumerator();
         }
         catch (Exception ex) when (ExtensionDiscoveryDiagnosticClassifier.IsDiscoveryException(ex))
         {
@@ -193,7 +193,7 @@ public static partial class ExtractorPluginRegistry
     {
         try
         {
-            return Directory.EnumerateFiles(directory, searchPattern, SearchOption.TopDirectoryOnly).GetEnumerator();
+            return CodeIndex.FileSystemTraversalPolicy.EnumerateFiles(directory, searchPattern).GetEnumerator();
         }
         catch (Exception ex) when (ExtensionDiscoveryDiagnosticClassifier.IsDiscoveryException(ex))
         {

--- a/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
+++ b/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
@@ -456,7 +456,7 @@ internal static class PostExtractionHookCallbackWorker
             startInfo.ArgumentList.Add(CommandName);
             startInfo.ArgumentList.Add(hook.AssemblyPath);
             startInfo.ArgumentList.Add(hook.TypeName);
-            AddProtocolLineLimitArguments(startInfo, maxProtocolLineBytes);
+            CodeIndex.ProcessLaunchPolicy.AddInvariantIntArgument(startInfo, ProtocolMaxLineBytesOption, maxProtocolLineBytes);
             error = string.Empty;
             return true;
         }
@@ -477,7 +477,7 @@ internal static class PostExtractionHookCallbackWorker
         startInfo.ArgumentList.Add(CommandName);
         startInfo.ArgumentList.Add(hook.AssemblyPath);
         startInfo.ArgumentList.Add(hook.TypeName);
-        AddProtocolLineLimitArguments(startInfo, maxProtocolLineBytes);
+        CodeIndex.ProcessLaunchPolicy.AddInvariantIntArgument(startInfo, ProtocolMaxLineBytesOption, maxProtocolLineBytes);
 
         error = string.Empty;
         return true;
@@ -647,12 +647,6 @@ internal static class PostExtractionHookCallbackWorker
 
         items.RemoveRange(limit, items.Count - limit);
         return true;
-    }
-
-    private static void AddProtocolLineLimitArguments(ProcessStartInfo startInfo, int maxProtocolLineBytes)
-    {
-        startInfo.ArgumentList.Add(ProtocolMaxLineBytesOption);
-        startInfo.ArgumentList.Add(maxProtocolLineBytes.ToString(CultureInfo.InvariantCulture));
     }
 
     private static bool TryResolveProtocolLineLimit(

--- a/src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
+++ b/src/CodeIndex/Indexer/Hooks/PostExtractionHooks.cs
@@ -270,7 +270,7 @@ public sealed class PostExtractionHookRunner : IDisposable
     {
         try
         {
-            return Directory.EnumerateFiles(hooksDirectory, "*.dll", SearchOption.TopDirectoryOnly).GetEnumerator();
+            return CodeIndex.FileSystemTraversalPolicy.EnumerateFiles(hooksDirectory, "*.dll").GetEnumerator();
         }
         catch (Exception ex) when (ExtensionDiscoveryDiagnosticClassifier.IsDiscoveryException(ex))
         {

--- a/src/CodeIndex/Indexer/IsolatedWorkerProcessLauncher.cs
+++ b/src/CodeIndex/Indexer/IsolatedWorkerProcessLauncher.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Reflection;
 using System.Runtime.Versioning;
-using System.Text;
 
 namespace CodeIndex.Indexer;
 
@@ -9,17 +8,7 @@ internal static class IsolatedWorkerProcessLauncher
 {
     internal static ProcessStartInfo CreateStartInfo()
     {
-        var startInfo = new ProcessStartInfo
-        {
-            UseShellExecute = false,
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            StandardInputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
-            StandardOutputEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
-            StandardErrorEncoding = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false),
-            CreateNoWindow = true,
-        };
+        var startInfo = CodeIndex.ProcessLaunchPolicy.CreateUtf8RedirectedWorkerStartInfo();
         ApplyEnvironmentAllowlist(startInfo);
         return startInfo;
     }

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -1039,7 +1039,7 @@ public class FileIndexer
         _ancestorIgnoreDirectories = BuildAncestorIgnoreDirectories(_ignoreRuleRoot, _projectRoot);
         _ignoreCase = ignoreCase;
         _directoryIgnoreCaseProbe = directoryIgnoreCaseProbe ?? ProbeExistingDirectoryIgnoreCase;
-        _enumerateFiles = enumerateFiles ?? (dir => Directory.EnumerateFiles(LongPath.EnsureWindowsPrefix(dir)));
+        _enumerateFiles = enumerateFiles ?? (dir => CodeIndex.FileSystemTraversalPolicy.EnumerateFiles(LongPath.EnsureWindowsPrefix(dir)));
         _directoryIgnoreCaseCache = new Dictionary<string, bool>(StringComparer.Ordinal);
         _maxFileSizeBytes = ResolveMaxFileSizeBytes(maxFileSizeBytes);
         _contentLoader = new FileContentLoader(_maxFileSizeBytes);
@@ -1873,7 +1873,7 @@ public class FileIndexer
         var prefixedDir = LongPath.EnsureWindowsPrefix(dir);
         foreach (var pattern in patterns)
         {
-            foreach (var file in Directory.EnumerateFiles(prefixedDir, pattern, SearchOption.TopDirectoryOnly))
+            foreach (var file in CodeIndex.FileSystemTraversalPolicy.EnumerateFiles(prefixedDir, pattern))
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 yield return LongPath.RemoveWindowsPrefix(file);
@@ -2018,7 +2018,7 @@ public class FileIndexer
     private static IEnumerable<string> EnumerateProjectMarkerDirectories(string dir)
         => EnumerateProjectMarkerDirectoriesForTesting is { } enumerate
             ? enumerate(dir)
-            : Directory.EnumerateDirectories(LongPath.EnsureWindowsPrefix(dir));
+            : CodeIndex.FileSystemTraversalPolicy.EnumerateDirectories(LongPath.EnsureWindowsPrefix(dir));
 
     private void AddProjectMarkerTraversalWarning(List<ScanError> errors, string directory, string exceptionType)
     {
@@ -2610,7 +2610,7 @@ public class FileIndexer
     {
         var candidateLimit = _maxDanglingFileSystemEntryScanCandidates;
         var candidateCount = 0;
-        foreach (var enumeratedEntry in Directory.EnumerateFileSystemEntries(LongPath.EnsureWindowsPrefix(dir)))
+        foreach (var enumeratedEntry in CodeIndex.FileSystemTraversalPolicy.EnumerateFileSystemEntries(LongPath.EnsureWindowsPrefix(dir)))
         {
             cancellationToken.ThrowIfCancellationRequested();
             candidateCount++;
@@ -2681,7 +2681,7 @@ public class FileIndexer
         int depth)
     {
         var fullyScanned = true;
-        foreach (var enumeratedSubDir in Directory.EnumerateDirectories(LongPath.EnsureWindowsPrefix(dir)))
+        foreach (var enumeratedSubDir in CodeIndex.FileSystemTraversalPolicy.EnumerateDirectories(LongPath.EnsureWindowsPrefix(dir)))
         {
             cancellationToken.ThrowIfCancellationRequested();
             var subDir = LongPath.RemoveWindowsPrefix(enumeratedSubDir);
@@ -3199,8 +3199,7 @@ public class FileIndexer
 
         try
         {
-            using var enumerator = Directory.EnumerateFileSystemEntries(LongPath.EnsureWindowsPrefix(dir)).GetEnumerator();
-            _ = enumerator.MoveNext();
+            _ = CodeIndex.FileSystemTraversalPolicy.HasAnyFileSystemEntry(LongPath.EnsureWindowsPrefix(dir));
             reason = string.Empty;
             return true;
         }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
@@ -454,7 +454,7 @@ internal static class SymbolExtractionWorker
         {
             startInfo.FileName = currentProcessPath!;
             startInfo.ArgumentList.Add(CommandName);
-            AddProtocolLineLimitArguments(startInfo, maxProtocolLineBytes);
+            CodeIndex.ProcessLaunchPolicy.AddInvariantIntArgument(startInfo, ProtocolMaxLineBytesOption, maxProtocolLineBytes);
             AddTestingArguments(startInfo);
             error = string.Empty;
             return true;
@@ -474,7 +474,7 @@ internal static class SymbolExtractionWorker
         }
 
         startInfo.ArgumentList.Add(CommandName);
-        AddProtocolLineLimitArguments(startInfo, maxProtocolLineBytes);
+        CodeIndex.ProcessLaunchPolicy.AddInvariantIntArgument(startInfo, ProtocolMaxLineBytesOption, maxProtocolLineBytes);
         AddTestingArguments(startInfo);
 
         error = string.Empty;
@@ -646,12 +646,6 @@ internal static class SymbolExtractionWorker
 
         if (cancellationToken.WaitHandle.WaitOne(milliseconds))
             cancellationToken.ThrowIfCancellationRequested();
-    }
-
-    private static void AddProtocolLineLimitArguments(ProcessStartInfo startInfo, int maxProtocolLineBytes)
-    {
-        startInfo.ArgumentList.Add(ProtocolMaxLineBytesOption);
-        startInfo.ArgumentList.Add(maxProtocolLineBytes.ToString(CultureInfo.InvariantCulture));
     }
 
     private static void AddTestingArguments(ProcessStartInfo startInfo)

--- a/src/CodeIndex/Lsp/LspServer.cs
+++ b/src/CodeIndex/Lsp/LspServer.cs
@@ -1869,19 +1869,10 @@ internal sealed class LspServer : IDisposable
     }
 
     internal static string PathToUri(string path, string? projectRoot = null)
-    {
-        var fullPath = Path.IsPathRooted(path)
-            ? Path.GetFullPath(path)
-            : Path.GetFullPath(path, projectRoot ?? Environment.CurrentDirectory);
-        return new Uri(fullPath).AbsoluteUri;
-    }
+        => CodeIndex.FileUriPolicy.PathToFileUri(path, projectRoot);
 
     internal static string UriToPath(string uri)
-    {
-        if (!Uri.TryCreate(uri, UriKind.Absolute, out var parsed) || !parsed.IsFile)
-            throw new ArgumentException("textDocument.uri must be an absolute file URI.");
-        return parsed.LocalPath;
-    }
+        => CodeIndex.FileUriPolicy.AbsoluteFileUriToPath(uri);
 
     private void CaptureInitializeWorkspaceFolders(JsonElement root)
     {

--- a/src/CodeIndex/ProcessLaunchPolicy.cs
+++ b/src/CodeIndex/ProcessLaunchPolicy.cs
@@ -1,0 +1,57 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+
+namespace CodeIndex;
+
+internal static class ProcessLaunchPolicy
+{
+    internal static ProcessStartInfo CreateNoShellStartInfo(
+        string? fileName = null,
+        string? workingDirectory = null,
+        bool redirectStandardInput = false,
+        bool redirectStandardOutput = false,
+        bool redirectStandardError = false,
+        bool createNoWindow = false)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            UseShellExecute = false,
+            RedirectStandardInput = redirectStandardInput,
+            RedirectStandardOutput = redirectStandardOutput,
+            RedirectStandardError = redirectStandardError,
+            CreateNoWindow = createNoWindow,
+        };
+        if (!string.IsNullOrEmpty(fileName))
+            startInfo.FileName = fileName;
+        if (workingDirectory != null)
+            startInfo.WorkingDirectory = workingDirectory;
+        return startInfo;
+    }
+
+    internal static ProcessStartInfo CreateUtf8RedirectedWorkerStartInfo()
+    {
+        var utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+        var startInfo = CreateNoShellStartInfo(
+            redirectStandardInput: true,
+            redirectStandardOutput: true,
+            redirectStandardError: true,
+            createNoWindow: true);
+        startInfo.StandardInputEncoding = utf8NoBom;
+        startInfo.StandardOutputEncoding = utf8NoBom;
+        startInfo.StandardErrorEncoding = utf8NoBom;
+        return startInfo;
+    }
+
+    internal static void AddArguments(ProcessStartInfo startInfo, params string[] args)
+    {
+        foreach (var arg in args)
+            startInfo.ArgumentList.Add(arg);
+    }
+
+    internal static void AddInvariantIntArgument(ProcessStartInfo startInfo, string optionName, int value)
+    {
+        startInfo.ArgumentList.Add(optionName);
+        startInfo.ArgumentList.Add(value.ToString(CultureInfo.InvariantCulture));
+    }
+}

--- a/tests/CodeIndex.Tests/AtomicFileWriterTests.cs
+++ b/tests/CodeIndex.Tests/AtomicFileWriterTests.cs
@@ -87,6 +87,115 @@ public class AtomicFileWriterTests
     }
 
     [Fact]
+    public void MoveReplacing_ParentDirectoryFlushFailure_ReportsPostReplaceDurabilityFailure_Issue4001()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("atomic_move_replace_flush");
+        try
+        {
+            var sourcePath = Path.Combine(projectRoot, "settings.new");
+            var destinationPath = Path.Combine(projectRoot, "settings.json");
+            File.WriteAllText(sourcePath, "new", Utf8NoBom);
+            File.WriteAllText(destinationPath, "old", Utf8NoBom);
+            AtomicFileWriter.FlushParentDirectoryForTesting = _ => throw new IOException("flush failed");
+
+            var ex = Assert.Throws<IOException>(() =>
+                AtomicFileWriter.MoveReplacing(sourcePath, destinationPath));
+
+            Assert.Contains("Atomic replace completed", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("target file was already replaced", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("parent directory could not be flushed", ex.Message, StringComparison.Ordinal);
+            Assert.False(File.Exists(sourcePath));
+            Assert.Equal("new", File.ReadAllText(destinationPath, Utf8NoBom));
+        }
+        finally
+        {
+            AtomicFileWriter.FlushParentDirectoryForTesting = null;
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void MoveFile_AppliesDestinationModeAfterMove_Issue4001()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("atomic_move_mode");
+        try
+        {
+            var sourcePath = Path.Combine(projectRoot, "source.db");
+            var destinationPath = Path.Combine(projectRoot, "destination.db");
+            string? modePath = null;
+            File.WriteAllText(sourcePath, "db", Utf8NoBom);
+
+            AtomicFileWriter.MoveFile(
+                sourcePath,
+                destinationPath,
+                overwrite: false,
+                applyDestinationMode: path => modePath = path);
+
+            Assert.False(File.Exists(sourcePath));
+            Assert.Equal("db", File.ReadAllText(destinationPath, Utf8NoBom));
+            Assert.Equal(destinationPath, modePath);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void PublishDirectory_ParentDirectoryFlushFailure_ReportsPublishedDirectory_Issue4001()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("atomic_directory_publish_flush");
+        try
+        {
+            var tempPath = Path.Combine(projectRoot, ".tmp-checkpoint");
+            var destinationPath = Path.Combine(projectRoot, "checkpoint");
+            Directory.CreateDirectory(tempPath);
+            File.WriteAllText(Path.Combine(tempPath, "manifest.txt"), "checkpoint", Utf8NoBom);
+            AtomicFileWriter.FlushParentDirectoryForTesting = _ => throw new IOException("flush failed");
+
+            var ex = Assert.Throws<IOException>(() =>
+                AtomicFileWriter.PublishDirectory(tempPath, destinationPath));
+
+            Assert.Contains("Directory publish completed", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("destination directory was already published", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("parent directory could not be flushed", ex.Message, StringComparison.Ordinal);
+            Assert.False(Directory.Exists(tempPath));
+            Assert.True(File.Exists(Path.Combine(destinationPath, "manifest.txt")));
+        }
+        finally
+        {
+            AtomicFileWriter.FlushParentDirectoryForTesting = null;
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void TryDeleteFile_CleanupFailureReportsAndSuppresses_Issue4001()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("atomic_cleanup_failure");
+        try
+        {
+            var path = Path.Combine(projectRoot, "cleanup.tmp");
+            var failures = new List<Exception>();
+            File.WriteAllText(path, "temp", Utf8NoBom);
+
+            var deleted = AtomicFileWriter.TryDeleteFile(
+                path,
+                failures.Add,
+                _ => throw new IOException("delete denied"));
+
+            Assert.False(deleted);
+            var failure = Assert.Single(failures);
+            Assert.Contains("delete denied", failure.Message, StringComparison.Ordinal);
+            Assert.True(File.Exists(path));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void WriteJson_SensitiveProfile_WritesPrivateFileAndFlushesParentDirectory_Issue3688()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("atomic_sensitive");

--- a/tests/CodeIndex.Tests/DiagnosticRedactorTests.cs
+++ b/tests/CodeIndex.Tests/DiagnosticRedactorTests.cs
@@ -6,6 +6,36 @@ namespace CodeIndex.Tests;
 public class DiagnosticRedactorTests
 {
     [Fact]
+    public void RedactSuggestionText_UsesSharedTypedPolicy_Issue3933()
+    {
+        var awsKey = "AKIA" + new string('A', 16);
+        var bearer = "Bearer " + new string('b', 20);
+        var highEntropy = "Abcdefghijklmnopqrstuvwxyz123456";
+        var text = $"key={awsKey} {bearer} api_key=secret {highEntropy}";
+
+        var redacted = DiagnosticRedactor.RedactSuggestionText(text, out var redactedTypes);
+
+        Assert.Contains(DiagnosticRedactor.SuggestionRedactedAwsAccessKey, redacted);
+        Assert.Contains(DiagnosticRedactor.SuggestionRedactedBearerToken, redacted);
+        Assert.Contains("api_key=" + DiagnosticRedactor.SuggestionRedactedCredential, redacted);
+        Assert.Contains(DiagnosticRedactor.SuggestionRedactedHighEntropyToken, redacted);
+        Assert.DoesNotContain(awsKey, redacted);
+        Assert.DoesNotContain("secret", redacted);
+        Assert.Equal(
+            ["aws_access_key", "bearer_token", "credential", "high_entropy_token"],
+            redactedTypes.Order(StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void IsSensitiveName_CoversSharedCredentialNames_Issue3933()
+    {
+        Assert.True(DiagnosticRedactor.IsSensitiveName("--github-token"));
+        Assert.True(DiagnosticRedactor.IsSensitiveName("CDIDX_ACCESS_KEY"));
+        Assert.True(DiagnosticRedactor.IsSensitiveName("serviceCredential"));
+        Assert.False(DiagnosticRedactor.IsSensitiveName("--workspace"));
+    }
+
+    [Fact]
     public void RedactReportLogLine_JsonLineRedactsStrings_Issue3724()
     {
         var token = "ghp_" + new string('a', 24);

--- a/tests/CodeIndex.Tests/FileSystemTraversalPolicyTests.cs
+++ b/tests/CodeIndex.Tests/FileSystemTraversalPolicyTests.cs
@@ -1,0 +1,55 @@
+using CodeIndex;
+
+namespace CodeIndex.Tests;
+
+public class FileSystemTraversalPolicyTests
+{
+    [Fact]
+    public void CreateTopDirectoryOnlyOptions_ReturnsExplicitTraversalPolicy_Issue3951()
+    {
+        var first = FileSystemTraversalPolicy.CreateTopDirectoryOnlyOptions();
+        var second = FileSystemTraversalPolicy.CreateTopDirectoryOnlyOptions();
+
+        Assert.NotSame(first, second);
+        Assert.False(first.RecurseSubdirectories);
+        Assert.False(first.IgnoreInaccessible);
+        Assert.False(first.ReturnSpecialDirectories);
+        Assert.Equal((FileAttributes)0, first.AttributesToSkip);
+    }
+
+    [Fact]
+    public void EnumerateHelpers_DoNotRecurseIntoChildDirectories_Issue3951()
+    {
+        var root = Path.Combine(Path.GetTempPath(), $"cdidx_traversal_policy_{Guid.NewGuid():N}");
+        var child = Path.Combine(root, "child");
+        try
+        {
+            Directory.CreateDirectory(child);
+            File.WriteAllText(Path.Combine(root, "root.txt"), "root");
+            File.WriteAllText(Path.Combine(child, "child.txt"), "child");
+
+            var files = FileSystemTraversalPolicy.EnumerateFiles(root)
+                .Select(Path.GetFileName)
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+            var directories = FileSystemTraversalPolicy.EnumerateDirectories(root)
+                .Select(Path.GetFileName)
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+            var entries = FileSystemTraversalPolicy.EnumerateFileSystemEntries(root)
+                .Select(Path.GetFileName)
+                .Order(StringComparer.Ordinal)
+                .ToArray();
+
+            Assert.Equal(["root.txt"], files);
+            Assert.Equal(["child"], directories);
+            Assert.Equal(["child", "root.txt"], entries);
+            Assert.True(FileSystemTraversalPolicy.HasAnyFileSystemEntry(root));
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+}

--- a/tests/CodeIndex.Tests/FileUriPolicyTests.cs
+++ b/tests/CodeIndex.Tests/FileUriPolicyTests.cs
@@ -1,0 +1,49 @@
+using CodeIndex;
+using CodeIndex.Database;
+using CodeIndex.Lsp;
+
+namespace CodeIndex.Tests;
+
+public class FileUriPolicyTests
+{
+    [Fact]
+    public void PathToFileUri_EscapesPathCharacters_Issue3995()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "cdidx uri root");
+        var uri = FileUriPolicy.PathToFileUri(Path.Combine("src", "a file#name.cs"), root);
+
+        Assert.StartsWith("file:", uri, StringComparison.Ordinal);
+        Assert.Contains("a%20file%23name.cs", uri, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LspPathToUri_UsesSharedFileUriPolicy_Issue3995()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "cdidx lsp uri");
+        var uri = LspServer.PathToUri(Path.Combine("src", "query #1.cs"), root);
+
+        Assert.Contains("query%20%231.cs", uri, StringComparison.Ordinal);
+        Assert.Equal(Path.GetFullPath(Path.Combine(root, "src", "query #1.cs")), LspServer.UriToPath(uri));
+    }
+
+    [Fact]
+    public void AbsoluteFileUriToPath_RejectsRelativeFileUri_Issue3995()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => LspServer.UriToPath("file:relative/path.cs"));
+
+        Assert.Contains(FileUriPolicy.AbsoluteFileUriRequiredMessage, ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DbConnectionFactory_ToReadOnlyUri_UsesSharedFileUriEscaping_Issue3995()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), "cdidx db #1.sqlite");
+
+        var uri = DbConnectionFactory.ToReadOnlyUri(dbPath);
+
+        Assert.StartsWith("file:", uri, StringComparison.Ordinal);
+        Assert.Contains("cdidx%20db%20%231.sqlite", uri, StringComparison.Ordinal);
+        Assert.EndsWith("?immutable=1&mode=ro", uri, StringComparison.Ordinal);
+        Assert.Equal(Path.GetFullPath(dbPath), DbConnectionFactory.TryGetLocalPath(uri));
+    }
+}

--- a/tests/CodeIndex.Tests/GlobalToolLogTests.cs
+++ b/tests/CodeIndex.Tests/GlobalToolLogTests.cs
@@ -324,6 +324,24 @@ public class GlobalToolLogTests
     }
 
     [Fact]
+    public void FormatArgs_RedactsSharedSensitiveNames_Issue3933()
+    {
+        using var env = EnvironmentVariableScope.Capture("CDIDX_LOG_REDACT");
+        env.Set("CDIDX_LOG_REDACT", null);
+
+        var formatted = GlobalToolLog.FormatArgs([
+            "--github-token",
+            "gh-secret",
+            "--serviceCredential=credential-secret",
+        ]);
+
+        Assert.Contains("--github-token <redacted>", formatted);
+        Assert.Contains("--serviceCredential=<redacted>", formatted);
+        Assert.DoesNotContain("gh-secret", formatted);
+        Assert.DoesNotContain("credential-secret", formatted);
+    }
+
+    [Fact]
     public void FormatArgs_TruncatesOverlongArgumentBeforeRedaction()
     {
         using var env = EnvironmentVariableScope.Capture("CDIDX_LOG_REDACT");

--- a/tests/CodeIndex.Tests/ProcessLaunchPolicyTests.cs
+++ b/tests/CodeIndex.Tests/ProcessLaunchPolicyTests.cs
@@ -1,0 +1,51 @@
+using CodeIndex;
+
+namespace CodeIndex.Tests;
+
+public class ProcessLaunchPolicyTests
+{
+    [Fact]
+    public void CreateNoShellStartInfo_SetsExplicitLaunchContract_Issue3991()
+    {
+        var startInfo = ProcessLaunchPolicy.CreateNoShellStartInfo(
+            fileName: "/usr/bin/git",
+            workingDirectory: "/tmp/work",
+            redirectStandardOutput: true,
+            redirectStandardError: true,
+            createNoWindow: true);
+
+        Assert.Equal("/usr/bin/git", startInfo.FileName);
+        Assert.Equal("/tmp/work", startInfo.WorkingDirectory);
+        Assert.False(startInfo.UseShellExecute);
+        Assert.False(startInfo.RedirectStandardInput);
+        Assert.True(startInfo.RedirectStandardOutput);
+        Assert.True(startInfo.RedirectStandardError);
+        Assert.True(startInfo.CreateNoWindow);
+        Assert.Equal(string.Empty, startInfo.Arguments);
+    }
+
+    [Fact]
+    public void AddInvariantIntArgument_AppendsProtocolArgumentPair_Issue3991()
+    {
+        var startInfo = ProcessLaunchPolicy.CreateNoShellStartInfo();
+
+        ProcessLaunchPolicy.AddInvariantIntArgument(startInfo, "--max-line-bytes", 8192);
+
+        Assert.Equal(["--max-line-bytes", "8192"], startInfo.ArgumentList.ToArray());
+    }
+
+    [Fact]
+    public void CreateUtf8RedirectedWorkerStartInfo_DisablesShellAndUsesUtf8NoBom_Issue3991()
+    {
+        var startInfo = ProcessLaunchPolicy.CreateUtf8RedirectedWorkerStartInfo();
+
+        Assert.False(startInfo.UseShellExecute);
+        Assert.True(startInfo.RedirectStandardInput);
+        Assert.True(startInfo.RedirectStandardOutput);
+        Assert.True(startInfo.RedirectStandardError);
+        Assert.True(startInfo.CreateNoWindow);
+        Assert.False(startInfo.StandardInputEncoding!.GetPreamble().Length > 0);
+        Assert.False(startInfo.StandardOutputEncoding!.GetPreamble().Length > 0);
+        Assert.False(startInfo.StandardErrorEncoding!.GetPreamble().Length > 0);
+    }
+}


### PR DESCRIPTION
## Summary

- Centralized diagnostic/suggestion/global-log redaction through `DiagnosticRedactor`.
- Added shared helpers for file URI conversion, process launch configuration, filesystem traversal, and atomic file mutation/cleanup policy.
- Updated the relevant CLI, LSP, indexer, import/restore, plugin/hook, and log/suggestion paths to use those helpers.
- Added focused regression coverage for each policy helper.

## Validation

- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net8.0 --filter "FullyQualifiedName~DiagnosticRedactorTests|FullyQualifiedName~GlobalToolLogTests|FullyQualifiedName~FileUriPolicyTests|FullyQualifiedName~ProcessLaunchPolicyTests|FullyQualifiedName~FileSystemTraversalPolicyTests|FullyQualifiedName~AtomicFileWriterTests" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net9.0 --filter "FullyQualifiedName~DiagnosticRedactorTests|FullyQualifiedName~GlobalToolLogTests|FullyQualifiedName~FileUriPolicyTests|FullyQualifiedName~ProcessLaunchPolicyTests|FullyQualifiedName~FileSystemTraversalPolicyTests|FullyQualifiedName~AtomicFileWriterTests" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net8.0 --filter "FullyQualifiedName~PrivateLogFile_TryRotateSlots|FullyQualifiedName~ReplaceImportedDatabase_|FullyQualifiedName~RunCheckpoint|FullyQualifiedName~SuggestionStoreTests" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net9.0 --filter "FullyQualifiedName~PrivateLogFile_TryRotateSlots|FullyQualifiedName~ReplaceImportedDatabase_|FullyQualifiedName~RunCheckpoint|FullyQualifiedName~SuggestionStoreTests" -p:UseSharedCompilation=false`
- Codex adversarial review: No blocking/actionable issues found.

## Documentation / Changelog

- Added `changelog.d/unreleased/3933.security.md`
- Added `changelog.d/unreleased/3951.security.md`
- Added `changelog.d/unreleased/3991.security.md`
- Added `changelog.d/unreleased/3995.fixed.md`
- Added `changelog.d/unreleased/4001.security.md`

## Follow-Up Candidates

- None.

Fixes #4001
Fixes #3951
Fixes #3991
Fixes #3995
Fixes #3933
