### PR TITLE
Harden XML reader settings for extractors

### DIFF
--- a/changelog.d/unreleased/3981.security.md
+++ b/changelog.d/unreleased/3981.security.md
@@ -1,0 +1,17 @@
+---
+category: security
+issues:
+  - 3981
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.BuildAutomation.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuralMetadata.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **XML extraction now uses shared bounded reader settings (#3981)** — extractor XML readers now centralize DTD policy, disable external resolution, and apply explicit document and entity character limits while keeping app manifests on the intentional DTD-ignore path.
+
+## 日本語
+
+- **XML 抽出で共有された上限制御付き reader 設定を使うようになりました (#3981)** — extractor の XML reader は DTD policy、外部解決の無効化、document / entity 文字数上限を一箇所で管理し、app manifest は意図した DTD-ignore 経路のまま処理します。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.BuildAutomation.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.BuildAutomation.cs
@@ -8,6 +8,8 @@ public static partial class SymbolExtractor
 {
     internal const int XmlExtractionMaxDepth = 64;
     internal const int XmlExtractionMaxElements = 4096;
+    internal const long XmlExtractionMaxCharactersInDocument = 4L * 1024 * 1024;
+    internal const long XmlExtractionMaxCharactersFromEntities = 16L * 1024;
 
     internal readonly record struct XmlStructureIssue(string Kind, int Line, string Message);
 
@@ -43,7 +45,7 @@ public static partial class SymbolExtractor
 
         try
         {
-            using var reader = XmlReader.Create(new StringReader(content), CreateExtractionXmlReaderSettings());
+            using var reader = XmlReader.Create(new StringReader(content), CreateExtractionXmlReaderSettings(DtdProcessing.Prohibit));
             while (reader.Read())
             {
                 if (reader.NodeType == XmlNodeType.Element)
@@ -113,9 +115,27 @@ public static partial class SymbolExtractor
         issue = default;
         var elementCount = 0;
 
+        if (content.Length > XmlExtractionMaxCharactersInDocument)
+        {
+            issue = new XmlStructureIssue(
+                "xml_structure_budget_exceeded",
+                1,
+                $"XML document length exceeds the extraction limit of {XmlExtractionMaxCharactersInDocument}; symbol extraction is capped.");
+            return true;
+        }
+
+        if (TryGetXmlDtdDeclarationLine(content, out var dtdLine))
+        {
+            issue = new XmlStructureIssue(
+                "xml_dtd_prohibited",
+                dtdLine,
+                "XML DTD declarations are prohibited during extraction.");
+            return true;
+        }
+
         try
         {
-            using var reader = XmlReader.Create(new StringReader(content), CreateExtractionXmlReaderSettings());
+            using var reader = XmlReader.Create(new StringReader(content), CreateExtractionXmlReaderSettings(DtdProcessing.Prohibit));
             while (reader.Read())
             {
                 if (reader.NodeType != XmlNodeType.Element)
@@ -149,14 +169,6 @@ public static partial class SymbolExtractor
                 }
             }
         }
-        catch (XmlException ex) when (IsDtdProhibitedException(ex))
-        {
-            issue = new XmlStructureIssue(
-                "xml_dtd_prohibited",
-                Math.Max(1, ex.LineNumber),
-                "XML DTD declarations are prohibited during extraction.");
-            return true;
-        }
         catch (XmlException)
         {
             return false;
@@ -165,17 +177,105 @@ public static partial class SymbolExtractor
         return false;
     }
 
-    private static XmlReaderSettings CreateExtractionXmlReaderSettings() => new()
+    internal static XmlReaderSettings CreateExtractionXmlReaderSettings(DtdProcessing dtdProcessing)
     {
-        DtdProcessing = DtdProcessing.Prohibit,
-        IgnoreComments = true,
-        IgnoreProcessingInstructions = true,
-        XmlResolver = null,
-    };
+        if (dtdProcessing is not (DtdProcessing.Prohibit or DtdProcessing.Ignore))
+            throw new ArgumentOutOfRangeException(nameof(dtdProcessing), dtdProcessing, "Only Prohibit and Ignore are supported for extractor XML readers.");
 
-    private static bool IsDtdProhibitedException(XmlException ex) =>
-        ex.Message.Contains("DTD", StringComparison.OrdinalIgnoreCase)
-        || ex.Message.Contains("DOCTYPE", StringComparison.OrdinalIgnoreCase);
+        return new XmlReaderSettings
+        {
+            DtdProcessing = dtdProcessing,
+            IgnoreComments = true,
+            IgnoreProcessingInstructions = true,
+            MaxCharactersInDocument = XmlExtractionMaxCharactersInDocument,
+            MaxCharactersFromEntities = XmlExtractionMaxCharactersFromEntities,
+            XmlResolver = null,
+        };
+    }
+
+    private static bool TryGetXmlDtdDeclarationLine(string content, out int line)
+    {
+        var span = content.AsSpan();
+        var currentLine = 1;
+
+        for (var index = 0; index < span.Length;)
+        {
+            if (TryAdvanceXmlLineBreak(span, ref index, ref currentLine))
+                continue;
+
+            if (span[index] != '<')
+            {
+                index++;
+                continue;
+            }
+
+            var rest = span[index..];
+            if (rest.StartsWith("<!DOCTYPE".AsSpan(), StringComparison.Ordinal))
+            {
+                line = currentLine;
+                return true;
+            }
+
+            if (rest.StartsWith("<!--".AsSpan(), StringComparison.Ordinal))
+            {
+                index = AdvancePastXmlSegment(span, index + 4, "-->", ref currentLine);
+                continue;
+            }
+
+            if (rest.StartsWith("<![CDATA[".AsSpan(), StringComparison.Ordinal))
+            {
+                index = AdvancePastXmlSegment(span, index + 9, "]]>", ref currentLine);
+                continue;
+            }
+
+            if (rest.StartsWith("<?".AsSpan(), StringComparison.Ordinal))
+            {
+                index = AdvancePastXmlSegment(span, index + 2, "?>", ref currentLine);
+                continue;
+            }
+
+            index++;
+        }
+
+        line = 1;
+        return false;
+    }
+
+    private static int AdvancePastXmlSegment(ReadOnlySpan<char> span, int index, string terminator, ref int currentLine)
+    {
+        var terminatorSpan = terminator.AsSpan();
+        while (index < span.Length)
+        {
+            if (span[index..].StartsWith(terminatorSpan, StringComparison.Ordinal))
+                return index + terminatorSpan.Length;
+
+            if (TryAdvanceXmlLineBreak(span, ref index, ref currentLine))
+                continue;
+
+            index++;
+        }
+
+        return span.Length;
+    }
+
+    private static bool TryAdvanceXmlLineBreak(ReadOnlySpan<char> span, ref int index, ref int currentLine)
+    {
+        if (span[index] == '\n')
+        {
+            currentLine++;
+            index++;
+            return true;
+        }
+
+        if (span[index] == '\r')
+        {
+            currentLine++;
+            index += index + 1 < span.Length && span[index + 1] == '\n' ? 2 : 1;
+            return true;
+        }
+
+        return false;
+    }
 
     private static int? TryAddMsBuildElementSymbol(
         long fileId,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuralMetadata.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.StructuralMetadata.cs
@@ -38,17 +38,10 @@ public static partial class SymbolExtractor
     private static List<SymbolRecord> ExtractAppManifestSymbols(long fileId, string content, string[] lines)
     {
         var symbols = new List<SymbolRecord>();
-        var settings = new XmlReaderSettings
-        {
-            DtdProcessing = DtdProcessing.Ignore,
-            IgnoreComments = true,
-            IgnoreProcessingInstructions = true,
-            XmlResolver = null,
-        };
 
         try
         {
-            using var reader = XmlReader.Create(new StringReader(content), settings);
+            using var reader = XmlReader.Create(new StringReader(content), CreateExtractionXmlReaderSettings(DtdProcessing.Ignore));
             while (reader.Read())
             {
                 if (reader.NodeType != XmlNodeType.Element)

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Text.Json;
+using System.Xml;
 using CodeIndex.Indexer;
 using CodeIndex.Indexer.Extensibility;
 using CodeIndex.Models;
@@ -333,6 +334,68 @@ public partial class SymbolExtractorTests
         Assert.Contains(symbols, symbol => symbol.Name == "requestedExecutionLevel.uiAccess");
         Assert.Contains(symbols, symbol => symbol.Name == "supportedOS.{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}");
         Assert.Contains(symbols, symbol => symbol.Name == "longPathAware");
+    }
+
+    [Theory]
+    [InlineData(DtdProcessing.Prohibit)]
+    [InlineData(DtdProcessing.Ignore)]
+    public void CreateExtractionXmlReaderSettings_UsesSharedLimits_Issue3981(DtdProcessing dtdProcessing)
+    {
+        var settings = SymbolExtractor.CreateExtractionXmlReaderSettings(dtdProcessing);
+
+        Assert.Equal(dtdProcessing, settings.DtdProcessing);
+        Assert.True(settings.IgnoreComments);
+        Assert.True(settings.IgnoreProcessingInstructions);
+        Assert.Equal(SymbolExtractor.XmlExtractionMaxCharactersInDocument, settings.MaxCharactersInDocument);
+        Assert.Equal(SymbolExtractor.XmlExtractionMaxCharactersFromEntities, settings.MaxCharactersFromEntities);
+    }
+
+    [Fact]
+    public void Extract_AppManifest_IgnoresDtdWithSharedReaderPolicy_Issue3981()
+    {
+        const string content = """
+            <!DOCTYPE assembly [
+              <!ENTITY local "ignored">
+            ]>
+            <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+              <assemblyIdentity version="1.0.0.0" name="CodeIndex.App" processorArchitecture="*" type="win32" />
+            </assembly>
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "app_manifest", content);
+
+        Assert.Contains(symbols, symbol =>
+            symbol.Kind == "assembly"
+            && symbol.Name == "CodeIndex.App"
+            && symbol.Line == 5);
+    }
+
+    [Fact]
+    public void TryGetXmlStructureIssue_DtdDetectionDoesNotUseExceptionMessage_Issue3981()
+    {
+        const string content = """
+            <?xml version="1.0"?>
+            <!-- <!DOCTYPE ignored> -->
+            <!DOCTYPE root [
+              <!ENTITY injected "value">
+            ]>
+            <root />
+            """;
+
+        Assert.True(SymbolExtractor.TryGetXmlStructureIssue(content, out var issue));
+        Assert.Equal("xml_dtd_prohibited", issue.Kind);
+        Assert.Equal(3, issue.Line);
+    }
+
+    [Fact]
+    public void TryGetXmlStructureIssue_DocumentCharactersBeyondLimitEmitsBudgetIssue_Issue3981()
+    {
+        var content = "<root>" + new string('a', (int)SymbolExtractor.XmlExtractionMaxCharactersInDocument) + "</root>";
+
+        Assert.True(SymbolExtractor.TryGetXmlStructureIssue(content, out var issue));
+        Assert.Equal("xml_structure_budget_exceeded", issue.Kind);
+        Assert.Equal(1, issue.Line);
+        Assert.Contains("document length", issue.Message, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Centralized extractor XML reader settings with explicit DTD policy, disabled external resolution, and document/entity character limits.
- Kept MSBuild/XML validation on DTD prohibit and app manifest extraction on the intentional DTD-ignore path.
- Replaced DTD diagnostic classification based on XmlException message text with source declaration detection.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Issue3981"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ValidateContent_XmlDtd_EmitsValidationIssue_Issue3801"`
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- Attempted `dotnet test CodeIndex.sln --no-restore`; stopped after 15+ minutes with no failure output because local concurrent test load kept it from completing in a useful window.

## Documentation / Changelog
- Added `changelog.d/unreleased/3981.security.md`.
- No README/guide update required; this is extractor hardening without a new user-facing command or option.

## Follow-up Candidates
- None.

Refs #3959
Fixes #3981