### PR TITLE
Bound JSON payload parsing

### DIFF
--- a/changelog.d/unreleased/3908.security.md
+++ b/changelog.d/unreleased/3908.security.md
@@ -1,0 +1,20 @@
+---
+category: security
+issues:
+  - 3908
+affected:
+  - src/CodeIndex/WorkerProtocolJsonValidator.cs
+  - src/CodeIndex/Cli/SuggestionStore.cs
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/SuggestionStoreTests.cs
+  - tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+---
+
+## English
+
+- **Bounded JSON protocol and metadata parsing (#3908)** — worker protocol JSON now uses explicit depth-limited parse and serializer options, suggestion-store streaming observes cancellation, and export manifests read unknown-extension samples with item and string caps.
+
+## 日本語
+
+- **JSON protocol と metadata parsing の境界を強化しました (#3908)** — worker protocol JSON は明示的な depth 制限付き parse / serializer options を使い、suggestion store の streaming 読み込みは cancellation を監視し、export manifest の unknown-extension sample は item 数と文字列長を制限して読み込むようになりました。

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -19,7 +19,9 @@ internal static class ExportImportCommandRunner
     internal const long MaxImportDatabaseCompressionRatio = 1000;
     private const int ImportCopyBufferSize = 81920;
     private const int ManifestUnknownExtensionFileLimit = DbContext.UnknownExtensionFilePathSampleLimit;
-    private const int ManifestUnknownExtensionPathCharLimit = 4096;
+    private const int ManifestUnknownExtensionJsonDepth = 4;
+    internal const int ManifestUnknownExtensionDecodedItemLimit = ManifestUnknownExtensionFileLimit;
+    internal const int ManifestUnknownExtensionPathCharLimit = 4096;
     private const int ManifestUnknownExtensionFilesTotalCharLimit = 32 * 1024;
     private static readonly DateTimeOffset DeterministicZipTimestamp = new(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
     private const string ExportCommandName = "export";
@@ -1111,27 +1113,71 @@ internal static class ExportImportCommandRunner
     private static UnknownExtensionFileSample ReadUnknownExtensionFileSample(SqliteConnection connection)
     {
         var json = ReadMetaString(connection, DbContext.UnknownExtensionFilePathsMetaKey);
-        if (string.IsNullOrWhiteSpace(json) || json.Length > MaxImportManifestBytes)
+        if (string.IsNullOrWhiteSpace(json) || Encoding.UTF8.GetByteCount(json) > MaxImportManifestBytes)
             return new(null, null, null, null);
 
         try
         {
-            var files = JsonSerializer.Deserialize<string[]>(json);
-            if (files == null)
+            var jsonBytes = Encoding.UTF8.GetBytes(json);
+            var reader = new Utf8JsonReader(
+                jsonBytes,
+                new JsonReaderOptions { MaxDepth = ManifestUnknownExtensionJsonDepth });
+            if (!reader.Read())
+                return new(null, null, null, null);
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                if (reader.Read())
+                    return new(null, null, null, null);
+
+                return new(null, 0, ManifestUnknownExtensionFileLimit, false);
+            }
+            if (reader.TokenType != JsonTokenType.StartArray)
+                return new(null, null, null, null);
+
+            var sample = new List<string>(ManifestUnknownExtensionFileLimit);
+            var decodedItems = 0;
+            var truncated = false;
+            var completed = false;
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonTokenType.EndArray)
+                {
+                    completed = true;
+                    break;
+                }
+                if (reader.TokenType != JsonTokenType.String)
+                    return new(null, null, null, null);
+
+                decodedItems++;
+                if (decodedItems > ManifestUnknownExtensionDecodedItemLimit)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                var path = reader.GetString();
+                if (string.IsNullOrWhiteSpace(path))
+                    continue;
+
+                if (sample.Count >= ManifestUnknownExtensionFileLimit)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                sample.Add(path.Length <= ManifestUnknownExtensionPathCharLimit
+                    ? path
+                    : path[..ManifestUnknownExtensionPathCharLimit]);
+            }
+
+            if (!completed && !truncated)
+                return new(null, null, null, null);
+            if (completed && reader.Read())
+                return new(null, null, null, null);
+            if (sample.Count == 0)
                 return new(null, 0, ManifestUnknownExtensionFileLimit, false);
 
-            var validFiles = files
-                .Where(path => !string.IsNullOrWhiteSpace(path))
-                .ToArray();
-            if (validFiles.Length == 0)
-                return new(null, 0, ManifestUnknownExtensionFileLimit, false);
-
-            var sample = validFiles
-                .Take(ManifestUnknownExtensionFileLimit)
-                .Select(path => path.Length <= ManifestUnknownExtensionPathCharLimit ? path : path[..ManifestUnknownExtensionPathCharLimit])
-                .ToArray();
-
-            return new(sample, sample.Length, ManifestUnknownExtensionFileLimit, validFiles.Length > sample.Length);
+            return new(sample.ToArray(), sample.Count, ManifestUnknownExtensionFileLimit, truncated);
         }
         catch (JsonException)
         {

--- a/src/CodeIndex/Cli/SuggestionStore.cs
+++ b/src/CodeIndex/Cli/SuggestionStore.cs
@@ -732,21 +732,27 @@ public class SuggestionStore
         return true;
     }
 
-    private static async Task<List<SuggestionRecord>> ReadFilteredSnapshotAsync(
+    internal static async Task<List<SuggestionRecord>> ReadFilteredSnapshotAsync(
         byte[] snapshot,
         Func<SuggestionRecord, bool> predicate,
         int skip,
         int? take,
-        bool normalizeDefaults)
+        bool normalizeDefaults,
+        CancellationToken cancellationToken = default)
     {
         var results = new List<SuggestionRecord>();
         var recordsRead = 0;
         var skipped = 0;
 
+        cancellationToken.ThrowIfCancellationRequested();
         await using var stream = new MemoryStream(snapshot, writable: false);
 
-        await foreach (var record in JsonSerializer.DeserializeAsyncEnumerable<SuggestionRecord>(stream, s_readOptions))
+        await foreach (var record in JsonSerializer
+            .DeserializeAsyncEnumerable<SuggestionRecord>(stream, s_readOptions, cancellationToken)
+            .WithCancellation(cancellationToken)
+            .ConfigureAwait(false))
         {
+            cancellationToken.ThrowIfCancellationRequested();
             recordsRead++;
             if (recordsRead > MaxSuggestionStoreRecords)
                 throw new JsonException($"Suggestion store contains more than {MaxSuggestionStoreRecords} records.");
@@ -764,6 +770,7 @@ public class SuggestionStore
             }
 
             results.Add(record);
+            cancellationToken.ThrowIfCancellationRequested();
             if (take.HasValue && results.Count >= take.Value)
                 break;
         }

--- a/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
+++ b/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
@@ -374,7 +374,8 @@ internal static class PostExtractionHookCallbackWorker
     internal const int WorkerKillWaitMilliseconds = 5000;
     private const string ProtocolMaxLineBytesOption = "--protocol-max-line-bytes";
     private const int CapturedConsoleMaxChars = 32 * 1024;
-    internal static readonly JsonSerializerOptions JsonOptions = PostExtractionHookCallbackWorkerJsonContext.Default.Options;
+    internal static readonly JsonSerializerOptions JsonOptions =
+        WorkerProtocolJsonValidator.CreateSerializerOptions(PostExtractionHookCallbackWorkerJsonContext.Default.Options);
 
     internal static bool TryRunCommand(
         string[] args,

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
@@ -383,7 +383,8 @@ internal static class SymbolExtractionWorker
     private const string TestDelayMillisecondsOption = "--test-delay-ms";
     private const string TestConsoleStdoutOption = "--test-console-stdout";
     private const int CapturedConsoleMaxChars = 32 * 1024;
-    internal static readonly JsonSerializerOptions JsonOptions = SymbolExtractionWorkerJsonContext.Default.Options;
+    internal static readonly JsonSerializerOptions JsonOptions =
+        WorkerProtocolJsonValidator.CreateSerializerOptions(SymbolExtractionWorkerJsonContext.Default.Options);
     internal static int? DelayMillisecondsForTesting { get; set; }
     internal static string? ConsoleStdoutForTesting { get; set; }
 

--- a/src/CodeIndex/WorkerProtocolJsonValidator.cs
+++ b/src/CodeIndex/WorkerProtocolJsonValidator.cs
@@ -4,18 +4,24 @@ namespace CodeIndex;
 
 internal static class WorkerProtocolJsonValidator
 {
+    internal const int DefaultMaxJsonDepth = 32;
     private const int DefaultMaxJsonProperties = 1_000_000;
+    internal static int? MaxJsonDepthForTesting { get; set; }
     internal static int? MaxJsonPropertiesForTesting { get; set; }
     internal static int? MaxStringCharactersForTesting { get; set; }
 
+    internal static JsonSerializerOptions CreateSerializerOptions(JsonSerializerOptions options)
+        => new(options) { MaxDepth = DefaultMaxJsonDepth };
+
     internal static bool TryValidate(string json, int maxStringCharacters, out string error)
     {
+        var maxDepth = ResolveMaxJsonDepth();
         var maxProperties = MaxJsonPropertiesForTesting ?? DefaultMaxJsonProperties;
         var effectiveMaxStringCharacters = MaxStringCharactersForTesting ?? maxStringCharacters;
         var propertyCount = 0;
         try
         {
-            using var document = JsonDocument.Parse(json);
+            using var document = JsonDocument.Parse(json, new JsonDocumentOptions { MaxDepth = maxDepth });
             ValidateElement(document.RootElement, maxProperties, effectiveMaxStringCharacters, ref propertyCount, out error);
             return error.Length == 0;
         }
@@ -24,6 +30,12 @@ internal static class WorkerProtocolJsonValidator
             error = SafeDiagnosticFormatter.FormatCategoryType("worker_protocol_error", nameof(JsonException));
             return false;
         }
+    }
+
+    private static int ResolveMaxJsonDepth()
+    {
+        var maxDepth = MaxJsonDepthForTesting ?? DefaultMaxJsonDepth;
+        return maxDepth > 0 ? maxDepth : DefaultMaxJsonDepth;
     }
 
     private static void ValidateElement(

--- a/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportCommandRunnerTests.cs
@@ -762,6 +762,56 @@ public class ExportImportCommandRunnerTests
     }
 
     [Fact]
+    public void RunExportArchive_ManifestBoundsUnknownExtensionSampleStringsBeforeMaterializing_Issue3908()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("export_unknown_extensions_string_bounds");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var longPath = new string('a', 5000) + ".unknown";
+            SetUnknownExtensionPathSamples(dbPath, [longPath]);
+
+            using var document = ExportArchiveManifest(projectRoot, dbPath);
+            var root = document.RootElement;
+            var exportedPath = root.GetProperty("unknown_extension_files")[0].GetString();
+
+            Assert.Equal(ExportImportCommandRunner.ManifestUnknownExtensionPathCharLimit, exportedPath?.Length);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunExportArchive_ManifestBoundsUnknownExtensionSampleItemsBeforeMaterializing_Issue3908()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("export_unknown_extensions_item_bounds");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var itemLimit = ExportImportCommandRunner.ManifestUnknownExtensionDecodedItemLimit;
+            var paths = Enumerable
+                .Range(0, itemLimit + 3)
+                .Select(index => $"samples/file-{index:D3}.unknown")
+                .ToArray();
+            SetUnknownExtensionPathSamples(dbPath, paths);
+
+            using var document = ExportArchiveManifest(projectRoot, dbPath);
+            var root = document.RootElement;
+            var files = root.GetProperty("unknown_extension_files");
+
+            Assert.Equal(DbContext.UnknownExtensionFilePathSampleLimit, files.GetArrayLength());
+            Assert.True(root.GetProperty("unknown_extension_file_sample_truncated").GetBoolean());
+            Assert.Equal(paths[DbContext.UnknownExtensionFilePathSampleLimit - 1], files[files.GetArrayLength() - 1].GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunImport_DryRunJsonReportsUnknownExtensionSampleMetadata_Issue3715()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("import_unknown_extensions_metadata");

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -568,6 +568,39 @@ public class IndexCommandRunnerTests
     }
 
     [Fact]
+    public void WorkerProtocol_RejectsExcessiveJsonDepth_Issue3908()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            try
+            {
+                WorkerProtocolJsonValidator.MaxJsonDepthForTesting = 4;
+                using var input = new StringReader("{\"FileId\":0,\"Lang\":{\"nested\":{\"too\":{\"deep\":\"csharp\"}}}}\n");
+                using var output = new StringWriter();
+                using var error = new StringWriter();
+
+                var handled = SymbolExtractionWorker.TryRunCommand(
+                    [SymbolExtractionWorker.CommandName],
+                    input,
+                    output,
+                    error,
+                    out var exitCode);
+
+                Assert.True(handled);
+                Assert.Equal(0, exitCode);
+                Assert.Equal(string.Empty, error.ToString());
+                using var document = JsonDocument.Parse(output.ToString());
+                var workerError = document.RootElement.GetProperty("WorkerError").GetString();
+                Assert.Equal("worker_protocol_error: JsonException", workerError);
+            }
+            finally
+            {
+                WorkerProtocolJsonValidator.MaxJsonDepthForTesting = null;
+            }
+        }
+    }
+
+    [Fact]
     public void WorkerProtocol_RejectsOversizedJsonStrings_Issue3759()
     {
         lock (TestConsoleLock.Gate)

--- a/tests/CodeIndex.Tests/SuggestionStoreTests.cs
+++ b/tests/CodeIndex.Tests/SuggestionStoreTests.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using System.Text;
+using System.Text.Json;
 using CodeIndex.Cli;
 using CodeIndex.Models;
 
@@ -159,6 +160,35 @@ public class SuggestionStoreTests : IDisposable
         Assert.Single(records);
         Assert.True(File.Exists(path));
         Assert.False(File.Exists(path + ".bak"));
+    }
+
+    [Fact]
+    public async Task ReadFilteredSnapshotAsync_ObservesCancellationDuringStreaming_Issue3908()
+    {
+        var records = new[]
+        {
+            MakeRecord("other", null, "first"),
+            MakeRecord("other", null, "second"),
+        };
+        var snapshot = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(records));
+        using var cts = new CancellationTokenSource();
+        var seen = 0;
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            SuggestionStore.ReadFilteredSnapshotAsync(
+                snapshot,
+                _ =>
+                {
+                    seen++;
+                    cts.Cancel();
+                    return true;
+                },
+                skip: 0,
+                take: null,
+                normalizeDefaults: false,
+                cts.Token));
+
+        Assert.Equal(1, seen);
     }
 
     // --- TryAdd tests / TryAdd テスト ---


### PR DESCRIPTION
## Summary

- Added an explicit worker-protocol JSON depth policy and reused it for symbol extraction and post-extraction hook worker serializer options.
- Changed unknown-extension export manifest sample parsing to stream through bounded JSON reader limits for bytes, depth, item count, and path string length.
- Passed cancellation through suggestion-store streaming JSON reads and covered the new boundaries with focused tests.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Issue3908"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~SuggestionStoreTests|FullyQualifiedName~ExportImportCommandRunnerTests|FullyQualifiedName~WorkerProtocol"`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Full `dotnet test` was attempted but interrupted after more than 8 minutes without additional output; targeted net8/net9 coverage above passed.

## Documentation And Changelog

- Added `changelog.d/unreleased/3908.security.md`.
- No user-facing docs were changed because command syntax and documented output contracts did not change.

## Review

- Adversarial review result: No blocking/actionable issues found.
- External `codex exec review --base origin/main` was attempted but could not complete because the Codex CLI reported a usage limit.

Fixes #3908

## Follow-up Candidates

- None.