### PR TITLE
Document and centralize sensitive buffer policy

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -2184,9 +2184,14 @@ bare `ArrayPool<byte>.Shared.Return(...)` at sensitive boundaries.
 When adding `ArrayPool<byte>` or in-memory accumulation (`MemoryStream`,
 captured `Utf8JsonWriter` output, report/archive buffers), first classify the
 data as sensitive bytes, bounded non-sensitive payload, generated JSON,
-archive/report bytes, or diagnostic snippet. Sensitive paths need a test that
-proves the cleared range; bounded accumulation paths need a test or constant
-that proves the maximum byte budget.
+archive/report bytes, or diagnostic snippet. Sensitive paths should route
+through `SensitiveBufferPolicy.ReturnSensitiveTokenBuffer`,
+`ReturnSensitivePayloadBuffer`, `ReturnSensitiveCopyBuffer`, or
+`ClearUsedSensitiveBytes`; these helper names are intended to be positive
+evidence during security audits. Bounded generated JSON capture should use
+`SensitiveBufferPolicy.GetBoundedGeneratedJsonInitialCapacity`. Sensitive paths
+need a test that proves the cleared range; bounded accumulation paths need a
+test or constant that proves the maximum byte budget.
 
 ## Custom Language Extraction
 
@@ -4052,7 +4057,11 @@ Cloud セッションは開発ループの中で `dotnet build` にフォール�
 
 `ArrayPool<byte>` や in-memory accumulation（`MemoryStream`、captured `Utf8JsonWriter` output、
 report/archive buffer）を追加するときは、まず data を sensitive bytes、bounded non-sensitive payload、
-generated JSON、archive/report bytes、diagnostic snippet に分類してください。Sensitive path には
+generated JSON、archive/report bytes、diagnostic snippet に分類してください。Sensitive path は
+`SensitiveBufferPolicy.ReturnSensitiveTokenBuffer`、`ReturnSensitivePayloadBuffer`、
+`ReturnSensitiveCopyBuffer`、`ClearUsedSensitiveBytes` を経由させてください。これらの helper 名は
+security audit で positive evidence として拾えるようにしています。Bounded generated JSON capture は
+`SensitiveBufferPolicy.GetBoundedGeneratedJsonInitialCapacity` を使ってください。Sensitive path には
 cleared range を証明するテストが必要です。Bounded accumulation path には maximum byte budget を
 証明するテストまたは定数が必要です。
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -2157,6 +2157,37 @@ The flag parser (`ProgramRunner.TryConsumeAuditLogFlags`) is run before `QueryCo
 - Documentation (README, CHANGELOG) is structured: English first, then Japanese.
 - No unnecessary production packages. Test-only packages are allowed when they clearly improve the harness and stay scoped to `tests/CodeIndex.Tests/`; they do not relax the production dependency rule.
 
+## Sensitive Buffer Policy
+
+Pooled byte buffers that may hold credentials, request payloads, local file
+bytes, or other user-controlled content must be cleared before the buffer can
+be observed again. Prefer a helper whose name states the policy instead of a
+bare `ArrayPool<byte>.Shared.Return(...)` at sensitive boundaries.
+
+- **Token material** uses full-buffer clearing when returning rented arrays.
+  `McpAuthenticationLimits.HashToken` hashes only the UTF-8 bytes written for
+  the token, zeroes that used range immediately, and returns the rented array
+  with `clearArray: true` so unused bytes from a previous rent are also erased.
+- **LSP request payloads** clear only the used payload range before returning a
+  rented buffer. The lease knows the declared content length, so clearing the
+  used range is the stable contract; bytes beyond that range are not part of
+  the payload and should not force a full rented-array clear on every request.
+- **Bounded HTTP copy buffers** are treated as possibly sensitive because they
+  can carry installer, archive, or response bytes before those bytes are
+  written to private storage. They clear the whole rented copy buffer before
+  returning it.
+- **ASCII protocol headers and generated JSON/report bytes** are not treated as
+  sensitive merely because they use pooled or accumulated storage. They still
+  need explicit maximum-byte budgets, but they do not require clearing unless
+  the call site starts carrying credentials or source payloads.
+
+When adding `ArrayPool<byte>` or in-memory accumulation (`MemoryStream`,
+captured `Utf8JsonWriter` output, report/archive buffers), first classify the
+data as sensitive bytes, bounded non-sensitive payload, generated JSON,
+archive/report bytes, or diagnostic snippet. Sensitive paths need a test that
+proves the cleared range; bounded accumulation paths need a test or constant
+that proves the maximum byte budget.
+
 ## Custom Language Extraction
 
 Downstream users can add lightweight language support without rebuilding
@@ -3999,6 +4030,31 @@ Cloud セッションは開発ループの中で `dotnet build` にフォール�
 - コメントは英日併記（例: `// Enable WAL mode / WALモードを有効化`）
 - ドキュメント（README, CHANGELOG）は前半英語、後半日本語の構成。
 - 不要な本番パッケージは入れない。test-only package は、テストハーネスの改善に明確に寄与し、`tests/CodeIndex.Tests/` に閉じる限り許容されるが、本番依存ルールを緩めるものではない。
+
+## センシティブバッファの方針
+
+認証情報、リクエスト payload、ローカルファイルの byte、その他 user-controlled content
+を保持しうる pooled byte buffer は、その buffer が再観測される前に clear する必要があります。
+センシティブ境界では素の `ArrayPool<byte>.Shared.Return(...)` より、方針を名前で示す helper を優先してください。
+
+- **Token material** は rented array を返すときに full-buffer clearing を使います。
+  `McpAuthenticationLimits.HashToken` は token として実際に書いた UTF-8 byte だけを hash し、
+  その used range をすぐ zero 化したうえで、rented array を `clearArray: true` で返すため、
+  過去の rent 由来の未使用 byte も消去されます。
+- **LSP request payload** は rented buffer を返す前に used payload range だけを clear します。
+  lease が宣言済み content length を保持しているため、used range clearing が安定した契約です。
+  その範囲外の byte は payload ではなく、リクエストごとに full rented-array clear を強制しません。
+- **Bounded HTTP copy buffer** は installer、archive、response byte を private storage に書く前に
+  通す可能性があるため、センシティブとして扱います。返却前に rented copy buffer 全体を clear します。
+- **ASCII protocol header と生成された JSON/report byte** は pooled / accumulated storage を使っていても、
+  それだけではセンシティブ扱いにしません。明示的な maximum-byte budget は必要ですが、call site が
+  認証情報や source payload を運び始めない限り clearing は必須ではありません。
+
+`ArrayPool<byte>` や in-memory accumulation（`MemoryStream`、captured `Utf8JsonWriter` output、
+report/archive buffer）を追加するときは、まず data を sensitive bytes、bounded non-sensitive payload、
+generated JSON、archive/report bytes、diagnostic snippet に分類してください。Sensitive path には
+cleared range を証明するテストが必要です。Bounded accumulation path には maximum byte budget を
+証明するテストまたは定数が必要です。
 
 ## カスタム言語抽出
 

--- a/changelog.d/unreleased/3989.docs.md
+++ b/changelog.d/unreleased/3989.docs.md
@@ -1,0 +1,18 @@
+---
+category: docs
+issues:
+  - 3989
+affected:
+  - DEVELOPER_GUIDE.md
+  - src/CodeIndex/Mcp/McpAuthentication.cs
+  - tests/CodeIndex.Tests/LspServerTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **Documented the sensitive buffer clearing policy (#3989)** — the developer guide now classifies token material, LSP request payloads, bounded HTTP copy buffers, and non-sensitive protocol/generated buffers, with focused tests covering token UTF-8 zeroing and LSP payload range clearing.
+
+## 日本語
+
+- **センシティブバッファの clearing 方針を文書化しました (#3989)** — 開発者ガイドで token material、LSP request payload、bounded HTTP copy buffer、非センシティブな protocol/generated buffer を分類し、token UTF-8 の zero 化と LSP payload range clearing を focused test で固定しました。

--- a/changelog.d/unreleased/4000.internal.md
+++ b/changelog.d/unreleased/4000.internal.md
@@ -1,0 +1,21 @@
+---
+category: internal
+issues:
+  - 4000
+affected:
+  - DEVELOPER_GUIDE.md
+  - src/CodeIndex/Security/SensitiveBufferPolicy.cs
+  - src/CodeIndex/Cli/BoundedHttpContentReader.cs
+  - src/CodeIndex/Lsp/LspServer.cs
+  - src/CodeIndex/Mcp/BoundedJsonUtf8Stream.cs
+  - src/CodeIndex/Mcp/McpAuthentication.cs
+  - tests/CodeIndex.Tests/SensitiveBufferPolicyTests.cs
+---
+
+## English
+
+- **Centralized sensitive buffer and bounded generated JSON policy (#4000)** — sensitive ArrayPool returns now route through `SensitiveBufferPolicy`, and bounded generated JSON capture uses a named helper with tests for the clear ranges and byte-budget clamp.
+
+## 日本語
+
+- **センシティブバッファと bounded generated JSON の方針を中央化しました (#4000)** — センシティブな ArrayPool 返却は `SensitiveBufferPolicy` 経由になり、bounded generated JSON capture も named helper を使うようにして、clear range と byte-budget clamp をテストで固定しました。

--- a/src/CodeIndex/Cli/BoundedHttpContentReader.cs
+++ b/src/CodeIndex/Cli/BoundedHttpContentReader.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using CodeIndex.Security;
 
 namespace CodeIndex.Cli;
 
@@ -90,20 +91,12 @@ internal static class BoundedHttpContentReader
         }
         finally
         {
-            ClearSensitiveCopyBuffer(buffer);
-            ArrayPool<byte>.Shared.Return(buffer, clearArray: false);
+            SensitiveBufferPolicy.ReturnSensitiveCopyBuffer(buffer);
         }
     }
 
     internal static void ClearSensitiveCopyBufferForTests(byte[] buffer) =>
-        ClearSensitiveCopyBuffer(buffer);
-
-    private static void ClearSensitiveCopyBuffer(byte[] buffer)
-    {
-        if (buffer.Length == 0)
-            return;
-        Array.Clear(buffer, 0, buffer.Length);
-    }
+        SensitiveBufferPolicy.ClearWholeSensitiveBuffer(buffer);
 
     private static void ThrowIfContentLengthExceedsLimit(HttpContent content, long maxBytes)
     {

--- a/src/CodeIndex/Lsp/LspServer.cs
+++ b/src/CodeIndex/Lsp/LspServer.cs
@@ -8,6 +8,7 @@ using CodeIndex.Cli;
 using CodeIndex.Database;
 using CodeIndex.Mcp;
 using CodeIndex.Models;
+using CodeIndex.Security;
 
 namespace CodeIndex.Lsp;
 
@@ -161,9 +162,7 @@ internal sealed class LspServer : IDisposable
 
         public void Dispose()
         {
-            ClearSensitivePayloadBuffer(Buffer, _usedBytes);
-            if (_rented)
-                ArrayPool<byte>.Shared.Return(Buffer, clearArray: false);
+            SensitiveBufferPolicy.ReturnSensitivePayloadBuffer(Buffer, _usedBytes, _rented);
         }
     }
 
@@ -401,7 +400,7 @@ internal sealed class LspServer : IDisposable
     }
 
     internal static void ClearSensitivePayloadBufferForTests(byte[] buffer, int usedBytes) =>
-        ClearSensitivePayloadBuffer(buffer, usedBytes);
+        SensitiveBufferPolicy.ClearUsedSensitiveBytes(buffer, usedBytes);
 
     private static SensitivePayloadBufferLease RentSensitivePayloadBuffer(int byteCount)
     {
@@ -412,13 +411,6 @@ internal sealed class LspServer : IDisposable
             ? ArrayPool<byte>.Shared.Rent(byteCount)
             : new byte[byteCount];
         return new SensitivePayloadBufferLease(buffer, byteCount, rented);
-    }
-
-    private static void ClearSensitivePayloadBuffer(byte[] buffer, int usedBytes)
-    {
-        if (usedBytes <= 0 || buffer.Length == 0)
-            return;
-        Array.Clear(buffer, 0, Math.Min(usedBytes, buffer.Length));
     }
 
     private static string SanitizeUnknownMethod(string method)
@@ -2179,7 +2171,7 @@ internal sealed class LspServer : IDisposable
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(buffer);
+            SensitiveBufferPolicy.ReturnNonSensitiveProtocolBuffer(buffer);
         }
     }
 

--- a/src/CodeIndex/Mcp/BoundedJsonUtf8Stream.cs
+++ b/src/CodeIndex/Mcp/BoundedJsonUtf8Stream.cs
@@ -1,10 +1,11 @@
 using System.Text;
+using CodeIndex.Security;
 
 namespace CodeIndex.Mcp;
 
 internal sealed class BoundedJsonUtf8Stream(int maxBytes, bool captureSerialized, Func<int, Exception> createLimitExceededException) : Stream
 {
-    private readonly MemoryStream? _buffer = captureSerialized ? new MemoryStream(Math.Min(Math.Max(maxBytes, 0), 16 * 1024)) : null;
+    private readonly MemoryStream? _buffer = captureSerialized ? new MemoryStream(SensitiveBufferPolicy.GetBoundedGeneratedJsonInitialCapacity(maxBytes)) : null;
 
     public int BytesWritten { get; private set; }
 

--- a/src/CodeIndex/Mcp/McpAuthentication.cs
+++ b/src/CodeIndex/Mcp/McpAuthentication.cs
@@ -103,6 +103,9 @@ internal static class McpAuthenticationLimits
         }
     }
 
+    internal static void HashTokenUtf8ForTests(ReadOnlySpan<char> token, Span<byte> utf8Buffer, Span<byte> destination) =>
+        HashTokenUtf8(token, utf8Buffer, destination);
+
     private static void HashTokenUtf8(ReadOnlySpan<char> token, Span<byte> utf8Buffer, Span<byte> destination)
     {
         var bytesWritten = Encoding.UTF8.GetBytes(token, utf8Buffer);

--- a/src/CodeIndex/Mcp/McpAuthentication.cs
+++ b/src/CodeIndex/Mcp/McpAuthentication.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json.Nodes;
+using CodeIndex.Security;
 
 namespace CodeIndex.Mcp;
 
@@ -99,7 +100,7 @@ internal static class McpAuthenticationLimits
         }
         finally
         {
-            ArrayPool<byte>.Shared.Return(rented, clearArray: true);
+            SensitiveBufferPolicy.ReturnSensitiveTokenBuffer(rented);
         }
     }
 
@@ -115,7 +116,7 @@ internal static class McpAuthenticationLimits
         }
         finally
         {
-            CryptographicOperations.ZeroMemory(utf8Buffer[..bytesWritten]);
+            SensitiveBufferPolicy.ClearSensitiveBytes(utf8Buffer[..bytesWritten]);
         }
     }
 }

--- a/src/CodeIndex/Security/SensitiveBufferPolicy.cs
+++ b/src/CodeIndex/Security/SensitiveBufferPolicy.cs
@@ -1,0 +1,48 @@
+using System.Buffers;
+using System.Security.Cryptography;
+
+namespace CodeIndex.Security;
+
+internal static class SensitiveBufferPolicy
+{
+    internal const int GeneratedJsonCaptureInitialCapacityBytes = 16 * 1024;
+
+    internal static int GetBoundedGeneratedJsonInitialCapacity(int maxBytes) =>
+        Math.Min(Math.Max(maxBytes, 0), GeneratedJsonCaptureInitialCapacityBytes);
+
+    internal static void ClearSensitiveBytes(Span<byte> bytes)
+    {
+        if (bytes.Length == 0)
+            return;
+        CryptographicOperations.ZeroMemory(bytes);
+    }
+
+    internal static void ClearUsedSensitiveBytes(byte[] buffer, int usedBytes)
+    {
+        if (usedBytes <= 0 || buffer.Length == 0)
+            return;
+        ClearSensitiveBytes(buffer.AsSpan(0, Math.Min(usedBytes, buffer.Length)));
+    }
+
+    internal static void ClearWholeSensitiveBuffer(byte[] buffer) =>
+        ClearSensitiveBytes(buffer.AsSpan());
+
+    internal static void ReturnSensitiveTokenBuffer(byte[] rented) =>
+        ArrayPool<byte>.Shared.Return(rented, clearArray: true);
+
+    internal static void ReturnSensitivePayloadBuffer(byte[] buffer, int usedBytes, bool rented)
+    {
+        ClearUsedSensitiveBytes(buffer, usedBytes);
+        if (rented)
+            ArrayPool<byte>.Shared.Return(buffer, clearArray: false);
+    }
+
+    internal static void ReturnSensitiveCopyBuffer(byte[] rented)
+    {
+        ClearWholeSensitiveBuffer(rented);
+        ArrayPool<byte>.Shared.Return(rented, clearArray: false);
+    }
+
+    internal static void ReturnNonSensitiveProtocolBuffer(byte[] rented) =>
+        ArrayPool<byte>.Shared.Return(rented);
+}

--- a/tests/CodeIndex.Tests/LspServerTests.cs
+++ b/tests/CodeIndex.Tests/LspServerTests.cs
@@ -63,6 +63,16 @@ public class LspServerTests
     }
 
     [Fact]
+    public void ClearSensitivePayloadBufferForTests_ClampsUsedBytesToBufferLength_Issue3989()
+    {
+        var buffer = new byte[] { 1, 2, 3 };
+
+        LspServer.ClearSensitivePayloadBufferForTests(buffer, usedBytes: 99);
+
+        Assert.Equal(new byte[] { 0, 0, 0 }, buffer);
+    }
+
+    [Fact]
     public void TryReadMessage_AcceptsHeaderLineAtMaxLength()
     {
         const string payload = "{}";

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -2807,6 +2807,19 @@ public sealed class Caller
     }
 
     [Fact]
+    public void McpAuthenticationLimits_HashTokenUtf8ForTests_ClearsUsedTokenBytes_Issue3989()
+    {
+        var buffer = Enumerable.Repeat((byte)0xA5, 16).ToArray();
+        var destination = new byte[McpAuthenticationLimits.Sha256HashBytes];
+
+        McpAuthenticationLimits.HashTokenUtf8ForTests("token", buffer, destination);
+
+        Assert.Equal(McpAuthenticationLimits.HashTokenToArray("token"), destination);
+        Assert.Equal(new byte[] { 0, 0, 0, 0, 0 }, buffer[..5]);
+        Assert.All(buffer[5..], value => Assert.Equal(0xA5, value));
+    }
+
+    [Fact]
     public void McpAuthenticatorFactory_NoEnv_ReturnsLocalStdio()
     {
         // FromEnvironment() must default to permissive stdio when the env var is unset or

--- a/tests/CodeIndex.Tests/SensitiveBufferPolicyTests.cs
+++ b/tests/CodeIndex.Tests/SensitiveBufferPolicyTests.cs
@@ -1,0 +1,40 @@
+using CodeIndex.Security;
+
+namespace CodeIndex.Tests;
+
+public class SensitiveBufferPolicyTests
+{
+    [Theory]
+    [InlineData(-1, 0)]
+    [InlineData(0, 0)]
+    [InlineData(1024, 1024)]
+    [InlineData(
+        SensitiveBufferPolicy.GeneratedJsonCaptureInitialCapacityBytes + 1,
+        SensitiveBufferPolicy.GeneratedJsonCaptureInitialCapacityBytes)]
+    public void GetBoundedGeneratedJsonInitialCapacity_ClampsToPolicyBudget_Issue4000(
+        int maxBytes,
+        int expected)
+    {
+        Assert.Equal(expected, SensitiveBufferPolicy.GetBoundedGeneratedJsonInitialCapacity(maxBytes));
+    }
+
+    [Fact]
+    public void ClearUsedSensitiveBytes_ClearsOnlyUsedRange_Issue4000()
+    {
+        var buffer = new byte[] { 1, 2, 3, 4 };
+
+        SensitiveBufferPolicy.ClearUsedSensitiveBytes(buffer, usedBytes: 2);
+
+        Assert.Equal(new byte[] { 0, 0, 3, 4 }, buffer);
+    }
+
+    [Fact]
+    public void ReturnSensitivePayloadBuffer_ClearsDirectBufferWithoutRequiringPoolReturn_Issue4000()
+    {
+        var buffer = new byte[] { 1, 2, 3, 4 };
+
+        SensitiveBufferPolicy.ReturnSensitivePayloadBuffer(buffer, usedBytes: 99, rented: false);
+
+        Assert.Equal(new byte[] { 0, 0, 0, 0 }, buffer);
+    }
+}


### PR DESCRIPTION
## Summary

- Documented the sensitive buffer clearing policy for token material, LSP payloads, bounded HTTP copy buffers, protocol headers, and generated payloads.
- Added `SensitiveBufferPolicy` so sensitive ArrayPool returns and bounded generated JSON capture use named policy helpers.
- Added focused tests for token UTF-8 zeroing, LSP payload clearing, helper range clearing, direct-buffer cleanup, and generated JSON capacity clamping.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~Issue3989 -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~Issue4000 -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation and Changelog

- Updated `DEVELOPER_GUIDE.md` in English and Japanese.
- Added `changelog.d/unreleased/3989.docs.md`.
- Added `changelog.d/unreleased/4000.internal.md`.

## Follow-up Candidates

None.

Fixes #3989
Fixes #4000