### PR TITLE
Gate relaxed JSONL encoder use

### DIFF
--- a/changelog.d/unreleased/3965.security.md
+++ b/changelog.d/unreleased/3965.security.md
@@ -1,0 +1,18 @@
+---
+category: security
+issues:
+  - 3965
+affected:
+  - src/CodeIndex/Diagnostics/LocalJsonlJsonWriterOptions.cs
+  - src/CodeIndex/Cli/MetricsSink.cs
+  - src/CodeIndex/Mcp/AuditLogSink.cs
+  - tests/CodeIndex.Tests/LocalJsonlJsonWriterOptionsTests.cs
+---
+
+## English
+
+- **Relaxed JSON escaping is now gated to local JSONL diagnostics sinks (#3965)** — metrics and MCP audit logs share a named local-only writer option, and tests prevent relaxed escaping from spreading into HTTP, HTML, or externally embedded JSON surfaces.
+
+## 日本語
+
+- **relaxed JSON escaping を local JSONL 診断 sink に限定しました (#3965)** — メトリクスと MCP 監査ログは local-only の名前付き writer option を共有し、HTTP、HTML、外部埋め込み JSON に relaxed escaping が広がらないようテストで固定しました。

--- a/src/CodeIndex/Cli/MetricsSink.cs
+++ b/src/CodeIndex/Cli/MetricsSink.cs
@@ -1,8 +1,8 @@
 using System.Globalization;
 using System.Text;
-using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Threading;
+using CodeIndex.Diagnostics;
 
 namespace CodeIndex.Cli;
 
@@ -248,18 +248,7 @@ internal static class MetricsSink
     private static byte[] SerializeEventBytes(MetricsEvent evt, int maxStringChars)
     {
         using var buffer = new MemoryStream();
-        using (var jw = new Utf8JsonWriter(buffer, new JsonWriterOptions
-        {
-            Indented = false,
-            // The default strict encoder escapes characters the JSON spec does not
-            // strictly require to be literal (e.g. the `+` in ISO-8601 timezone
-            // offsets becomes a unicode escape). Use the relaxed encoder so the
-            // JSONL stays human-readable in tail / grep workflows; the file is
-            // local-only.
-            // strict encoder は ISO-8601 timestamp の `+` 等まで unicode escape
-            // するため、ローカル前提の JSONL が tail / grep で読みづらくなる。relaxed encoder で人間可読のまま残す。
-            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-        }))
+        using (var jw = new Utf8JsonWriter(buffer, LocalJsonlJsonWriterOptions.Create()))
         {
             jw.WriteStartObject();
             jw.WriteString("timestamp", evt.Timestamp.ToString("O", CultureInfo.InvariantCulture));

--- a/src/CodeIndex/Diagnostics/LocalJsonlJsonWriterOptions.cs
+++ b/src/CodeIndex/Diagnostics/LocalJsonlJsonWriterOptions.cs
@@ -1,0 +1,23 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace CodeIndex.Diagnostics;
+
+/// <summary>
+/// JsonWriterOptions for local append-only JSONL diagnostics files only.
+/// </summary>
+internal static class LocalJsonlJsonWriterOptions
+{
+    internal static JsonWriterOptions Create()
+    {
+        // UnsafeRelaxedJsonEscaping is intentionally limited to private local JSONL
+        // files that operators read with tail/grep. Do not reuse these options for
+        // HTTP responses, HTML/script embedding, copied snippets, or any externally
+        // embedded JSON surface.
+        return new JsonWriterOptions
+        {
+            Indented = false,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        };
+    }
+}

--- a/src/CodeIndex/Mcp/AuditLogSink.cs
+++ b/src/CodeIndex/Mcp/AuditLogSink.cs
@@ -1,7 +1,6 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
-using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
@@ -412,13 +411,7 @@ internal sealed class AuditLogSink : IDisposable
             bytes => new AuditEventByteLimitExceededException(bytes));
         try
         {
-            using (var jw = new Utf8JsonWriter(buffer, new JsonWriterOptions
-            {
-                Indented = false,
-                // Mirror MetricsSink: local-only JSONL stays human readable in tail/grep.
-                // 出力は local 限定なので tail/grep で読める relaxed encoder を使う。
-                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
-            }))
+            using (var jw = new Utf8JsonWriter(buffer, LocalJsonlJsonWriterOptions.Create()))
             {
                 WriteEventCore(jw, evt, includeValues);
             }

--- a/tests/CodeIndex.Tests/LocalJsonlJsonWriterOptionsTests.cs
+++ b/tests/CodeIndex.Tests/LocalJsonlJsonWriterOptionsTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Encodings.Web;
+using CodeIndex.Diagnostics;
+
+namespace CodeIndex.Tests;
+
+public class LocalJsonlJsonWriterOptionsTests
+{
+    [Fact]
+    public void Create_ReturnsRelaxedLocalJsonlOptions()
+    {
+        var options = LocalJsonlJsonWriterOptions.Create();
+
+        Assert.False(options.Indented);
+        Assert.Same(JavaScriptEncoder.UnsafeRelaxedJsonEscaping, options.Encoder);
+    }
+
+    [Fact]
+    public void RelaxedEncoderAndHelperStayLimitedToLocalJsonlSinks()
+    {
+        var repositoryRoot = FindRepositoryRootForTest();
+        AssertOnlyAllowedFilesContain(
+            repositoryRoot,
+            "UnsafeRelaxedJsonEscaping",
+            new[]
+            {
+                "src/CodeIndex/Diagnostics/LocalJsonlJsonWriterOptions.cs",
+                "tests/CodeIndex.Tests/LocalJsonlJsonWriterOptionsTests.cs",
+            });
+        AssertOnlyAllowedFilesContain(
+            repositoryRoot,
+            "LocalJsonlJsonWriterOptions.Create()",
+            new[]
+            {
+                "src/CodeIndex/Cli/MetricsSink.cs",
+                "src/CodeIndex/Mcp/AuditLogSink.cs",
+                "tests/CodeIndex.Tests/LocalJsonlJsonWriterOptionsTests.cs",
+            });
+    }
+
+    private static void AssertOnlyAllowedFilesContain(
+        string repositoryRoot,
+        string text,
+        IEnumerable<string> allowedRelativePaths)
+    {
+        var allowed = new HashSet<string>(
+            allowedRelativePaths.Select(NormalizeRelativePath),
+            StringComparer.Ordinal);
+        var offenders = EnumerateSourceFiles(repositoryRoot)
+            .Select(path => new
+            {
+                FullPath = path,
+                RelativePath = NormalizeRelativePath(Path.GetRelativePath(repositoryRoot, path)),
+            })
+            .Where(file => !allowed.Contains(file.RelativePath))
+            .Where(file => File.ReadAllText(file.FullPath).Contains(text, StringComparison.Ordinal))
+            .Select(file => file.RelativePath)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.Empty(offenders);
+    }
+
+    private static IEnumerable<string> EnumerateSourceFiles(string repositoryRoot)
+    {
+        foreach (var root in new[] { "src/CodeIndex", "tests/CodeIndex.Tests" })
+        {
+            var fullRoot = Path.Combine(repositoryRoot, root);
+            foreach (var path in Directory.EnumerateFiles(fullRoot, "*.cs", SearchOption.AllDirectories))
+            {
+                if (IsBuildOutput(path))
+                    continue;
+                yield return path;
+            }
+        }
+    }
+
+    private static bool IsBuildOutput(string path)
+    {
+        foreach (var segment in path.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar))
+        {
+            if (segment is "bin" or "obj")
+                return true;
+        }
+
+        return false;
+    }
+
+    private static string NormalizeRelativePath(string path) =>
+        path.Replace(Path.DirectorySeparatorChar, '/').Replace(Path.AltDirectorySeparatorChar, '/');
+
+    private static string FindRepositoryRootForTest()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "CHANGELOG.md")) &&
+                File.Exists(Path.Combine(current.FullName, "CodeIndex.sln")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new InvalidOperationException("Could not locate repository root.");
+    }
+}


### PR DESCRIPTION
## Summary
- Centralize relaxed JSON writer options behind a named local-only JSONL helper.
- Route metrics and MCP audit JSONL serialization through that helper.
- Add tests that keep relaxed escaping and helper usage limited to the local JSONL sinks.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~LocalJsonlJsonWriterOptionsTests|FullyQualifiedName~MetricsSinkTests|FullyQualifiedName~AuditLogSinkTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet test`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: No blocking/actionable issues found.

## Documentation / Changelog
- Added `changelog.d/unreleased/3965.security.md`.
- No AGENTS.md, CLAUDE.md, or AGENT_GUIDE.md changes.

Fixes #3965