### PR TITLE
Create private control files up front

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -60,7 +60,7 @@ Development contracts:
 | `codeindex.db` plus WAL/SHM sidecars | Mode `0600` is applied when the files exist. |
 | `suggestions-*.json` suggestion stores | Written atomically with owner-only mode `0600` on POSIX. |
 | Atomic file writes | `AtomicFileWriter` writes to a sibling temp file, applies the requested POSIX mode before replacement, flushes file contents, renames over the target, and fsyncs the parent directory on Unix. Callers must use the `Sensitive` write profile for local state, caches, suggestions, checkpoints, and other private payloads; user-requested exports and reports use the default `Public` profile unless their content is explicitly private. If the parent directory flush fails after replacement, the command fails explicitly so callers know the file was replaced but directory durability was not confirmed. Windows skips directory fsync because the helper only promises it on supported Unix platforms. |
-| Index lock metadata sidecars and active workspace `active.json` | Written as owner-only files and read through small bounded buffers so stale or corrupted diagnostics cannot expose local paths more broadly or force unbounded allocation. |
+| Index locks, watch sub-run spools, staged hook scripts, lock metadata sidecars, and active workspace `active.json` | Created or written as owner-only files (`0600`) before contents are exposed, and read through small bounded buffers where applicable so stale or corrupted diagnostics cannot expose local paths more broadly or force unbounded allocation. |
 | Checkpoint roots, snapshot directories, manifest files, copied DB/WAL/SHM snapshots, and restore staging/backup directories | Forced owner-only on POSIX. |
 | `status --json` | Reports `data_dir_mode` and `db_file_mode` when the platform exposes Unix file modes. |
 
@@ -2274,7 +2274,7 @@ net9 CI lane に合わせる場合は `FRAMEWORK=net9.0 make test` を使いま�
 | `codeindex.db` と WAL/SHM sidecar | ファイルが存在する場合は mode `0600` を適用。 |
 | `suggestions-*.json` suggestion store | POSIX では owner-only の mode `0600` で atomic write します。 |
 | atomic file write | `AtomicFileWriter` は sibling temp file に書き込み、要求された POSIX mode を置換前に適用し、file content を flush してから target へ rename し、Unix では parent directory を fsync します。local state、cache、suggestion、checkpoint など private payload には `Sensitive` write profile を使い、user-requested export や report は内容が明示的に private でない限り既定の `Public` profile を使います。置換後に parent directory flush が失敗した場合、file は置換済みだが directory durability を確認できていないことが caller に分かるよう command は明示的に失敗します。Windows では、この helper の directory fsync 保証は supported Unix platform に限定されるため skip します。 |
-| index lock metadata sidecar と active workspace の `active.json` | owner-only file として書き、stale / corrupt diagnostic が local path を広く漏らしたり unbounded allocation を強制したりしないよう小さな bounded buffer で読みます。 |
+| index lock、watch sub-run spool、staged hook script、lock metadata sidecar、active workspace の `active.json` | 内容が露出する前に owner-only file (`0600`) として作成または書き込み、該当するものは stale / corrupt diagnostic が local path を広く漏らしたり unbounded allocation を強制したりしないよう小さな bounded buffer で読みます。 |
 | database checkpoint root、snapshot directory、manifest file、copy された DB/WAL/SHM snapshot、restore staging/backup directory | POSIX では owner-only に固定。 |
 | `status --json` | platform が Unix file mode を公開する場合、`data_dir_mode` と `db_file_mode` を報告。 |
 

--- a/changelog.d/unreleased/3984.security.md
+++ b/changelog.d/unreleased/3984.security.md
@@ -3,6 +3,7 @@ category: security
 issues:
   - 3984
 affected:
+  - src/CodeIndex/Cli/AtomicFileWriter.cs
   - src/CodeIndex/Cli/DataDirectorySecurity.cs
   - src/CodeIndex/Cli/ExclusiveFileLock.cs
   - src/CodeIndex/Cli/IndexWatchRunner.cs

--- a/changelog.d/unreleased/3984.security.md
+++ b/changelog.d/unreleased/3984.security.md
@@ -1,0 +1,22 @@
+---
+category: security
+issues:
+  - 3984
+affected:
+  - src/CodeIndex/Cli/DataDirectorySecurity.cs
+  - src/CodeIndex/Cli/ExclusiveFileLock.cs
+  - src/CodeIndex/Cli/IndexWatchRunner.cs
+  - src/CodeIndex/Cli/HookCommandRunner.cs
+  - tests/CodeIndex.Tests/DataDirectorySecurityTests.cs
+  - tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
+  - tests/CodeIndex.Tests/HookCommandRunnerTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Private temp and control files are created with owner-only modes up front (#3984)** — watch sub-run spool files, index lock files, staged hook scripts, and sensitive atomic temp files now request POSIX `0600` at creation time instead of relying only on a later chmod.
+
+## 日本語
+
+- **一時ファイルと制御ファイルを作成時点から owner-only mode にしました (#3984)** — watch sub-run spool file、index lock file、staged hook script、sensitive atomic temp file は、後続の chmod だけに頼らず POSIX `0600` を作成時に要求するようになりました。

--- a/src/CodeIndex/Cli/AtomicFileWriter.cs
+++ b/src/CodeIndex/Cli/AtomicFileWriter.cs
@@ -101,15 +101,7 @@ internal static class AtomicFileWriter
         if (profile != WriteProfile.Sensitive || OperatingSystem.IsWindows())
             return new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None);
 
-        return new FileStream(
-            path,
-            new FileStreamOptions
-            {
-                Mode = FileMode.CreateNew,
-                Access = FileAccess.Write,
-                Share = FileShare.None,
-                UnixCreateMode = DataDirectorySecurity.PrivateFileMode,
-            });
+        return DataDirectorySecurity.OpenPrivateFileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None);
     }
 
     private static Action<string>? ResolveProfileModeCallback(WriteProfile profile)

--- a/src/CodeIndex/Cli/DataDirectorySecurity.cs
+++ b/src/CodeIndex/Cli/DataDirectorySecurity.cs
@@ -83,6 +83,20 @@ internal static class DataDirectorySecurity
         File.SetUnixFileMode(path, PrivateFileMode);
     }
 
+    internal static FileStream OpenPrivateFileStream(string path, FileMode mode, FileAccess access, FileShare share)
+    {
+        var options = new FileStreamOptions
+        {
+            Mode = mode,
+            Access = access,
+            Share = share,
+        };
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            options.UnixCreateMode = PrivateFileMode;
+
+        return new FileStream(LongPath.EnsureWindowsPrefix(path), options);
+    }
+
     private static DirectoryInfo CreateDirectoryWithPrivateMode(string path)
     {
         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/src/CodeIndex/Cli/ExclusiveFileLock.cs
+++ b/src/CodeIndex/Cli/ExclusiveFileLock.cs
@@ -7,8 +7,8 @@ internal static class ExclusiveFileLock
 {
     internal static FileStream Open(string lockPath)
     {
-        var stream = new FileStream(
-            LongPath.EnsureWindowsPrefix(lockPath),
+        var stream = DataDirectorySecurity.OpenPrivateFileStream(
+            lockPath,
             FileMode.OpenOrCreate,
             FileAccess.ReadWrite,
             FileShare.None);

--- a/src/CodeIndex/Cli/HookCommandRunner.cs
+++ b/src/CodeIndex/Cli/HookCommandRunner.cs
@@ -214,7 +214,7 @@ public static class HookCommandRunner
 
     private static void WriteStagedHookScript(string ioStagedHookPath, string chainedHookPath, string projectPath)
     {
-        using (var stream = new FileStream(ioStagedHookPath, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+        using (var stream = CreateStagedHookFileStream(ioStagedHookPath))
         {
             using (var writer = new StreamWriter(
                 stream,
@@ -231,6 +231,9 @@ public static class HookCommandRunner
 
         MakeExecutable(ioStagedHookPath);
     }
+
+    internal static FileStream CreateStagedHookFileStream(string ioStagedHookPath)
+        => DataDirectorySecurity.OpenPrivateFileStream(ioStagedHookPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
 
     private static void ReplaceFile(string sourceFileName, string destinationFileName, string? destinationBackupFileName)
     {

--- a/src/CodeIndex/Cli/IndexWatchRunner.cs
+++ b/src/CodeIndex/Cli/IndexWatchRunner.cs
@@ -347,7 +347,7 @@ internal static class IndexWatchRunner
             {
                 spoolPath = Path.Combine(Path.GetTempPath(), $"cdidx-watch-subrun-{Guid.NewGuid():N}.jsonl");
                 spoolWriter = new StreamWriter(
-                    new FileStream(spoolPath, FileMode.CreateNew, FileAccess.Write, FileShare.Read),
+                    CreateSubRunSpoolFileStream(spoolPath),
                     new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
             }
 
@@ -421,6 +421,9 @@ internal static class IndexWatchRunner
         DeleteSpoolFile(spoolPath);
         return subRunExitCode;
     }
+
+    internal static FileStream CreateSubRunSpoolFileStream(string spoolPath)
+        => DataDirectorySecurity.OpenPrivateFileStream(spoolPath, FileMode.CreateNew, FileAccess.Write, FileShare.Read);
 
     private static bool TryWriteSpooledSubRunOutput(string? spoolPath, out bool endedWithLineBreak)
     {

--- a/tests/CodeIndex.Tests/DataDirectorySecurityTests.cs
+++ b/tests/CodeIndex.Tests/DataDirectorySecurityTests.cs
@@ -226,6 +226,45 @@ public class DataDirectorySecurityTests
     }
 
     [Fact]
+    public void OpenPrivateFileStream_OnPosix_CreatesPrivateFilesUpFront_Issue3984()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            return;
+
+        var root = Path.Combine(Path.GetTempPath(), $"cdidx_private_create_{Guid.NewGuid():N}");
+        try
+        {
+            Directory.CreateDirectory(root);
+            var createNewPath = Path.Combine(root, "watch-spool.jsonl");
+            using (var stream = DataDirectorySecurity.OpenPrivateFileStream(
+                createNewPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.Read))
+            {
+                stream.WriteByte(1);
+                AssertPrivateFileMode(createNewPath);
+            }
+
+            var openOrCreatePath = Path.Combine(root, "codeindex.db.lock");
+            using (var stream = DataDirectorySecurity.OpenPrivateFileStream(
+                openOrCreatePath,
+                FileMode.OpenOrCreate,
+                FileAccess.ReadWrite,
+                FileShare.None))
+            {
+                stream.WriteByte(1);
+                AssertPrivateFileMode(openOrCreatePath);
+            }
+        }
+        finally
+        {
+            if (Directory.Exists(root))
+                Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
     public void WritePrivateText_MoveFailure_DoesNotLeaveTempFile()
     {
         var root = Path.Combine(Path.GetTempPath(), $"cdidx_sensitive_file_atomic_{Guid.NewGuid():N}");
@@ -287,5 +326,14 @@ public class DataDirectorySecurityTests
             Directory.Delete(path, recursive: true);
         else if (File.Exists(path))
             File.Delete(path);
+    }
+
+    private static void AssertPrivateFileMode(string path)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var mode = File.GetUnixFileMode(path) & DataDirectorySecurity.PermissionBits;
+        Assert.Equal(DataDirectorySecurity.PrivateFileMode, mode);
     }
 }

--- a/tests/CodeIndex.Tests/HookCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/HookCommandRunnerTests.cs
@@ -397,6 +397,28 @@ public class HookCommandRunnerTests
         }
     }
 
+    [Fact]
+    public void CreateStagedHookFileStream_OnPosix_CreatesPrivateFileUpFront_Issue3984()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = TestProjectHelper.CreateTempProject("hook_private_staged");
+        try
+        {
+            var stagedPath = Path.Combine(projectRoot, ".pre-commit.test.tmp");
+
+            using var stream = HookCommandRunner.CreateStagedHookFileStream(stagedPath);
+
+            Assert.True(stream.CanWrite);
+            AssertPrivateFileMode(stagedPath);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
     private (int ExitCode, string StdOut, string StdErr) RunIndexAndCaptureStreams(string[] args)
     {
         using var capture = ConsoleCapture.Start(captureOut: true, captureError: true);
@@ -424,6 +446,15 @@ public class HookCommandRunnerTests
 
     private static void AssertNoHookTempFiles(string hooksDir)
         => Assert.Empty(Directory.GetFiles(hooksDir, ".pre-commit.*.tmp"));
+
+    private static void AssertPrivateFileMode(string path)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var mode = File.GetUnixFileMode(path) & DataDirectorySecurity.PermissionBits;
+        Assert.Equal(DataDirectorySecurity.PrivateFileMode, mode);
+    }
 
     private static string QuoteShellForTest(string value)
         => "'" + value.Replace("'", "'\"'\"'", StringComparison.Ordinal) + "'";

--- a/tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
@@ -267,6 +267,28 @@ public class IndexWatchRunnerTests
     }
 
     [Fact]
+    public void CreateSubRunSpoolFileStream_OnPosix_CreatesPrivateFileUpFront_Issue3984()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = CreateTempProject();
+        try
+        {
+            var spoolPath = Path.Combine(projectRoot, "subrun.jsonl");
+
+            using var stream = IndexWatchRunner.CreateSubRunSpoolFileStream(spoolPath);
+
+            Assert.True(stream.CanWrite);
+            AssertPrivateFileMode(spoolPath);
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void BuildBatchPathSamples_BoundsLongRelativePaths_Issue3804()
     {
         var method = typeof(IndexWatchRunner).GetMethod("BuildBatchPathSamples", BindingFlags.NonPublic | BindingFlags.Static);
@@ -795,6 +817,15 @@ public class IndexWatchRunnerTests
         catch (UnauthorizedAccessException)
         {
         }
+    }
+
+    private static void AssertPrivateFileMode(string path)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var mode = File.GetUnixFileMode(path) & DataDirectorySecurity.PermissionBits;
+        Assert.Equal(DataDirectorySecurity.PrivateFileMode, mode);
     }
 
     private sealed class SignalingStringWriter : StringWriter


### PR DESCRIPTION
## Summary
- Add a shared private file stream helper that requests POSIX `0600` at file creation time.
- Use it for watch sub-run spool files, exclusive lock files, staged hook scripts, and sensitive atomic temp files.
- Add POSIX mode coverage for private create paths and update the filesystem permissions docs.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DataDirectorySecurityTests|FullyQualifiedName~IndexWatchRunnerTests|FullyQualifiedName~HookCommandRunnerTests|FullyQualifiedName~ExclusiveFileLockTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Note: a full `dotnet test` run was attempted locally but was interrupted after a prolonged no-output hang; the targeted net8.0/net9.0 test run above passed.

## Documentation / Changelog
- Updated `DEVELOPER_GUIDE.md` English and Japanese filesystem permission sections.
- Added `changelog.d/unreleased/3984.security.md`.

## Follow-up Candidates
- None.

Fixes #3984