### PR TITLE
Fix inactive workspace JSON contracts

### DIFF
--- a/changelog.d/unreleased/3939.fixed.md
+++ b/changelog.d/unreleased/3939.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3939
+affected:
+  - src/CodeIndex/Cli/WorkspaceCommandRunner.cs
+  - src/CodeIndex/Cli/WorkspaceManifest.cs
+  - tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+---
+
+## English
+
+- **`workspace current --json` now returns an explicit inactive state (#3939)** — when no active workspace is set, JSON output includes `active:false`, `workspace:null`, and stable `status` / `reason` / `code` fields instead of serializing to `{}`.
+
+## 日本語
+
+- **`workspace current --json` が明示的な inactive state を返すようになりました (#3939)** — active workspace が未設定の場合、JSON 出力は `{}` ではなく `active:false`、`workspace:null`、安定した `status` / `reason` / `code` フィールドを含みます。

--- a/changelog.d/unreleased/3956.fixed.md
+++ b/changelog.d/unreleased/3956.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3956
+affected:
+  - src/CodeIndex/Cli/WorkspaceManifest.cs
+  - tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+---
+
+## English
+
+- **Inactive workspace status JSON is now machine-readable (#3956)** — `workspace status --json` now includes `manifest_found:false` and a stable `manifest_status.code` when no workspace manifest is present.
+
+## 日本語
+
+- **inactive workspace status の JSON が機械判定しやすくなりました (#3956)** — workspace manifest が存在しない場合、`workspace status --json` は `manifest_found:false` と安定した `manifest_status.code` を含むようになりました。

--- a/src/CodeIndex/Cli/WorkspaceCommandRunner.cs
+++ b/src/CodeIndex/Cli/WorkspaceCommandRunner.cs
@@ -69,7 +69,7 @@ internal static class WorkspaceCommandRunner
     {
         var state = ActiveWorkspace.Load();
         if (json)
-            Console.WriteLine(JsonSerializer.Serialize(new ActiveWorkspaceJsonResult(state, null), jsonOptions));
+            Console.WriteLine(JsonSerializer.Serialize(ActiveWorkspaceJsonResult.From(state, null), jsonOptions));
         else if (state == null)
             Console.WriteLine("No active workspace set.");
         else
@@ -129,7 +129,7 @@ internal static class WorkspaceCommandRunner
         }
 
         if (json)
-            Console.WriteLine(JsonSerializer.Serialize(new ActiveWorkspaceJsonResult(state, ActiveWorkspace.StatePath), jsonOptions));
+            Console.WriteLine(JsonSerializer.Serialize(ActiveWorkspaceJsonResult.From(state, ActiveWorkspace.StatePath), jsonOptions));
         else
             Console.WriteLine($"Active workspace set to {state.Name}: {state.DbPath}");
         return CommandExitCodes.Success;

--- a/src/CodeIndex/Cli/WorkspaceManifest.cs
+++ b/src/CodeIndex/Cli/WorkspaceManifest.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using CodeIndex.Indexer;
 
 namespace CodeIndex.Cli;
@@ -17,7 +18,45 @@ internal sealed record WorkspaceListJsonResult(
     IReadOnlyList<WorkspaceMember> Members,
     WorkspaceManifestStatusJsonResult ManifestStatus);
 
-internal sealed record ActiveWorkspaceJsonResult(ActiveWorkspaceState? ActiveWorkspace, string? Path);
+internal sealed record ActiveWorkspaceJsonResult
+{
+    [JsonPropertyName("active")]
+    public bool Active { get; init; }
+
+    [JsonPropertyName("workspace")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
+    public ActiveWorkspaceState? Workspace { get; init; }
+
+    [JsonPropertyName("active_workspace")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public ActiveWorkspaceState? ActiveWorkspace => Workspace;
+
+    [JsonPropertyName("path")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Path { get; init; }
+
+    [JsonPropertyName("status")]
+    public string Status { get; init; } = "inactive";
+
+    [JsonPropertyName("reason")]
+    public string Reason { get; init; } = "not_set";
+
+    [JsonPropertyName("code")]
+    public string Code { get; init; } = "active_workspace_not_set";
+
+    internal static ActiveWorkspaceJsonResult From(ActiveWorkspaceState? state, string? path)
+        => state is null
+            ? new ActiveWorkspaceJsonResult()
+            : new ActiveWorkspaceJsonResult
+            {
+                Active = true,
+                Workspace = state,
+                Path = path,
+                Status = "active",
+                Reason = "active",
+                Code = "active_workspace_set",
+            };
+}
 
 internal sealed record ConfigShowJsonResult(
     string? ConfigPath,

--- a/src/CodeIndex/Cli/WorkspaceManifest.cs
+++ b/src/CodeIndex/Cli/WorkspaceManifest.cs
@@ -16,7 +16,11 @@ internal sealed record WorkspaceManifest(
 internal sealed record WorkspaceListJsonResult(
     WorkspaceManifest? Manifest,
     IReadOnlyList<WorkspaceMember> Members,
-    WorkspaceManifestStatusJsonResult ManifestStatus);
+    WorkspaceManifestStatusJsonResult ManifestStatus)
+{
+    [JsonPropertyName("manifest_found")]
+    public bool ManifestFound => Manifest is not null;
+}
 
 internal sealed record ActiveWorkspaceJsonResult
 {
@@ -90,7 +94,22 @@ internal sealed record WorkspaceManifestStatusJsonResult(
     string Reason,
     string? Path,
     IReadOnlyList<string> SearchedPaths,
-    IReadOnlyList<string> SupportedFiles);
+    IReadOnlyList<string> SupportedFiles)
+{
+    [JsonPropertyName("manifest_found")]
+    public bool ManifestFound => Path is not null;
+
+    [JsonPropertyName("code")]
+    public string Code
+        => Path is not null
+            ? "workspace_manifest_found"
+            : Reason switch
+            {
+                "invalid" => "workspace_manifest_invalid",
+                "not_found" => "workspace_manifest_not_found",
+                _ => "workspace_manifest_unavailable",
+            };
+}
 
 internal sealed record ConfigEffectiveValueJsonResult(
     string EnvironmentVariable,

--- a/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
@@ -683,6 +683,41 @@ public class WorkspaceCommandRunnerTests
     }
 
     [Fact]
+    public void WorkspaceCurrentJsonNoActiveWorkspace_ReturnsExplicitInactiveState_Issue3939()
+    {
+        var root = TestProjectHelper.CreateTempProject("cdidx_workspace_current_no_active");
+        var configHome = TestProjectHelper.CreateTempProject("cdidx_workspace_current_no_active_config");
+        var previous = Environment.CurrentDirectory;
+        try
+        {
+            using var env = EnvironmentVariableScope.Capture(ActiveWorkspace.EnvironmentVariable, "XDG_CONFIG_HOME");
+            Environment.SetEnvironmentVariable(ActiveWorkspace.EnvironmentVariable, null);
+            Environment.SetEnvironmentVariable("XDG_CONFIG_HOME", configHome);
+            Environment.CurrentDirectory = root;
+
+            var (exitCode, stdout, stderr) = ConsoleCapture.Capture(() => WorkspaceCommandRunner.Run(["current", "--json"], _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Empty(stderr);
+            using var document = JsonDocument.Parse(stdout);
+            var payload = document.RootElement;
+            Assert.False(payload.GetProperty("active").GetBoolean());
+            Assert.Equal(JsonValueKind.Null, payload.GetProperty("workspace").ValueKind);
+            Assert.Equal("inactive", payload.GetProperty("status").GetString());
+            Assert.Equal("not_set", payload.GetProperty("reason").GetString());
+            Assert.Equal("active_workspace_not_set", payload.GetProperty("code").GetString());
+            Assert.False(payload.TryGetProperty("active_workspace", out _));
+            Assert.False(payload.TryGetProperty("path", out _));
+        }
+        finally
+        {
+            Environment.CurrentDirectory = previous;
+            TestProjectHelper.DeleteDirectory(root);
+            TestProjectHelper.DeleteDirectory(configHome);
+        }
+    }
+
+    [Fact]
     public void ActiveWorkspace_AffectsQueryResolutionButNotIndexResolution()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_active_workspace_project");

--- a/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/WorkspaceCommandRunnerTests.cs
@@ -648,7 +648,7 @@ public class WorkspaceCommandRunnerTests
     }
 
     [Fact]
-    public void WorkspaceStatusJsonNoManifest_IncludesDiscoveryMetadata_Issue3905()
+    public void WorkspaceStatusJsonNoManifest_IncludesDiscoveryMetadata_Issues3905_3956()
     {
         var root = TestProjectHelper.CreateTempProject("cdidx_workspace_status_no_manifest");
         var previous = Environment.CurrentDirectory;
@@ -663,11 +663,14 @@ public class WorkspaceCommandRunnerTests
             Assert.Empty(stderr);
             using var document = JsonDocument.Parse(stdout);
             var payload = document.RootElement;
+            Assert.False(payload.GetProperty("manifest_found").GetBoolean());
             Assert.False(payload.TryGetProperty("manifest", out _));
             Assert.Empty(payload.GetProperty("members").EnumerateArray());
             var manifestStatus = payload.GetProperty("manifest_status");
             Assert.Equal("not_found", manifestStatus.GetProperty("status").GetString());
             Assert.Equal("not_found", manifestStatus.GetProperty("reason").GetString());
+            Assert.False(manifestStatus.GetProperty("manifest_found").GetBoolean());
+            Assert.Equal("workspace_manifest_not_found", manifestStatus.GetProperty("code").GetString());
             Assert.Contains(
                 manifestStatus.GetProperty("supported_files").EnumerateArray(),
                 item => item.GetString() == WorkspaceManifestLoader.FileName);


### PR DESCRIPTION
## Summary
- Make `workspace current --json` return an explicit inactive state with `active:false`, `workspace:null`, and stable `status`/`reason`/`code` fields.
- Preserve active-workspace compatibility fields while exposing the new `workspace` shape.
- Make `workspace status --json` no-manifest states expose `manifest_found:false` and stable manifest diagnostic codes.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~WorkspaceCurrentJsonNoActiveWorkspace" -p:UseAppHost=false -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~WorkspaceStatusJsonNoManifest|FullyQualifiedName~WorkspaceCurrentJsonNoActiveWorkspace" -p:UseAppHost=false -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter WorkspaceCommandRunnerTests --no-restore`
- `dotnet run --project tools/CodeIndex.Changelog -p:UseAppHost=false -- check`
- `dotnet build CodeIndex.sln -p:UseAppHost=false -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `workspace current --json` inactive-state CLI smoke
- `git diff --check 1cff42d...`

## Review
- Codex adversarial review: No blocking/actionable issues found.

## Documentation / Changelog
- Added `changelog.d/unreleased/3939.fixed.md`.
- Added `changelog.d/unreleased/3956.fixed.md`.
- No prose docs were changed because the existing guides do not document the inactive `workspace current/status --json` schema in detail.

## Follow-ups
- None.

Fixes #3939
Fixes #3956