### PR TITLE
Add source-code guard diagnostics

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -1208,11 +1208,11 @@ The shared GitHub HTTP client uses an explicit 10-second submission timeout by d
 
 ### Heuristic source code guard (not a security boundary)
 
-The description, context, and optional tool invocation context fields pass through `SourceCodeDetector` before storage and optional GitHub submission. This heuristic rejects common pasted code patterns (multi-line blocks, backtick or tilde fenced code, import runs, function definitions) but intentionally allows short inline code examples so gap descriptions remain useful. Rejections return a bounded `source_code_rejection` object with the rejected field name and stable `reason_code`; they do not echo the rejected text. It is **not a security boundary** — a determined agent could bypass it. The guard is a best-effort filter to catch accidental code inclusion, not a guarantee that no code-like text will ever be transmitted.
+The description, context, and optional tool invocation context fields pass through `SourceCodeDetector` before storage and optional GitHub submission. This heuristic rejects common pasted code patterns (multi-line blocks, backtick or tilde fenced code, import runs, function definitions) but intentionally allows short inline code examples so gap descriptions remain useful. Rejections return a bounded `source_code_rejection` object with the rejected field name, stable primary `reason_code`, and `reason_code_counts` diagnostics for the heuristics that matched; they do not echo the rejected text. It is **not a security boundary** or data-loss-prevention boundary — a determined agent could bypass it, and encoded or obfuscated code-like text can be a false negative. The guard is a best-effort filter to catch accidental code inclusion, not a guarantee that no code-like text will ever be transmitted.
 
 ### SourceCodeDetector design
 
-`SourceCodeDetector` uses six independent heuristics to reject text that looks like pasted source code. Each heuristic is implemented as a clearly named private method with detailed comments explaining what it detects and why, and maps to a stable reason code such as `statement-ending`, `indented-code-lines`, `block-structure`, `repeated-imports`, `function-definition`, or `fenced-code-block`. The class is designed for readability: anyone reviewing the open-source code can verify the detection logic and confirm that no source code passes through.
+`SourceCodeDetector` uses six independent heuristics to reject text that looks like pasted source code. Each heuristic is implemented as a clearly named private method with detailed comments explaining what it detects and why, and maps to a stable reason code such as `statement-ending`, `indented-code-lines`, `block-structure`, `repeated-imports`, `function-definition`, or `fenced-code-block`. Detection evaluates every heuristic so diagnostics can report matched reason-code counts while preserving the first matched reason as the primary `reason_code`. The class is designed for readability: anyone reviewing the open-source code can verify the detection logic and understand the false-negative tradeoff.
 
 The detector intentionally allows short inline code examples (e.g. `` `const foo = () => {}` ``) and only rejects multi-line code blocks. False negatives (missing some code) are acceptable; false positives (rejecting valid descriptions) are not.
 
@@ -3456,11 +3456,11 @@ upstream Issue を作成する前に、`GitHubIssueReporter` は同じ SHA256 �
 
 ### ヒューリスティックなソースコードガード（セキュリティ境界ではない）
 
-description、context、および任意の tool invocation context フィールドは、保存およびオプションの GitHub 送信前に `SourceCodeDetector` を通過する。このヒューリスティックは一般的なコードコピペパターン（複数行ブロック、バッククォートまたはチルダのフェンスドコード、import の連打、関数定義）を拒否するが、ギャップの説明として有用な短いインラインコード例は意図的に許容する。拒否時は、拒否対象フィールド名と安定した `reason_code` を持つ上限付きの `source_code_rejection` object を返し、拒否された本文は反映しない。これは**セキュリティ境界ではない** — 意図的に回避しようとするエージェントは回避できる。このガードはコードの誤混入を防ぐベストエフォートのフィルタであり、コード的テキストが一切送信されないことの保証ではない。
+description、context、および任意の tool invocation context フィールドは、保存およびオプションの GitHub 送信前に `SourceCodeDetector` を通過する。このヒューリスティックは一般的なコードコピペパターン（複数行ブロック、バッククォートまたはチルダのフェンスドコード、import の連打、関数定義）を拒否するが、ギャップの説明として有用な短いインラインコード例は意図的に許容する。拒否時は、拒否対象フィールド名、安定した主理由の `reason_code`、およびマッチしたヒューリスティックの `reason_code_counts` 診断を持つ上限付きの `source_code_rejection` object を返し、拒否された本文は反映しない。これは**セキュリティ境界でもデータ漏えい防止境界でもない** — 意図的に回避しようとするエージェントは回避でき、エンコードまたは難読化されたコード風テキストは偽陰性になり得る。このガードはコードの誤混入を防ぐベストエフォートのフィルタであり、コード的テキストが一切送信されないことの保証ではない。
 
 ### SourceCodeDetector の設計
 
-`SourceCodeDetector` は6つの独立したヒューリスティックを使って、コピペされたソースコードに見えるテキストを拒否する。各ヒューリスティックは明確な名前の private メソッドとして実装され、何を検出し、なぜそれがソースコードの兆候なのかを詳細なコメントで説明している。また、`statement-ending`、`indented-code-lines`、`block-structure`、`repeated-imports`、`function-definition`、`fenced-code-block` のような安定した理由コードに対応する。可読性を重視して設計されており、オープンソースのコードをレビューする誰もが検出ロジックを検証し、ソースコードが通過しないことを確認できる。
+`SourceCodeDetector` は6つの独立したヒューリスティックを使って、コピペされたソースコードに見えるテキストを拒否する。各ヒューリスティックは明確な名前の private メソッドとして実装され、何を検出し、なぜそれがソースコードの兆候なのかを詳細なコメントで説明している。また、`statement-ending`、`indented-code-lines`、`block-structure`、`repeated-imports`、`function-definition`、`fenced-code-block` のような安定した理由コードに対応する。検出時はすべてのヒューリスティックを評価するため、最初にマッチした理由を主 `reason_code` として維持しながら、マッチした理由コードの件数を診断として返せる。可読性を重視して設計されており、オープンソースのコードをレビューする誰もが検出ロジックと偽陰性のトレードオフを理解できる。
 
 短いインラインコード例（例: `` `const foo = () => {}` ``）は意図的に許容し、複数行のコードブロックのみを拒否する。偽陰性（一部のコードの見逃し）は許容する。偽陽性（有効な説明の拒否）は許容しない。
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -2374,7 +2374,7 @@ The MCP `tools/list` response includes an `examples` array for every registered 
 | `backfill_fold` | Upgrade folded-name keys in an existing DB without reparsing source files |
 | `suggest_improvement` | Submit structured improvement suggestions or error reports |
 
-`suggest_improvement` always stores accepted suggestions locally. Its response includes `submitted_to_github` and `github_submission_reason` so clients can distinguish `submitted`, `token_not_configured`, `repo_not_configured`, `network_error`, and `api_error`; failed GitHub attempts also include `github_submission_error`. If the source-code guard rejects `description`, `context`, or `toolInvocationContext`, the error `structuredContent` includes `source_code_rejection.field` and `source_code_rejection.reason_code` without echoing the rejected text.
+`suggest_improvement` always stores accepted suggestions locally. Its response includes `submitted_to_github` and `github_submission_reason` so clients can distinguish `submitted`, `token_not_configured`, `repo_not_configured`, `network_error`, and `api_error`; failed GitHub attempts also include `github_submission_error`. If the source-code guard rejects `description`, `context`, or `toolInvocationContext`, the error `structuredContent` includes `source_code_rejection.field`, the primary `source_code_rejection.reason_code`, and bounded `source_code_rejection.reason_code_counts` diagnostics without echoing the rejected text. The guard is a convenience filter for accidental pasted code, not a data-loss-prevention or security boundary; encoded or obfuscated code-like text may pass through.
 
 The MCP `index` tool returns a `diagnostics` object when non-fatal indexing problems occur. It includes category counts and up to 50 bounded items for recoverable indexing errors and skipped file-size measurements; item paths are project-relative when possible, and messages are redacted and bounded so permission or path failures can be acted on without leaking local absolute paths or token-shaped values.
 
@@ -4931,7 +4931,7 @@ OpenAI Codex CLI (`codex.json` または `~/.codex/config.json`):
 | `backfill_fold` | 既存 DB の folded-name key をソース再解析なしで更新 |
 | `suggest_improvement` | 構造化された改善提案またはエラー報告を送信 |
 
-`suggest_improvement` は受理した提案を常にローカル保存します。応答には `submitted_to_github` と `github_submission_reason` が含まれ、クライアントは `submitted`、`token_not_configured`、`repo_not_configured`、`network_error`、`api_error` を区別できます。GitHub 送信に失敗した場合は `github_submission_error` も含まれます。ソースコードガードが `description`、`context`、または `toolInvocationContext` を拒否した場合、エラーの `structuredContent` には拒否された本文を反映せずに `source_code_rejection.field` と `source_code_rejection.reason_code` が含まれます。
+`suggest_improvement` は受理した提案を常にローカル保存します。応答には `submitted_to_github` と `github_submission_reason` が含まれ、クライアントは `submitted`、`token_not_configured`、`repo_not_configured`、`network_error`、`api_error` を区別できます。GitHub 送信に失敗した場合は `github_submission_error` も含まれます。ソースコードガードが `description`、`context`、または `toolInvocationContext` を拒否した場合、エラーの `structuredContent` には拒否された本文を反映せずに `source_code_rejection.field`、主理由の `source_code_rejection.reason_code`、および上限付き診断の `source_code_rejection.reason_code_counts` が含まれます。このガードは誤って貼り付けられたコードを拾う便宜的なフィルタであり、データ漏えい防止やセキュリティ境界ではありません。エンコードまたは難読化されたコード風テキストは通過する可能性があります。
 
 MCP の `index` tool は、致命的ではない indexing 問題が発生した場合に `diagnostics` object を返します。recoverable な indexing error と file-size 測定 skip について category count と最大 50 件の bounded item を含み、path は可能な限り project-relative、message は redaction と上限適用済みなので、local absolute path や token 風の値を漏らさず permission / path 問題を判断できます。
 

--- a/changelog.d/unreleased/3974.security.md
+++ b/changelog.d/unreleased/3974.security.md
@@ -1,0 +1,20 @@
+---
+category: security
+issues:
+  - 3974
+affected:
+  - src/CodeIndex/Cli/SourceCodeDetector.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/SourceCodeDetectorTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+  - USER_GUIDE.md
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Source-code guard diagnostics now include matched reason counts (#3974)** — `suggest_improvement` rejections keep the primary `source_code_rejection.reason_code`, add bounded `reason_code_counts` diagnostics without echoing rejected text, and document that the guard is a convenience filter rather than a security or data-loss-prevention boundary.
+
+## 日本語
+
+- **ソースコードガード診断にマッチした理由件数を追加しました (#3974)** — `suggest_improvement` の拒否は主理由の `source_code_rejection.reason_code` を維持し、拒否された本文を反映せずに上限付きの `reason_code_counts` 診断を追加します。また、このガードがセキュリティ境界やデータ漏えい防止境界ではなく便宜的なフィルタであることを明記しました。

--- a/src/CodeIndex/Cli/SourceCodeDetector.cs
+++ b/src/CodeIndex/Cli/SourceCodeDetector.cs
@@ -7,11 +7,25 @@ namespace CodeIndex.Cli;
 /// Source-code detection result with a stable reason code for diagnostics.
 /// 診断用の安定した理由コードを持つソースコード検出結果。
 /// </summary>
-public readonly record struct SourceCodeDetectionResult(bool ContainsSourceCode, string? ReasonCode)
+public readonly record struct SourceCodeDetectionResult(
+    bool ContainsSourceCode,
+    string? ReasonCode,
+    IReadOnlyDictionary<string, int> ReasonCounts)
 {
-    public static SourceCodeDetectionResult NoSourceCode { get; } = new(false, null);
+    private static readonly IReadOnlyDictionary<string, int> EmptyReasonCounts = new Dictionary<string, int>(StringComparer.Ordinal);
 
-    public static SourceCodeDetectionResult Detected(string reasonCode) => new(true, reasonCode);
+    public SourceCodeDetectionResult(bool containsSourceCode, string? reasonCode)
+        : this(containsSourceCode, reasonCode, EmptyReasonCounts)
+    {
+    }
+
+    public static SourceCodeDetectionResult NoSourceCode { get; } = new(false, null, EmptyReasonCounts);
+
+    public static SourceCodeDetectionResult Detected(string reasonCode) =>
+        new(true, reasonCode, new Dictionary<string, int>(StringComparer.Ordinal) { [reasonCode] = 1 });
+
+    public static SourceCodeDetectionResult Detected(string reasonCode, IReadOnlyDictionary<string, int> reasonCounts) =>
+        new(true, reasonCode, reasonCounts);
 }
 
 /// <summary>
@@ -137,25 +151,27 @@ public static class SourceCodeDetector
         // 各ヒューリスティックを独立して実行する。
         // 1つでもマッチすればテキストをフラグする。
 
-        if (HasCodeStatementPattern(text))
-            return SourceCodeDetectionResult.Detected(ReasonStatementEnding);
+        var reasonCounts = new Dictionary<string, int>(StringComparer.Ordinal);
+        string? primaryReason = null;
 
-        if (HasConsecutiveCodeLines(text))
-            return SourceCodeDetectionResult.Detected(ReasonIndentedCodeLines);
+        CountReason(ReasonStatementEnding, HasCodeStatementPattern(text));
+        CountReason(ReasonIndentedCodeLines, HasConsecutiveCodeLines(text));
+        CountReason(ReasonBlockStructure, HasBlockStructure(text));
+        CountReason(ReasonRepeatedImports, HasRepeatedImports(text));
+        CountReason(ReasonFunctionDefinition, HasMultiLineFunctionDefinition(text));
+        CountReason(ReasonFencedCodeBlock, HasFencedCodeBlock(text));
 
-        if (HasBlockStructure(text))
-            return SourceCodeDetectionResult.Detected(ReasonBlockStructure);
+        return primaryReason is null
+            ? SourceCodeDetectionResult.NoSourceCode
+            : SourceCodeDetectionResult.Detected(primaryReason, reasonCounts);
 
-        if (HasRepeatedImports(text))
-            return SourceCodeDetectionResult.Detected(ReasonRepeatedImports);
-
-        if (HasMultiLineFunctionDefinition(text))
-            return SourceCodeDetectionResult.Detected(ReasonFunctionDefinition);
-
-        if (HasFencedCodeBlock(text))
-            return SourceCodeDetectionResult.Detected(ReasonFencedCodeBlock);
-
-        return SourceCodeDetectionResult.NoSourceCode;
+        void CountReason(string reasonCode, bool matched)
+        {
+            if (!matched)
+                return;
+            reasonCounts[reasonCode] = reasonCounts.TryGetValue(reasonCode, out var count) ? count + 1 : 1;
+            primaryReason ??= reasonCode;
+        }
     }
 
     // ---------------------------------------------------------------

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -6992,6 +6992,9 @@ public partial class McpServer
     private static JsonObject CreateSourceCodeReasonCounts(SourceCodeDetectionResult detection)
     {
         var counts = new JsonObject();
+        if (detection.ReasonCounts is null)
+            return counts;
+
         foreach (var reason in detection.ReasonCounts)
         {
             if (reason.Value > 0)

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -6977,6 +6977,7 @@ public partial class McpServer
             {
                 ["field"] = field,
                 ["reason_code"] = detection.ReasonCode ?? "unknown",
+                ["reason_code_counts"] = CreateSourceCodeReasonCounts(detection),
             },
         };
         return CreateToolErrorResponse(
@@ -6986,6 +6987,18 @@ public partial class McpServer
             suggestion: "Describe the gap in natural language without including code.",
             retrySafe: false,
             extraData: extraData);
+    }
+
+    private static JsonObject CreateSourceCodeReasonCounts(SourceCodeDetectionResult detection)
+    {
+        var counts = new JsonObject();
+        foreach (var reason in detection.ReasonCounts)
+        {
+            if (reason.Value > 0)
+                counts[reason.Key] = reason.Value;
+        }
+
+        return counts;
     }
 
     private static string[]? ReadEvidencePaths(JsonNode? node, out string? error)

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -15431,6 +15431,11 @@ public sealed class Caller
         var rejection = response["result"]!["structuredContent"]!["source_code_rejection"]!;
         Assert.Equal("description", rejection["field"]!.GetValue<string>());
         Assert.Equal(SourceCodeDetector.ReasonStatementEnding, rejection["reason_code"]!.GetValue<string>());
+        var reasonCounts = rejection["reason_code_counts"]!.AsObject();
+        Assert.Equal(1, reasonCounts[SourceCodeDetector.ReasonStatementEnding]!.GetValue<int>());
+        Assert.Equal(1, reasonCounts[SourceCodeDetector.ReasonIndentedCodeLines]!.GetValue<int>());
+        Assert.Equal(1, reasonCounts[SourceCodeDetector.ReasonBlockStructure]!.GetValue<int>());
+        Assert.Equal(1, reasonCounts[SourceCodeDetector.ReasonFunctionDefinition]!.GetValue<int>());
     }
 
     [Fact]
@@ -15458,6 +15463,8 @@ public sealed class Caller
         var rejection = response["result"]!["structuredContent"]!["source_code_rejection"]!;
         Assert.Equal("description", rejection["field"]!.GetValue<string>());
         Assert.Equal(SourceCodeDetector.ReasonFencedCodeBlock, rejection["reason_code"]!.GetValue<string>());
+        var reasonCounts = rejection["reason_code_counts"]!.AsObject();
+        Assert.Equal(1, reasonCounts[SourceCodeDetector.ReasonFencedCodeBlock]!.GetValue<int>());
         Assert.DoesNotContain(leakedToken, response.ToJsonString());
     }
 

--- a/tests/CodeIndex.Tests/SourceCodeDetectorTests.cs
+++ b/tests/CodeIndex.Tests/SourceCodeDetectorTests.cs
@@ -41,12 +41,42 @@ public class SourceCodeDetectorTests
         Assert.False(SourceCodeDetector.ContainsSourceCode(text));
     }
 
+    [Theory]
+    [InlineData("The base64 payload `cHVibGljIHZvaWQgRm9vKCkgeyByZXR1cm47IH0=` should be discussed without decoding it.")]
+    [InlineData("The obfuscated sample p u b l i c v o i d Foo ( ) { r e t u r n ; } should be treated as prose here.")]
+    public void AllowsEncodedOrObfuscatedTextBecauseGuardIsNotSecurityBoundary_Issue3974(string text)
+    {
+        var result = SourceCodeDetector.Detect(text);
+
+        Assert.False(result.ContainsSourceCode);
+        Assert.Null(result.ReasonCode);
+        Assert.Empty(result.ReasonCounts);
+    }
+
     [Fact]
     public void AllowsSingleLineCodeMention()
     {
         // Mentioning a single line of code in a sentence is fine.
         // 文中で1行のコードに言及するのは問題ない。
         var text = "When I write `public class MyRecord : IDisposable`, the symbol extractor misses it.";
+        Assert.False(SourceCodeDetector.ContainsSourceCode(text));
+    }
+
+    [Theory]
+    [InlineData("Rust macro call `println!(\"hi\")` is not indexed as a symbol.")]
+    [InlineData("SQL mention `SELECT * FROM files WHERE path = ?` should stay inline.")]
+    [InlineData("Python example `def foo():` is a heading mention, not a pasted function body.")]
+    public void AllowsShortInlineExamples_Issue3974(string text)
+    {
+        Assert.False(SourceCodeDetector.ContainsSourceCode(text));
+    }
+
+    [Fact]
+    public void AllowsMultilingualProseWithCodeTerms_Issue3974()
+    {
+        var text = "日本語の説明: Python の `def foo():` が見出しとして扱われる。"
+                 + " English note: this is prose about function extraction, not a pasted function body.";
+
         Assert.False(SourceCodeDetector.ContainsSourceCode(text));
     }
 
@@ -90,6 +120,7 @@ public class SourceCodeDetectorTests
         Assert.False(SourceCodeDetector.ContainsSourceCode("   "));
         Assert.False(SourceCodeDetector.ContainsSourceCode(null!));
         Assert.Null(SourceCodeDetector.Detect(null).ReasonCode);
+        Assert.Empty(SourceCodeDetector.Detect(null).ReasonCounts);
     }
 
     [Fact]
@@ -331,6 +362,40 @@ public class SourceCodeDetectorTests
                  + "    puts 'done'\n"
                  + "end";
         Assert.True(SourceCodeDetector.ContainsSourceCode(text));
+    }
+
+    [Theory]
+    [InlineData("The failure uses this function:\nfunction load() {\n    const token = readToken();\n    return token;\n}")]
+    [InlineData("Here are the imports:\nimport alpha\nimport beta\nimport gamma")]
+    [InlineData("Indented snippet:\n    var current = 1\n    return current\n    Console.WriteLine(current)")]
+    public void RejectsAdversarialMultiLineSnippets_Issue3974(string text)
+    {
+        Assert.True(SourceCodeDetector.ContainsSourceCode(text));
+    }
+
+    [Fact]
+    public void Detect_ReportsMatchedReasonCounts_Issue3974()
+    {
+        var text = "using System;\n"
+                 + "using System.IO;\n"
+                 + "using System.Linq;\n"
+                 + "public void Run()\n"
+                 + "{\n"
+                 + "    var value = 1;\n"
+                 + "    return;\n"
+                 + "    Console.WriteLine(value);\n"
+                 + "}";
+
+        var result = SourceCodeDetector.Detect(text);
+
+        Assert.True(result.ContainsSourceCode);
+        Assert.Equal(SourceCodeDetector.ReasonStatementEnding, result.ReasonCode);
+        Assert.Equal(1, result.ReasonCounts[SourceCodeDetector.ReasonStatementEnding]);
+        Assert.Equal(1, result.ReasonCounts[SourceCodeDetector.ReasonIndentedCodeLines]);
+        Assert.Equal(1, result.ReasonCounts[SourceCodeDetector.ReasonBlockStructure]);
+        Assert.Equal(1, result.ReasonCounts[SourceCodeDetector.ReasonRepeatedImports]);
+        Assert.Equal(1, result.ReasonCounts[SourceCodeDetector.ReasonFunctionDefinition]);
+        Assert.False(result.ReasonCounts.ContainsKey(SourceCodeDetector.ReasonFencedCodeBlock));
     }
 
     // ================================================================


### PR DESCRIPTION
## Summary
- Preserve the primary `source_code_rejection.reason_code` while adding bounded `reason_code_counts` diagnostics for matched SourceCodeDetector heuristics.
- Add Issue #3974 adversarial coverage for encoded/obfuscated prose, multilingual prose, short inline examples, multi-line snippets, and MCP error payloads.
- Document in English and Japanese that the guard is a convenience filter, not a security or data-loss-prevention boundary, and add a changelog fragment.

## Validation
- `dotnet build`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~SourceCodeDetectorTests`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~McpServerTests.SuggestImprovement`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter FullyQualifiedName~InstallScriptTests.DownloadAndInstall_UsesConfiguredReleaseBaseUrl`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Full `dotnet test` was also attempted; the run reported `InstallScriptTests.DownloadAndInstall_UsesConfiguredReleaseBaseUrl` once and was interrupted after unrelated concurrent `dotnet` activity. That test passed when rerun alone.

## Review Notes
- Codex adversarial review was attempted with `codex exec review --commit HEAD`, but the nested Codex environment could not execute even minimal shell commands (`/bin/zsh` exit 134) and Node REPL failed with `sandboxCwd must be an absolute file URI` before producing review findings. A manual adversarial pass found and fixed default-struct null handling for reason counts; no remaining blocking/actionable issues found.

Fixes #3974