### PR TITLE
Scrub subprocess environments and unify GitHub download policy

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -411,6 +411,14 @@ On startup, `cdidx` walks up from the current directory looking for `.cdidx-vers
 
 `cdidx --check-updates` and `cdidx status --check-updates` query the GitHub latest-release endpoint through `UpdateChecker`, using the same 24-hour cache and `CDIDX_DISABLE_UPDATE_CHECK=1` opt-out as the `--version` hint. `cdidx upgrade --check-only` reuses that check. `cdidx upgrade` is intentionally a thin wrapper around the signed release installer: it downloads `install.sh`, verifies the current binary directory is writable, sets `CDIDX_INSTALL_DIR` to that directory, and runs the installer for the latest release.
 
+Upgrade installer and git subprocesses scrub the inherited process environment
+before launch. They forward only the shared subprocess allowlist needed for
+PATH/home/temp/proxy/certificate behavior plus tool-specific knobs such as
+`CDIDX_INSTALL_DIR`, installer verification variables, and selected `GIT_*`
+controls. `CDIDX_TEST_*` variables are not a public runtime contract; they are
+forwarded only to isolated worker processes so repository tests can exercise
+worker-only hooks without exposing the rest of the host environment.
+
 `cdidx upgrade --json` has a stdout contract suitable for automation. Check-only
 and no-update results use the update-check fields
 (`current_version`, `latest_version`, `update_available`, `from_cache`,
@@ -2670,6 +2678,13 @@ endpoint を確認します。`cdidx upgrade --check-only` はこの check を�
 `cdidx upgrade` は signed release installer の薄い wrapper で、`install.sh` を download し、
 現在の binary directory が writable か確認し、`CDIDX_INSTALL_DIR` をその directory に向けて
 latest release の installer を実行します。
+
+Upgrade installer と git subprocess は、起動前に継承環境を scrub します。
+forward するのは、PATH / home / temp / proxy / certificate 挙動に必要な共有 subprocess
+allowlist と、`CDIDX_INSTALL_DIR`、installer verification variables、選択された `GIT_*`
+controls のような tool-specific knob だけです。`CDIDX_TEST_*` variables は public runtime
+contract ではありません。repository tests が worker-only hook を検証できるよう、isolated worker
+process にだけ forward します。
 
 `cdidx upgrade --json` は automation 向けの stdout contract を持ちます。check-only と
 no-update の結果は update-check fields (`current_version`, `latest_version`,

--- a/changelog.d/unreleased/3910.security.md
+++ b/changelog.d/unreleased/3910.security.md
@@ -1,0 +1,19 @@
+---
+category: security
+issues:
+  - 3910
+affected:
+  - src/CodeIndex/SubprocessEnvironmentPolicy.cs
+  - src/CodeIndex/Cli/GitHelper.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Indexer/IsolatedWorkerProcessLauncher.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Git and upgrade subprocesses now scrub inherited environments (#3910)** — git helpers and the upgrade installer now launch with an explicit allowlist for PATH/home/temp/proxy/certificate and tool-specific variables, while `CDIDX_TEST_*` forwarding remains limited to isolated worker test hooks.
+
+## 日本語
+
+- **git と upgrade subprocess が継承環境を scrub するようになりました (#3910)** — git helper と upgrade installer は PATH / home / temp / proxy / certificate と tool-specific variables の明示 allowlist で起動し、`CDIDX_TEST_*` の forward は isolated worker の test hook に限定されます。

--- a/changelog.d/unreleased/3973.fixed.md
+++ b/changelog.d/unreleased/3973.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3973
+affected:
+  - src/CodeIndex/Cli/GitHubHttpClientFactory.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/GitHubHttpCancellationTests.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **Release downloads now use the shared GitHub HTTP policy (#3973)** — upgrade asset downloads now share bounded timeouts, proxy/default-credential handling, and bounded redacted HTTP failure diagnostics without sending GitHub API-only media type headers to release assets.
+
+## 日本語
+
+- **release download が共有 GitHub HTTP policy を使うようになりました (#3973)** — upgrade asset download は bounded timeout、proxy/default credential handling、bounded かつ redacted された HTTP failure diagnostics を共有し、release asset には GitHub API 専用の media type header を送らないようになりました。

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -110,12 +110,14 @@ public static class GitHelper
         if (gitExecutablePath == null)
             return null;
 
-        return CodeIndex.ProcessLaunchPolicy.CreateNoShellStartInfo(
+        var startInfo = CodeIndex.ProcessLaunchPolicy.CreateNoShellStartInfo(
             fileName: gitExecutablePath,
             workingDirectory: projectRoot,
             redirectStandardOutput: true,
             redirectStandardError: true,
             createNoWindow: true);
+        CodeIndex.SubprocessEnvironmentPolicy.ApplyGitEnvironment(startInfo);
+        return startInfo;
     }
 
     private static ProcessStartInfo CreateGitStartInfoOrThrow(string projectRoot)

--- a/src/CodeIndex/Cli/GitHubHttpClientFactory.cs
+++ b/src/CodeIndex/Cli/GitHubHttpClientFactory.cs
@@ -14,7 +14,20 @@ internal static class GitHubHttpClientFactory
 
     internal static HttpClient CreateDefaultHttpClient(TimeSpan timeout)
     {
-        var effectiveTimeout = NormalizeRequestTimeout(timeout);
+        var client = CreateHttpClient(timeout);
+        ApplyDefaultHeaders(client.DefaultRequestHeaders);
+        return client;
+    }
+
+    internal static HttpClient CreateReleaseDownloadHttpClient(TimeSpan timeout)
+    {
+        var client = CreateHttpClient(timeout);
+        ApplyReleaseDownloadHeaders(client.DefaultRequestHeaders);
+        return client;
+    }
+
+    internal static HttpClientHandler CreateDefaultHttpClientHandler()
+    {
         var handler = new HttpClientHandler
         {
             UseProxy = true,
@@ -23,11 +36,15 @@ internal static class GitHubHttpClientFactory
         if (ShouldUseDefaultProxyCredentials())
             handler.DefaultProxyCredentials = CredentialCache.DefaultCredentials;
 
-        var client = new HttpClient(handler)
+        return handler;
+    }
+
+    private static HttpClient CreateHttpClient(TimeSpan timeout)
+    {
+        var client = new HttpClient(CreateDefaultHttpClientHandler())
         {
-            Timeout = effectiveTimeout,
+            Timeout = NormalizeRequestTimeout(timeout),
         };
-        ApplyDefaultHeaders(client.DefaultRequestHeaders);
         return client;
     }
 
@@ -57,8 +74,7 @@ internal static class GitHubHttpClientFactory
 
     internal static void ApplyDefaultHeaders(HttpRequestHeaders headers)
     {
-        if (headers.UserAgent.Count == 0)
-            headers.UserAgent.Add(new ProductInfoHeaderValue(new ProductHeaderValue("cdidx")));
+        ApplyReleaseDownloadHeaders(headers);
 
         var hasGitHubAccept = false;
         foreach (var accept in headers.Accept)
@@ -75,6 +91,34 @@ internal static class GitHubHttpClientFactory
 
         if (!headers.Contains(GitHubApiVersionHeader))
             headers.Add(GitHubApiVersionHeader, GitHubApiVersion);
+    }
+
+    internal static void ApplyReleaseDownloadHeaders(HttpRequestHeaders headers)
+    {
+        if (headers.UserAgent.Count == 0)
+            headers.UserAgent.Add(new ProductInfoHeaderValue(new ProductHeaderValue("cdidx")));
+    }
+
+    internal static async Task EnsureSuccessStatusCodeWithBoundedDiagnosticsAsync(
+        HttpResponseMessage response,
+        string operation,
+        CancellationToken cancellationToken)
+    {
+        if (response.IsSuccessStatusCode)
+            return;
+
+        var errorBody = string.Empty;
+        if (response.Content != null)
+        {
+            await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            errorBody = await GitHubIssueReporter.ReadBoundedApiErrorBodyAsync(stream, cancellationToken).ConfigureAwait(false);
+        }
+
+        var detail = GitHubIssueReporter.BuildApiErrorDetail((int)response.StatusCode, errorBody);
+        throw new HttpRequestException(
+            $"GitHub release download failed for {operation}: {detail}",
+            null,
+            response.StatusCode);
     }
 
     internal static bool ShouldUseDefaultProxyCredentials()

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -3629,6 +3629,7 @@ internal static partial class ProgramRunner
             fileName: ResolveTrustedBashPath(),
             workingDirectory: Path.GetDirectoryName(fullScriptPath) ?? string.Empty);
         CodeIndex.ProcessLaunchPolicy.AddArguments(startInfo, fullScriptPath, releaseTag);
+        CodeIndex.SubprocessEnvironmentPolicy.ApplyUpgradeInstallerEnvironment(startInfo);
         startInfo.Environment["CDIDX_INSTALL_DIR"] = installDir;
         return startInfo;
     }

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -4013,7 +4013,7 @@ internal static partial class ProgramRunner
             Uri.EscapeDataString(assetName));
 
     private static HttpClient CreateUpgradeHttpClient()
-        => new() { Timeout = TimeSpan.FromSeconds(20) };
+        => GitHubHttpClientFactory.CreateReleaseDownloadHttpClient(TimeSpan.FromSeconds(20));
 
     internal static async Task<string> DownloadReleaseChecksumManifestAsync(
         HttpClient client,
@@ -4026,11 +4026,15 @@ internal static partial class ProgramRunner
             timeout,
             cancellationToken);
         using var request = new HttpRequestMessage(HttpMethod.Get, BuildReleaseAssetUrl(releaseTag, ReleaseChecksumAssetName));
+        GitHubHttpClientFactory.ApplyReleaseDownloadHeaders(request.Headers);
         using var response = await client.SendAsync(
             request,
             HttpCompletionOption.ResponseHeadersRead,
             downloadScope.Token).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+        await GitHubHttpClientFactory.EnsureSuccessStatusCodeWithBoundedDiagnosticsAsync(
+            response,
+            ReleaseChecksumAssetName,
+            downloadScope.Token).ConfigureAwait(false);
         var bytes = await BoundedHttpContentReader.ReadAsByteArrayAsync(
             response.Content,
             MaxReleaseChecksumBytes,
@@ -4102,11 +4106,15 @@ internal static partial class ProgramRunner
             timeout,
             cancellationToken);
         using var request = new HttpRequestMessage(HttpMethod.Get, BuildInstallerScriptUrl(releaseTag));
+        GitHubHttpClientFactory.ApplyReleaseDownloadHeaders(request.Headers);
         using var response = await client.SendAsync(
             request,
             HttpCompletionOption.ResponseHeadersRead,
             downloadScope.Token).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+        await GitHubHttpClientFactory.EnsureSuccessStatusCodeWithBoundedDiagnosticsAsync(
+            response,
+            InstallerScriptAssetName,
+            downloadScope.Token).ConfigureAwait(false);
         await BoundedHttpContentReader.WriteToPrivateFileAsync(
             response.Content,
             scriptPath,

--- a/src/CodeIndex/Indexer/IsolatedWorkerProcessLauncher.cs
+++ b/src/CodeIndex/Indexer/IsolatedWorkerProcessLauncher.cs
@@ -9,46 +9,8 @@ internal static class IsolatedWorkerProcessLauncher
     internal static ProcessStartInfo CreateStartInfo()
     {
         var startInfo = CodeIndex.ProcessLaunchPolicy.CreateUtf8RedirectedWorkerStartInfo();
-        ApplyEnvironmentAllowlist(startInfo);
+        CodeIndex.SubprocessEnvironmentPolicy.ApplyIsolatedWorkerEnvironment(startInfo);
         return startInfo;
-    }
-
-    private static readonly string[] EnvironmentAllowlist =
-    [
-        "PATH",
-        "DOTNET_ROOT",
-        "DOTNET_ROOT_X64",
-        "DOTNET_ROOT_X86",
-        "DOTNET_ROOT_ARM64",
-        "DOTNET_BUNDLE_EXTRACT_BASE_DIR",
-        "TMPDIR",
-        "TMP",
-        "TEMP",
-        "SystemRoot",
-        "WINDIR",
-    ];
-
-    private static void ApplyEnvironmentAllowlist(ProcessStartInfo startInfo)
-    {
-        startInfo.Environment.Clear();
-        foreach (var name in EnvironmentAllowlist)
-        {
-            var value = Environment.GetEnvironmentVariable(name);
-            if (!string.IsNullOrEmpty(value))
-                startInfo.Environment[name] = value;
-        }
-
-        foreach (System.Collections.DictionaryEntry item in Environment.GetEnvironmentVariables())
-        {
-            if (item.Key is not string name
-                || item.Value is not string value
-                || !name.StartsWith("CDIDX_TEST_", StringComparison.Ordinal))
-            {
-                continue;
-            }
-
-            startInfo.Environment[name] = value;
-        }
     }
 
     internal static bool ShouldStartCurrentExecutable(

--- a/src/CodeIndex/SubprocessEnvironmentPolicy.cs
+++ b/src/CodeIndex/SubprocessEnvironmentPolicy.cs
@@ -1,0 +1,135 @@
+using System.Diagnostics;
+
+namespace CodeIndex;
+
+internal static class SubprocessEnvironmentPolicy
+{
+    internal const string TestEnvironmentPrefix = "CDIDX_TEST_";
+
+    private static readonly string[] BaseEnvironmentAllowlist =
+    [
+        "PATH",
+        "HOME",
+        "USERPROFILE",
+        "HOMEDRIVE",
+        "HOMEPATH",
+        "XDG_CONFIG_HOME",
+        "XDG_CACHE_HOME",
+        "XDG_DATA_HOME",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "SystemRoot",
+        "WINDIR",
+        "COMSPEC",
+    ];
+
+    private static readonly string[] DotNetRuntimeEnvironmentAllowlist =
+    [
+        "DOTNET_ROOT",
+        "DOTNET_ROOT_X64",
+        "DOTNET_ROOT_X86",
+        "DOTNET_ROOT_ARM64",
+        "DOTNET_BUNDLE_EXTRACT_BASE_DIR",
+    ];
+
+    private static readonly string[] ProxyEnvironmentAllowlist =
+    [
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "no_proxy",
+    ];
+
+    private static readonly string[] CertificateEnvironmentAllowlist =
+    [
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "CURL_CA_BUNDLE",
+        "GIT_SSL_CAINFO",
+    ];
+
+    private static readonly string[] GitEnvironmentAllowlist =
+    [
+        "GIT_CONFIG_NOSYSTEM",
+        "GIT_CONFIG_GLOBAL",
+        "GIT_CONFIG_SYSTEM",
+        "GIT_CEILING_DIRECTORIES",
+        "GIT_DISCOVERY_ACROSS_FILESYSTEM",
+        "GIT_OPTIONAL_LOCKS",
+    ];
+
+    private static readonly string[] UpgradeInstallerEnvironmentAllowlist =
+    [
+        "CDIDX_ALLOW_RISKY_INSTALL_DIR",
+        "CDIDX_GITHUB_API_BASE_URL",
+        "CDIDX_GITHUB_BASE_URL",
+        "CDIDX_INSTALL_UPDATE_PATH",
+        "CDIDX_RELEASE_GPG_FINGERPRINT",
+        "CDIDX_REQUIRE_ATTESTATION",
+        "CDIDX_STRICT_VERIFY",
+        "CDIDX_VERIFY_POLICY",
+    ];
+
+    internal static void ApplyIsolatedWorkerEnvironment(ProcessStartInfo startInfo)
+    {
+        ApplyAllowlist(startInfo, BaseEnvironmentAllowlist, DotNetRuntimeEnvironmentAllowlist);
+        CopyPrefixedEnvironmentVariables(startInfo, TestEnvironmentPrefix);
+    }
+
+    internal static void ApplyGitEnvironment(ProcessStartInfo startInfo)
+    {
+        ApplyAllowlist(
+            startInfo,
+            BaseEnvironmentAllowlist,
+            ProxyEnvironmentAllowlist,
+            CertificateEnvironmentAllowlist,
+            GitEnvironmentAllowlist);
+        if (!startInfo.Environment.ContainsKey("GIT_TERMINAL_PROMPT"))
+            startInfo.Environment["GIT_TERMINAL_PROMPT"] = "0";
+    }
+
+    internal static void ApplyUpgradeInstallerEnvironment(ProcessStartInfo startInfo)
+        => ApplyAllowlist(
+            startInfo,
+            BaseEnvironmentAllowlist,
+            ProxyEnvironmentAllowlist,
+            CertificateEnvironmentAllowlist,
+            UpgradeInstallerEnvironmentAllowlist);
+
+    private static void ApplyAllowlist(ProcessStartInfo startInfo, params string[][] allowlistGroups)
+    {
+        startInfo.Environment.Clear();
+        foreach (var group in allowlistGroups)
+        {
+            foreach (var name in group)
+                CopyEnvironmentVariable(startInfo, name);
+        }
+    }
+
+    private static void CopyEnvironmentVariable(ProcessStartInfo startInfo, string name)
+    {
+        var value = Environment.GetEnvironmentVariable(name);
+        if (!string.IsNullOrEmpty(value))
+            startInfo.Environment[name] = value;
+    }
+
+    private static void CopyPrefixedEnvironmentVariables(ProcessStartInfo startInfo, string prefix)
+    {
+        foreach (System.Collections.DictionaryEntry item in Environment.GetEnvironmentVariables())
+        {
+            if (item.Key is not string name
+                || item.Value is not string value
+                || !name.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            startInfo.Environment[name] = value;
+        }
+    }
+}

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -702,6 +702,50 @@ public class GitHelperTests : IDisposable
     }
 
     [Fact]
+    public void RunGitCapturingResult_ScrubsInheritedEnvironmentByAllowlist_Issue3910()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        using var env = EnvironmentVariableScope.Capture(
+            "HTTPS_PROXY",
+            "CDIDX_TEST_GIT_POLICY_3910",
+            "CDIDX_SECRET_GIT_POLICY_3910");
+        env.Set("HTTPS_PROXY", "http://proxy.example.test:8080");
+        env.Set("CDIDX_TEST_GIT_POLICY_3910", "test-only");
+        env.Set("CDIDX_SECRET_GIT_POLICY_3910", "secret");
+
+        var repoDir = Path.Combine(_tempDir, "repo-git-env");
+        Directory.CreateDirectory(repoDir);
+        var fakeGitDir = Path.Combine(_tempDir, "fake-git-env");
+        Directory.CreateDirectory(fakeGitDir);
+        WriteFakeGitThatPrintsSelectedEnvironment(fakeGitDir);
+
+        var oldGitExecutablePath = GitHelper.GitExecutablePathOverride;
+        GitHelper.GitExecutablePathOverride = Path.Combine(fakeGitDir, "git");
+        try
+        {
+            var result = GitHelper.RunGitCapturingResultForTests(
+                repoDir,
+                gitEnvironmentOverrides: null,
+                CancellationToken.None,
+                "status");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Contains("HTTPS_PROXY=http://proxy.example.test:8080", result.Output);
+            Assert.Contains("GIT_TERMINAL_PROMPT=0", result.Output);
+            Assert.Contains("CDIDX_TEST_GIT_POLICY_3910=", result.Output);
+            Assert.Contains("CDIDX_SECRET_GIT_POLICY_3910=", result.Output);
+            Assert.DoesNotContain("test-only", result.Output);
+            Assert.DoesNotContain("secret", result.Output);
+        }
+        finally
+        {
+            GitHelper.GitExecutablePathOverride = oldGitExecutablePath;
+        }
+    }
+
+    [Fact]
     public void GetChangedFilesFromCommit_CancelDuringGitCommand_ThrowsOperationCanceled()
     {
         if (OperatingSystem.IsWindows())
@@ -1408,6 +1452,21 @@ if [ "$1" = "diff-tree" ]; then
 fi
 exit 1
 """.Replace("__CHANGED_PATH__", changedPath, StringComparison.Ordinal));
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+    }
+
+    private static void WriteFakeGitThatPrintsSelectedEnvironment(string directory)
+    {
+        var script = Path.Combine(directory, "git");
+        File.WriteAllText(script, """
+#!/bin/sh
+printf 'HTTPS_PROXY=%s\n' "${HTTPS_PROXY:-}"
+printf 'GIT_TERMINAL_PROMPT=%s\n' "${GIT_TERMINAL_PROMPT:-}"
+printf 'CDIDX_TEST_GIT_POLICY_3910=%s\n' "${CDIDX_TEST_GIT_POLICY_3910:-}"
+printf 'CDIDX_SECRET_GIT_POLICY_3910=%s\n' "${CDIDX_SECRET_GIT_POLICY_3910:-}"
+exit 0
+""");
         if (!OperatingSystem.IsWindows())
             File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
     }

--- a/tests/CodeIndex.Tests/GitHubHttpCancellationTests.cs
+++ b/tests/CodeIndex.Tests/GitHubHttpCancellationTests.cs
@@ -39,6 +39,22 @@ public sealed class GitHubHttpCancellationTests : IDisposable
     }
 
     [Fact]
+    public void GitHubHttpClientFactory_CreateReleaseDownloadClient_UsesSharedPolicyWithoutApiHeaders_Issue3973()
+    {
+        env.Set(GitHubHttpClientFactory.ProxyDefaultCredentialsEnvironmentVariable, "true");
+
+        using var handler = GitHubHttpClientFactory.CreateDefaultHttpClientHandler();
+        using var client = GitHubHttpClientFactory.CreateReleaseDownloadHttpClient(
+            GitHubHttpClientFactory.MaxRequestTimeout + TimeSpan.FromSeconds(1));
+
+        Assert.Same(CredentialCache.DefaultCredentials, handler.DefaultProxyCredentials);
+        Assert.Equal(GitHubHttpClientFactory.MaxRequestTimeout, client.Timeout);
+        Assert.Contains(client.DefaultRequestHeaders.UserAgent, value => value.Product?.Name == "cdidx");
+        Assert.Empty(client.DefaultRequestHeaders.Accept);
+        Assert.False(client.DefaultRequestHeaders.Contains("X-GitHub-Api-Version"));
+    }
+
+    [Fact]
     public async Task UpdateChecker_FetchLatestReleaseTagAsync_RequestTimeoutCancelsPendingSend_Issue3684()
     {
         var handler = new BlockingHttpMessageHandler();

--- a/tests/CodeIndex.Tests/ProcessLaunchPolicyTests.cs
+++ b/tests/CodeIndex.Tests/ProcessLaunchPolicyTests.cs
@@ -2,6 +2,7 @@ using CodeIndex;
 
 namespace CodeIndex.Tests;
 
+[Collection("SQLite pool sensitive")]
 public class ProcessLaunchPolicyTests
 {
     [Fact]
@@ -47,5 +48,47 @@ public class ProcessLaunchPolicyTests
         Assert.False(startInfo.StandardInputEncoding!.GetPreamble().Length > 0);
         Assert.False(startInfo.StandardOutputEncoding!.GetPreamble().Length > 0);
         Assert.False(startInfo.StandardErrorEncoding!.GetPreamble().Length > 0);
+    }
+
+    [Fact]
+    public void SubprocessEnvironmentPolicy_WorkerOnlyForwardsTestPrefixedEnvironment_Issue3910()
+    {
+        using var env = EnvironmentVariableScope.Capture(
+            "CDIDX_TEST_SUBPROCESS_POLICY_3910",
+            "CDIDX_SECRET_SUBPROCESS_POLICY_3910",
+            "HTTPS_PROXY");
+        env.Set("CDIDX_TEST_SUBPROCESS_POLICY_3910", "allowed");
+        env.Set("CDIDX_SECRET_SUBPROCESS_POLICY_3910", "secret");
+        env.Set("HTTPS_PROXY", "http://proxy.example.test:8080");
+        var startInfo = ProcessLaunchPolicy.CreateNoShellStartInfo();
+
+        SubprocessEnvironmentPolicy.ApplyIsolatedWorkerEnvironment(startInfo);
+
+        Assert.Equal("allowed", startInfo.Environment["CDIDX_TEST_SUBPROCESS_POLICY_3910"]);
+        Assert.False(startInfo.Environment.ContainsKey("CDIDX_SECRET_SUBPROCESS_POLICY_3910"));
+        Assert.False(startInfo.Environment.ContainsKey("HTTPS_PROXY"));
+    }
+
+    [Fact]
+    public void SubprocessEnvironmentPolicy_GitKeepsProxyAndGitKnobsWithoutCdidxSecrets_Issue3910()
+    {
+        using var env = EnvironmentVariableScope.Capture(
+            "HTTPS_PROXY",
+            "GIT_CONFIG_NOSYSTEM",
+            "CDIDX_TEST_SUBPROCESS_POLICY_3910",
+            "CDIDX_SECRET_SUBPROCESS_POLICY_3910");
+        env.Set("HTTPS_PROXY", "http://proxy.example.test:8080");
+        env.Set("GIT_CONFIG_NOSYSTEM", "1");
+        env.Set("CDIDX_TEST_SUBPROCESS_POLICY_3910", "test-only");
+        env.Set("CDIDX_SECRET_SUBPROCESS_POLICY_3910", "secret");
+        var startInfo = ProcessLaunchPolicy.CreateNoShellStartInfo();
+
+        SubprocessEnvironmentPolicy.ApplyGitEnvironment(startInfo);
+
+        Assert.Equal("http://proxy.example.test:8080", startInfo.Environment["HTTPS_PROXY"]);
+        Assert.Equal("1", startInfo.Environment["GIT_CONFIG_NOSYSTEM"]);
+        Assert.Equal("0", startInfo.Environment["GIT_TERMINAL_PROMPT"]);
+        Assert.False(startInfo.Environment.ContainsKey("CDIDX_TEST_SUBPROCESS_POLICY_3910"));
+        Assert.False(startInfo.Environment.ContainsKey("CDIDX_SECRET_SUBPROCESS_POLICY_3910"));
     }
 }

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -1626,6 +1626,36 @@ public class ProgramRunnerTests
     }
 
     [Fact]
+    public void CreateInstallerProcessStartInfo_ScrubsEnvironmentByAllowlist_Issue3910()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        lock (TestConsoleLock.Gate)
+        {
+            using var env = EnvironmentVariableScope.Capture(
+                "HTTPS_PROXY",
+                "CDIDX_VERIFY_POLICY",
+                "CDIDX_TEST_INSTALLER_POLICY_3910",
+                "CDIDX_SECRET_INSTALLER_POLICY_3910");
+            env.Set("HTTPS_PROXY", "http://proxy.example.test:8080");
+            env.Set("CDIDX_VERIFY_POLICY", "strict");
+            env.Set("CDIDX_TEST_INSTALLER_POLICY_3910", "test-only");
+            env.Set("CDIDX_SECRET_INSTALLER_POLICY_3910", "secret");
+            var root = Path.Combine(Path.GetTempPath(), $"cdidx installer env {Guid.NewGuid():N}");
+            var script = Path.Combine(root, "install.sh");
+
+            var startInfo = ProgramRunner.CreateInstallerProcessStartInfo(script, "v1.27.0", root);
+
+            Assert.Equal("http://proxy.example.test:8080", startInfo.Environment["HTTPS_PROXY"]);
+            Assert.Equal("strict", startInfo.Environment["CDIDX_VERIFY_POLICY"]);
+            Assert.Equal(root, startInfo.Environment["CDIDX_INSTALL_DIR"]);
+            Assert.False(startInfo.Environment.ContainsKey("CDIDX_TEST_INSTALLER_POLICY_3910"));
+            Assert.False(startInfo.Environment.ContainsKey("CDIDX_SECRET_INSTALLER_POLICY_3910"));
+        }
+    }
+
+    [Fact]
     public void RunInstallerProcess_StartFailureReturnsInstallError_Issue3685()
     {
         lock (TestConsoleLock.Gate)

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -2550,6 +2550,67 @@ exit 7
     }
 
     [Fact]
+    public async Task DownloadReleaseChecksumManifestAsync_HttpFailureUsesBoundedRedactedDiagnostics_Issue3973()
+    {
+        var errorBody = """
+            {
+              "message": "denied",
+              "authorization": "Bearer secret-token-3973",
+              "details": "release asset unavailable"
+            }
+            """;
+        using var client = new HttpClient(new StaticResponseHandler(
+            new StringContent(errorBody, Encoding.UTF8, "application/json"),
+            HttpStatusCode.Forbidden))
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() =>
+            ProgramRunner.DownloadReleaseChecksumManifestAsync(
+                client,
+                "v1.27.0",
+                TimeSpan.FromSeconds(1),
+                CancellationToken.None));
+
+        Assert.Equal(HttpStatusCode.Forbidden, ex.StatusCode);
+        Assert.Contains("GitHub release download failed for sha256sums.txt: 403:", ex.Message);
+        Assert.Contains("[redacted]", ex.Message);
+        Assert.DoesNotContain("secret-token-3973", ex.Message);
+        Assert.True(ex.Message.Length < 700, ex.Message);
+    }
+
+    [Fact]
+    public async Task DownloadInstallerScriptAsync_UsesReleaseDownloadHeadersWithoutApiMediaType_Issue3973()
+    {
+        var handler = new StaticResponseHandler(new ByteArrayContent(Encoding.UTF8.GetBytes("#!/bin/sh\n")));
+        using var client = new HttpClient(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        var scriptPath = Path.Combine(Path.GetTempPath(), $"cdidx_install_header_{Guid.NewGuid():N}.sh");
+        try
+        {
+            await ProgramRunner.DownloadInstallerScriptAsync(
+                client,
+                "v1.27.0",
+                scriptPath,
+                TimeSpan.FromSeconds(1),
+                CancellationToken.None);
+
+            Assert.NotNull(handler.LastRequest);
+            Assert.Contains(handler.LastRequest!.Headers.UserAgent, value => value.Product?.Name == "cdidx");
+            Assert.Empty(handler.LastRequest.Headers.Accept);
+            Assert.False(handler.LastRequest.Headers.Contains("X-GitHub-Api-Version"));
+        }
+        finally
+        {
+            if (File.Exists(scriptPath))
+                File.Delete(scriptPath);
+        }
+    }
+
+    [Fact]
     public async Task UpdateChecker_ReadLatestReleaseTagAsync_ParsesTagName()
     {
         using var content = new ByteArrayContent(Encoding.UTF8.GetBytes("""{"tag_name":"v1.27.0"}"""));


### PR DESCRIPTION
## Summary
- Added a shared subprocess environment policy and applied it to isolated workers, git helpers, and the upgrade installer so inherited secrets are scrubbed by allowlist.
- Added a release-download GitHub HTTP client path that shares timeout/proxy/default-credential policy while keeping GitHub API media-type headers scoped to API requests.
- Added bounded, redacted diagnostics for release asset HTTP failures and changelog fragments for both issues.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~ProcessLaunchPolicyTests|FullyQualifiedName~RunGitCapturingResult_ScrubsInheritedEnvironmentByAllowlist_Issue3910|FullyQualifiedName~CreateInstallerProcessStartInfo_ScrubsEnvironmentByAllowlist_Issue3910|FullyQualifiedName~IsolatedWorkers_StartInfo_ScrubsEnvironmentByAllowlist_Issue3759"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~GitHubHttpCancellationTests|FullyQualifiedName~DownloadReleaseChecksumManifestAsync_HttpFailureUsesBoundedRedactedDiagnostics_Issue3973|FullyQualifiedName~DownloadInstallerScriptAsync_UsesReleaseDownloadHeadersWithoutApiMediaType_Issue3973"`
- `dotnet run --project tools/CodeIndex.Changelog -- check --no-restore`
- Adversarial review: `No blocking/actionable issues found.`

## Notes
- Full-suite validation surfaced a load-sensitive existing timeout test failure now tracked in #4027; the failed test passed when rerun in isolation.

Fixes #3910
Fixes #3973