### PR TITLE
Fix CLI help contracts for search, excerpt, and goto

### DIFF
--- a/changelog.d/unreleased/3893.fixed.md
+++ b/changelog.d/unreleased/3893.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 3893
+affected:
+  - src/CodeIndex/Cli/CliFlagSchema.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+---
+
+## English
+
+- **Search audit help now lists implemented output-control flags (#3893)** — `search --help` includes the audit projection, sampling, per-file, JSON byte limit, result-only, and follow-up flags already accepted by the parser, and `recipes`/`audit` now provide direct help and aliases for the underlying search audit flows.
+
+## 日本語
+
+- **search audit help に実装済みの出力制御フラグを表示するようになりました (#3893)** — `search --help` は、parser が既に受理している audit projection、sampling、per-file、JSON byte limit、result-only、follow-up の各フラグを表示し、`recipes` / `audit` から search audit の流れに直接入れる help と alias も追加しました。

--- a/changelog.d/unreleased/3916.fixed.md
+++ b/changelog.d/unreleased/3916.fixed.md
@@ -1,0 +1,21 @@
+---
+category: fixed
+issues:
+  - 3916
+affected:
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/ConsoleUiTests.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+---
+
+## English
+
+- **CLI help and excerpt contracts are tighter (#3916)** — `inspect`, `excerpt`, `references`, `batch`, `db`, and `hooks` help now documents their actual modes and JSON Lines behavior, legacy `refs`/`stats`/`fold` help resolves to command-specific usage, unknown `--help --json` returns a JSON usage error, and `excerpt` accepts `path:line` / `path:start-end` locations with clearer focus-option validation.
+
+## 日本語
+
+- **CLI help と excerpt 契約を厳密化しました (#3916)** — `inspect`、`excerpt`、`references`、`batch`、`db`、`hooks` の help は実際の mode と JSON Lines の挙動を記載し、legacy alias の `refs` / `stats` / `fold` は command-specific usage に解決され、未知コマンドの `--help --json` は JSON usage error を返し、`excerpt` は `path:line` / `path:start-end` location と明確な focus option validation を受け付けるようになりました。

--- a/changelog.d/unreleased/3934.fixed.md
+++ b/changelog.d/unreleased/3934.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3934
+affected:
+  - src/CodeIndex/Cli/CliFlagSchema.cs
+  - tests/CodeIndex.Tests/CliFlagSchemaTests.cs
+---
+
+## English
+
+- **`goto --exclude-tests` now matches its help contract (#3934)** — `goto` accepts the documented exclude filters instead of rejecting `--exclude-tests` and `--exclude-path` as unsupported options.
+
+## 日本語
+
+- **`goto --exclude-tests` が help 契約どおりに動くようになりました (#3934)** — `goto` は、記載済みの除外フィルタを受け付け、`--exclude-tests` や `--exclude-path` を未対応オプションとして拒否しなくなりました。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -99,7 +99,7 @@ internal static class CliFlagSchema
 
     private static readonly string[] ExcludeFilterCommands =
     [
-        "search", "definition", "references", "callers", "callees", "symbols", "files",
+        "search", "definition", "goto", "references", "callers", "callees", "symbols", "files",
         "find", "map", "inspect", "deps", "impact", "unused", "hotspots",
     ];
 

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -59,7 +59,7 @@ internal static class CliFlagSchema
     // サブコマンド一覧の正本。ConsoleUi.Commands と一致することをテストで確認する。
     public static IReadOnlyList<string> AllCommands { get; } =
     [
-        "index", "backfill-fold", "optimize", "search", "definition", "goto", "references", "callers", "callees",
+        "index", "backfill-fold", "optimize", "search", "recipes", "audit", "definition", "goto", "references", "callers", "callees",
         "symbols", "files", "find", "excerpt", "map", "inspect", "outline", "status", "validate-config",
         "validate", "deps", "impact", "unused", "hotspots", "suggestions", "languages", "batch", "mcp", "completions", "db", "vacuum", "report", "license", "upgrade",
     ];
@@ -194,7 +194,7 @@ internal static class CliFlagSchema
 
     private static readonly string[] JsonCommands =
     [
-        "index", "backfill-fold", "optimize", "vacuum", "search", "definition", "goto", "references", "callers", "callees",
+        "index", "backfill-fold", "optimize", "vacuum", "search", "recipes", "audit", "definition", "goto", "references", "callers", "callees",
         "symbols", "files", "find", "excerpt", "map", "inspect", "outline", "status",
         "validate", "deps", "impact", "unused", "hotspots", "suggestions", "languages", "db", "report", "upgrade",
     ];
@@ -203,7 +203,7 @@ internal static class CliFlagSchema
 
     private static readonly string[] FormatCommands =
     [
-        "search", "definition", "references", "callers", "callees", "symbols", "find", "map", "inspect", "validate", "deps", "suggestions",
+        "search", "audit", "definition", "references", "callers", "callees", "symbols", "find", "map", "inspect", "validate", "deps", "suggestions",
     ];
 
     private static readonly string[] ProfileCommands =

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -99,9 +99,10 @@ public static class ConsoleUi
         ("symbols", "cdidx symbols [query|--query <query>|-- <query>] [--name <name>] [--db <path>] [--json[=array]] [--format <text|json|count|lsp|qf|sarif>] [--verbose] [--limit <n>|--top <n>] [--sort <hotspot|references|size|complexity|path>] [--lang <lang>] [--kind <kind>] [--visibility <v[,v]>] [--exclude-visibility <v[,v]>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--exact|--exact-name] [--count] [--since <datetime>]"),
         ("files", "cdidx files [query|--query <query>|-- <query>] [--db <path>] [--json[=ndjson|array]] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--count] [--since <datetime>] [--bytes]"),
         ("find", "cdidx find <query> (--path <glob>|--all) [--db <path>] [--json] [--format <text|json|count|compact|csv|tsv|lsp|qf|sarif>] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--exclude-path <glob>] [--exclude-tests] [--before <n>] [--after <n>] [--snippet-lines <n>] [--focus-line <line>] [--focus-column <n>] [--max-line-width <n>] [--exact] [--regex] [--count]"),
-        ("excerpt", "cdidx excerpt <path> --start <line> [--end <line>] [--before <n>] [--after <n>] [--max-line-width <n>] [--focus-line <line>] [--focus-column <n>] [--focus-length <n>] [--db <path>] [--json] [--verbose]"),
+        ("excerpt", "cdidx excerpt <path[:line|:start-end]> [--start <line>|--start-line <line>] [--end <line>|--end-line <line>] [--before <n>] [--after <n>] [--max-line-width <n>] [--focus-line <line>] [--focus-column <n>] [--focus-length <n>] [--db <path>] [--json] [--verbose]"),
         ("map", "cdidx map [--db <path>] [--json] [--format <text|json|compact>] [--pretty] [--compact] [--summary-only] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--bytes] [--sections <tree,languages,hotspots,metrics>] [--depth <n>] [--min-entrypoint-confidence <0.0..1.0>]"),
-        ("inspect", "cdidx inspect <query>|--query <query>|-- <query>|--path <file> --line <line> [--db <path>] [--json] [--format <text|json|compact>] [--pretty] [--compact] [--fields <csv>] [--body-only] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--kind <kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--body-start <line>] [--body-lines <n>|--body-line-count <n>] [--line <line>|--start-line <line>] [--end-line <line>] [--context <n>|--before <n>|--after <n>] [--max-line-width <n>] [--exact|--exact-name]"),
+        ("inspect", "cdidx inspect <query>|--query <query>|-- <query> [--db <path>] [--json] [--format <text|json|compact>] [--pretty] [--compact] [--fields <csv>] [--body-only] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--kind <kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--body-start <line>] [--body-lines <n>|--body-line-count <n>] [--context <n>|--before <n>|--after <n>] [--max-line-width <n>] [--exact|--exact-name]"),
+        ("inspect", "cdidx inspect --path <file> --line <line> [--end-line <line>] [--db <path>] [--json] [--format <text|json|compact>] [--pretty] [--compact] [--fields <csv>] [--body-only] [--body] [--body-start <line>] [--body-lines <n>|--body-line-count <n>] [--context <n>|--before <n>|--after <n>] [--max-line-width <n>]"),
         ("outline", "cdidx outline <path> [--db <path>] [--json] [--pretty] [--compact] [--verbose] [--limit <n>|--top <n>]"),
         ("status", "cdidx status [--db <path>] [--json] [--verbose] [--check[=workspace,fold,graph,issues,hotspot,csharp,sql,newer]] [--stale-after <duration>] [--explain <field>] [--log-path] [--config] [--check-updates]"),
         ("workspace", "cdidx workspace <list|status|use|current> [name] [--json]"),
@@ -115,6 +116,13 @@ public static class ConsoleUi
         ("db", "cdidx db checkpoints --list [--db <path>] [--json]"),
         ("db", "cdidx db restore <name<=128> [--db <path>] [--json]"),
         ("db", "cdidx db restore-backups --list|--prune [--keep <n>] [--db <path>] [--json]"),
+        ("db-integrity", "cdidx db integrity|--integrity-check [--db <path>] [--json]"),
+        ("db-schema", $"cdidx db schema [--type <table|index|trigger|view>] [--name <object>] [--limit <n<={DbCommandRunner.SchemaEntryLimit}>] [--max-sql-chars <n<={DbCommandRunner.SchemaSqlTextLimit}>] [--summary-only] [--include-internal|--exclude-internal] [--db <path>] [--json]"),
+        ("db-prune", "cdidx db prune --dry-run|--apply [--db <path>] [--json]"),
+        ("db-checkpoint", "cdidx db checkpoint [name<=128] [--dry-run] [--db <path>] [--json]"),
+        ("db-checkpoints", "cdidx db checkpoints --list [--db <path>] [--json]"),
+        ("db-restore", "cdidx db restore <name<=128> [--db <path>] [--json]"),
+        ("db-restore-backups", "cdidx db restore-backups --list|--prune [--keep <n>] [--db <path>] [--json]"),
         ("diff", "cdidx diff <db1> <db2> [--json] [--summary-only] [--detailed] [--limit <n<=10000>]"),
         ("report", "cdidx report --output <path> [--db <path>] [--json] [--log-lines <n<=2000>] [--no-log] [--include-args]"),
         ("validate", "cdidx validate [--db <path>] [--json[=array]] [--format <text|json|count|compact|csv|tsv|lsp|qf|sarif>] [--verbose] [--limit <n>|--top <n>] [--kind <kind>] [--severity <info|warning|error>] [--path <glob>]"),
@@ -127,7 +135,10 @@ public static class ConsoleUi
         ("export", "cdidx export ctags [--output <path>] [--db <path>] [--json] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests]"),
         ("import", "cdidx import <archive> [--db <path>] [--prune-paths] [--dry-run|--check] [--json]"),
         ("languages", "cdidx languages [--db <path>] [--json] [--indexed-only] [--language <lang>|--extension <ext>|--alias <alias>] [--capability <graph|references|symbols|missing-graph|missing-references|missing-symbols|search-only>]"),
-        ("batch", "cdidx batch [--db <path>]  # reads JSON string arrays from stdin, one query command per line; max 1,048,576 chars/line and 256 arguments"),
+        ("batch", "cdidx batch [--db <path>]  # stdin is JSON Lines: one JSON string array per line; invalid lines emit per-line JSON errors and make the process exit non-zero"),
+        ("hooks-install", "cdidx hooks install [--project <path>] [--force] [--json]"),
+        ("hooks-uninstall", "cdidx hooks uninstall [--project <path>] [--force] [--json]"),
+        ("hooks-status", "cdidx hooks status [--project <path>] [--json]"),
         ("mcp", "cdidx mcp [--db <path>] [--transport stdio|http] [--http-listen <host:port>] [--audit-log <path>] [--audit-log-include-values] [--audit-log-max-bytes <n>] [--suggestion-dedup-threshold <0..1>]"),
         ("lsp", "cdidx lsp [--db <path>]"),
         ("completions", "cdidx completions <shell>"),
@@ -142,11 +153,45 @@ public static class ConsoleUi
         ("completions", "--json is not supported; output is a shell script for the selected shell."),
         ("recipes", "Alias for `cdidx search --list-recipes`; recipe-list JSON is a single object, so --json=array is rejected."),
         ("audit", "Alias for `cdidx search --recipe <recipe>`; pass search filters after the recipe name."),
+        ("references", "--json and --format json emit JSON Lines (one JSON object per result), not a single JSON array."),
+        ("references", "`refs` is a compatibility alias for `references`; prefer `references` in scripts and documentation."),
+        ("excerpt", "Line ranges can be supplied as `path:line` or `path:start-end`; explicit --start/--end flags override range parsing."),
+        ("excerpt", "--focus-line and --focus-length each require --focus-column so clamped excerpts know the column to keep visible."),
+        ("inspect", "In query mode --path is a glob filter; in line mode --path <file> --line <line> selects a source location."),
+        ("status", "`stats` is a compatibility alias for `status`; prefer `status` in scripts and documentation."),
+        ("backfill-fold", "`fold` is a compatibility alias for `backfill-fold`; prefer `backfill-fold` in scripts and documentation."),
+        ("batch", "Each stdin line must be a JSON string array such as [\"search\",\"Needle\",\"--json\"]; blank lines are skipped."),
+        ("batch", "Each input line writes one JSON result or error record; malformed lines and failed commands set a non-zero exit status after draining stdin."),
+        ("hooks", "install writes `.git/hooks/pre-commit`; run `cdidx hooks status` first to inspect the current hook state."),
+        ("hooks-install", "Writes `.git/hooks/pre-commit`; use `cdidx hooks status` first and --force only when replacing an unmanaged hook is intended."),
+        ("hooks-uninstall", "Removes the managed `.git/hooks/pre-commit`; --force is required for unmanaged hook content."),
+        ("hooks-status", "Reports whether `.git/hooks/pre-commit` is managed by cdidx without changing hook files."),
         ("db", "schema defaults to the full sqlite_master dump for support bundles; use --summary-only, --limit, --max-sql-chars, and --exclude-internal for bounded diagnostics."),
         ("db", "checkpoint --dry-run reports the DB/WAL/SHM files and byte count without creating the checkpoint directory."),
         ("db", "checkpoint creates a filesystem snapshot next to the DB; restore replaces the DB and keeps a pre-restore backup directory."),
         ("db", "prune --dry-run only counts orphan rows; prune --apply deletes them and may run WAL checkpoint maintenance."),
+        ("db-integrity", "Runs SQLite `PRAGMA integrity_check`; no database content is changed."),
+        ("db-schema", "Defaults to a bounded sqlite_master dump for support bundles; use --summary-only, --limit, --max-sql-chars, and --exclude-internal for smaller diagnostics."),
+        ("db-prune", "--dry-run only counts orphan rows; --apply deletes them and may run WAL checkpoint maintenance."),
+        ("db-checkpoint", "--dry-run reports DB/WAL/SHM files and byte count; without --dry-run it creates a filesystem snapshot next to the DB."),
+        ("db-checkpoints", "Lists existing checkpoint snapshots without changing database files."),
+        ("db-restore", "Replaces the DB from a checkpoint and keeps a pre-restore backup directory next to the DB."),
+        ("db-restore-backups", "--list reports pre-restore backups; --prune deletes older backup directories beyond --keep."),
     ];
+
+    private static readonly HashSet<string> HiddenCommandUsageNames = new(StringComparer.Ordinal)
+    {
+        "db-integrity",
+        "db-schema",
+        "db-prune",
+        "db-checkpoint",
+        "db-checkpoints",
+        "db-restore",
+        "db-restore-backups",
+        "hooks-install",
+        "hooks-uninstall",
+        "hooks-status",
+    };
 
     public static string FormatSummaryLine(string label, object? value, int labelWidth = SummaryLabelWidth, string indent = "")
         => $"{indent}{label.PadRight(labelWidth)}: {value}";
@@ -903,8 +948,13 @@ public static class ConsoleUi
 
         Console.WriteLine("Usage:");
         Console.WriteLine("  cdidx <projectPath>");
-        foreach (var (_, usage) in CommandUsageLines)
+        foreach (var (name, usage) in CommandUsageLines)
+        {
+            if (HiddenCommandUsageNames.Contains(name))
+                continue;
+
             WriteHelpLine($"  {usage}");
+        }
         Console.WriteLine();
         PrintCommandSummary();
         Console.WriteLine();
@@ -1243,6 +1293,7 @@ public static class ConsoleUi
 
     public static string? GetUsageLine(string command)
     {
+        command = NormalizeCommandUsageName(command);
         foreach (var (name, usage) in CommandUsageLines)
         {
             if (string.Equals(name, command, StringComparison.Ordinal))
@@ -1254,6 +1305,7 @@ public static class ConsoleUi
 
     public static bool PrintCommandUsage(string command)
     {
+        command = NormalizeCommandUsageName(command);
         var usages = GetCommandUsageLines(command);
         if (usages.Count == 0)
             return false;
@@ -1276,6 +1328,7 @@ public static class ConsoleUi
 
     private static IReadOnlyList<string> GetCommandUsageLines(string command)
     {
+        command = NormalizeCommandUsageName(command);
         var usages = new List<string>();
         foreach (var (name, usage) in CommandUsageLines)
         {
@@ -1291,6 +1344,7 @@ public static class ConsoleUi
 
     private static IReadOnlyList<string> GetCommandUsageNotes(string command)
     {
+        command = NormalizeCommandUsageName(command);
         var notes = new List<string>();
         foreach (var (name, note) in CommandUsageNotes)
         {
@@ -1300,6 +1354,15 @@ public static class ConsoleUi
 
         return notes;
     }
+
+    private static string NormalizeCommandUsageName(string command) =>
+        command switch
+        {
+            "refs" => "references",
+            "stats" => "status",
+            "fold" => "backfill-fold",
+            _ => command,
+        };
 
     // --- Did-you-mean / もしかして ---
 

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -88,7 +88,9 @@ public static class ConsoleUi
         ("index-commits", "cdidx index <projectPath> --commits <commit-ref> [commit-ref ...] [--db <path>] [--verbose] [--dry-run [--dry-run-path-limit <n>]] [--json] [--memory-trace] [--duration-format <auto|seconds|hms>] [--max-file-bytes <bytes>] [--include-symbol-kind <kind>[,<kind>]] [--exclude-symbol-kind <kind>[,<kind>]]"),
         ("index-changed-between", "cdidx index <projectPath> --changed-between <old-ref> <new-ref> [--db <path>] [--verbose] [--dry-run [--dry-run-path-limit <n>]] [--json] [--memory-trace] [--duration-format <auto|seconds|hms>] [--max-file-bytes <bytes>] [--include-symbol-kind <kind>[,<kind>]] [--exclude-symbol-kind <kind>[,<kind>]]"),
         ("index-files", "cdidx index <projectPath> --files <path> [path ...] [--db <path>] [--verbose] [--dry-run [--dry-run-path-limit <n>]] [--json] [--memory-trace] [--duration-format <auto|seconds|hms>] [--max-file-bytes <bytes>] [--include-symbol-kind <kind>[,<kind>]] [--exclude-symbol-kind <kind>[,<kind>]]"),
-        ("search", "cdidx search <query>|--query <query>|-- <query>|--recipe <name|name/query>|--list-recipes|--named-query <name>=<query> [--named-query <name>=<query> ...] [--include-query <name>] [--exclude-query <name>] [--cursor <cursor>] [--audit-scope <source|all>] [--show-excluded] [--db <path>] [--json[=ndjson|array]] [--pretty] [--format <text|json|count|compact|csv|tsv|lsp|qf|sarif|issue-drafts>] [--open-issues <path|github|github:owner/name>] [--repo <owner/name>] [--duplicate-confidence <low|medium|high>|--duplicate-threshold <score>] [--issue-title <title>] [--issue-label <label>] [--verbose] [--limit <n>|--top <n>|--max-results <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--exclude-comments] [--exclude-strings] [--exclude-fixtures] [--snippet-lines <n>] [--snippet-focus <leftmost|quality|proximity>] [--max-line-width <n>] [--fts] [--exact|--exact-substring] [--prefix] [--count] [--group-by <file|symbol>] [--since <datetime>] [--no-dedup] [--no-visibility-rank] [--require-before <query>] [--require-after <query>] [--reject-before <query>] [--reject-after <query>] [--guard-window <n>] [--guard-scope <window|same-line>]"),
+        ("search", "cdidx search <query>|--query <query>|-- <query>|--recipe <name|name/query>|--list-recipes|--named-query <name>=<query> [--named-query <name>=<query> ...] [--include-query <name>] [--exclude-query <name>] [--cursor <cursor>] [--audit-scope <source|all>] [--show-excluded] [--db <path>] [--json[=ndjson|array]] [--pretty] [--format <text|json|count|compact|csv|tsv|lsp|qf|sarif|issue-drafts>] [--open-issues <path|github|github:owner/name>] [--repo <owner/name>] [--duplicate-confidence <low|medium|high>|--duplicate-threshold <score>] [--issue-title <title>] [--issue-label <label>] [--verbose] [--limit <n>|--top <n>|--max-results <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--exclude-comments] [--exclude-strings] [--exclude-fixtures] [--snippet-lines <n>] [--snippet-focus <leftmost|quality|proximity>] [--max-line-width <n>] [--fts] [--exact|--exact-substring] [--prefix] [--count] [--group-by <file|symbol>] [--since <datetime>] [--no-dedup] [--no-visibility-rank] [--require-before <query>] [--require-after <query>] [--reject-before <query>] [--reject-after <query>] [--guard-window <n>] [--guard-scope <window|same-line>] [--unique <path|symbol|origin>] [--count-by <path|symbol|origin>] [--origin <origin>] [--match-origin <origin>] [--exclude-origin <origin>] [--result-kind <kind>] [--search-fields <fields>] [--results-only] [--first-per-file] [--sample <n>] [--per-file-limit <n>] [--max-json-bytes <n>] [--next-steps]"),
+        ("recipes", "cdidx recipes [--json] [--pretty]"),
+        ("audit", "cdidx audit <recipe|recipe/query> [search filters] [--json] [--format <text|json|issue-drafts>]"),
         ("definition", "cdidx definition <query>|--query <query>|-- <query> [--db <path>] [--json] [--format <text|json|count|compact|csv|tsv|lsp|qf|sarif>] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--kind <kind>] [--visibility <v[,v]>] [--exclude-visibility <v[,v]>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--exact|--exact-name] [--count] [--since <datetime>]"),
         ("goto", "cdidx goto <query>|--query <query>|-- <query> [--db <path>] [--json] [--limit <n>|--top <n>] [--lang <lang>] [--kind <kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--exact|--exact-name] [--all]"),
         ("references", "cdidx references <query>|--query <query>|-- <query> [--db <path>] [--json] [--format <text|json|count|compact|csv|tsv|lsp|qf|sarif>] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--kind <kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--snippet-lines <n>] [--max-line-width <n>] [--exact|--exact-name] [--count]"),
@@ -138,6 +140,8 @@ public static class ConsoleUi
     [
         ("mcp", "--json is not supported; MCP requests and responses are JSON-RPC over the selected transport."),
         ("completions", "--json is not supported; output is a shell script for the selected shell."),
+        ("recipes", "Alias for `cdidx search --list-recipes`; recipe-list JSON is a single object, so --json=array is rejected."),
+        ("audit", "Alias for `cdidx search --recipe <recipe>`; pass search filters after the recipe name."),
         ("db", "schema defaults to the full sqlite_master dump for support bundles; use --summary-only, --limit, --max-sql-chars, and --exclude-internal for bounded diagnostics."),
         ("db", "checkpoint --dry-run reports the DB/WAL/SHM files and byte count without creating the checkpoint directory."),
         ("db", "checkpoint creates a filesystem snapshot next to the DB; restore replaces the DB and keeps a pre-restore backup directory."),
@@ -946,6 +950,8 @@ public static class ConsoleUi
         Console.WriteLine("  optimize                   Optimize FTS5 segments in an existing index DB");
         Console.WriteLine("  vacuum                     Reclaim free SQLite pages from an existing index DB");
         Console.WriteLine("  search <query>             Full-text search across indexed chunks");
+        Console.WriteLine("  recipes                    List built-in search audit recipes");
+        Console.WriteLine("  audit <recipe>             Run a built-in search audit recipe");
         Console.WriteLine("  definition <query>         Resolve symbol definitions with extracted ranges");
         Console.WriteLine("  goto <query>               Return one best LSP Location for a definition");
         Console.WriteLine("  references <query>         Find indexed references for a symbol (--kind uses reference kind)");
@@ -1421,7 +1427,7 @@ public static class ConsoleUi
 
     private static readonly string[] Commands =
     [
-        "index", "backfill-fold", "optimize", "search", "definition", "goto", "references", "callers", "callees",
+        "index", "backfill-fold", "optimize", "search", "recipes", "audit", "definition", "goto", "references", "callers", "callees",
         "symbols", "files", "find", "excerpt", "map", "inspect", "outline", "status", "validate-config",
         "validate", "deps", "impact", "unused", "hotspots", "suggestions", "languages", "batch", "mcp", "completions", "db", "vacuum", "report", "license", "upgrade",
     ];

--- a/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
@@ -248,6 +248,8 @@ internal static partial class ProgramRunner
         {
             "upgrade" => RunUpgrade(subArgs, context.JsonOptions, context.AppVersion, context.CancellationToken),
             "index" => IndexCommandRunner.Run(subArgs, context.JsonOptions),
+            "recipes" => RunRecipesAlias(subArgs, context),
+            "audit" => RunAuditAlias(subArgs, context),
             "export" => ExportImportCommandRunner.RunExport(subArgs, context.JsonOptions, context.AppVersion, context.CancellationToken),
             "import" => ExportImportCommandRunner.RunImport(subArgs, context.JsonOptions, context.CancellationToken),
             "diff" => DiffCommandRunner.Run(subArgs, context.JsonOptions, context.CancellationToken),
@@ -272,6 +274,33 @@ internal static partial class ProgramRunner
                 => IndexCommandRunner.Run(originalArgs, context.JsonOptions),
             _ => ShowError(originalArgs, $"Unknown command: {commandName}")
         };
+
+    private static int RunRecipesAlias(string[] subArgs, CommandRunContext context)
+    {
+        var searchArgs = new string[subArgs.Length + 1];
+        searchArgs[0] = "--list-recipes";
+        Array.Copy(subArgs, 0, searchArgs, 1, subArgs.Length);
+        return QueryCommandRunner.RunSearch(searchArgs, context.JsonOptions, context.CancellationToken);
+    }
+
+    private static int RunAuditAlias(string[] subArgs, CommandRunContext context)
+    {
+        if (subArgs.Length == 0 || subArgs[0].StartsWith("-", StringComparison.Ordinal))
+        {
+            return CommandErrorWriter.WriteJsonOrHuman(
+                ContainsJsonOutputFlag(subArgs),
+                context.JsonOptions,
+                "audit requires a recipe name.",
+                CommandExitCodes.UsageError,
+                "pass a recipe name after `cdidx audit`, or run `cdidx recipes` to list built-in recipes.");
+        }
+
+        var searchArgs = new string[subArgs.Length + 1];
+        searchArgs[0] = "--recipe";
+        searchArgs[1] = subArgs[0];
+        Array.Copy(subArgs, 1, searchArgs, 2, subArgs.Length - 1);
+        return QueryCommandRunner.RunSearch(searchArgs, context.JsonOptions, context.CancellationToken);
+    }
 
     internal static bool IsProjectPathArg(string arg)
     {

--- a/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
@@ -113,8 +113,20 @@ internal static partial class ProgramRunner
     {
         if (args.Length > 1 && ArgHelper.WantsHelp(args.AsSpan(1)))
         {
-            if (!ConsoleUi.PrintCommandUsage(args[0]))
-                ConsoleUi.PrintUsage(showBanner: true);
+            var helpCommand = ResolveSubcommandHelpName(args);
+            if (!ConsoleUi.PrintCommandUsage(helpCommand))
+            {
+                if (IsProjectPathArg(args[0]))
+                    ConsoleUi.PrintUsage(showBanner: true);
+                else
+                {
+                    exitCode = ShowError(args, $"Unknown command: {args[0]}", context.JsonOptions);
+                    GlobalToolLog.Info($"command_complete exit_code={exitCode} subcommand_help_unknown=true");
+                    EmitCommandMetric(args[0], args, context.StartTimestamp, context.Stopwatch, exitCode);
+                    return true;
+                }
+            }
+
             exitCode = CommandExitCodes.Success;
             GlobalToolLog.Info($"command_complete exit_code={exitCode} subcommand_help=true");
             EmitCommandMetric(args[0], args, context.StartTimestamp, context.Stopwatch, exitCode);
@@ -122,6 +134,58 @@ internal static partial class ProgramRunner
         }
 
         exitCode = CommandExitCodes.Success;
+        return false;
+    }
+
+    private static string ResolveSubcommandHelpName(string[] args)
+    {
+        if (args.Length > 2
+            && string.Equals(args[0], "db", StringComparison.Ordinal)
+            && TryGetHelpSubcommand(args.AsSpan(1), out var dbSubcommand))
+        {
+            return dbSubcommand switch
+            {
+                "integrity" or "--integrity-check" => "db-integrity",
+                "schema" => "db-schema",
+                "prune" => "db-prune",
+                "checkpoint" => "db-checkpoint",
+                "checkpoints" => "db-checkpoints",
+                "restore" => "db-restore",
+                "restore-backups" => "db-restore-backups",
+                _ => "db",
+            };
+        }
+
+        if (args.Length > 2
+            && string.Equals(args[0], "hooks", StringComparison.Ordinal)
+            && TryGetHelpSubcommand(args.AsSpan(1), out var hooksSubcommand))
+        {
+            return hooksSubcommand switch
+            {
+                "install" => "hooks-install",
+                "uninstall" => "hooks-uninstall",
+                "status" => "hooks-status",
+                _ => "hooks",
+            };
+        }
+
+        return args[0];
+    }
+
+    private static bool TryGetHelpSubcommand(ReadOnlySpan<string> args, out string subcommand)
+    {
+        foreach (var arg in args)
+        {
+            if (arg is "--help" or "-h")
+                break;
+            if (arg.StartsWith("-", StringComparison.Ordinal) && arg != "--integrity-check")
+                continue;
+
+            subcommand = arg;
+            return true;
+        }
+
+        subcommand = string.Empty;
         return false;
     }
 
@@ -218,6 +282,7 @@ internal static partial class ProgramRunner
             "definition" => a => QueryCommandRunner.RunDefinition(a, context.JsonOptions),
             "goto" => a => QueryCommandRunner.RunGoto(a, context.JsonOptions),
             "references" => a => QueryCommandRunner.RunReferences(a, context.JsonOptions),
+            "refs" => a => QueryCommandRunner.RunReferences(a, context.JsonOptions),
             "callers" => a => QueryCommandRunner.RunCallers(a, context.JsonOptions),
             "callees" => a => QueryCommandRunner.RunCallees(a, context.JsonOptions),
             "symbols" => a => QueryCommandRunner.RunSymbols(a, context.JsonOptions),
@@ -228,6 +293,7 @@ internal static partial class ProgramRunner
             "inspect" => a => QueryCommandRunner.RunInspect(a, context.JsonOptions),
             "outline" => a => QueryCommandRunner.RunOutline(a, context.JsonOptions),
             "status" => a => QueryCommandRunner.RunStatus(a, context.JsonOptions, context.AppVersion, context.CancellationToken),
+            "stats" => a => QueryCommandRunner.RunStatus(a, context.JsonOptions, context.AppVersion, context.CancellationToken),
             "validate" => a => QueryCommandRunner.RunValidate(a, context.JsonOptions),
             "languages" => a => QueryCommandRunner.RunLanguages(a, context.JsonOptions),
             "impact" => a => QueryCommandRunner.RunImpact(a, context.JsonOptions),
@@ -255,6 +321,7 @@ internal static partial class ProgramRunner
             "diff" => DiffCommandRunner.Run(subArgs, context.JsonOptions, context.CancellationToken),
             "hooks" => HookCommandRunner.Run(subArgs, context.JsonOptions),
             "backfill-fold" => IndexCommandRunner.RunBackfillFold(subArgs, context.JsonOptions),
+            "fold" => IndexCommandRunner.RunBackfillFold(subArgs, context.JsonOptions),
             "optimize" => IndexCommandRunner.RunOptimizeFts(subArgs, context.JsonOptions),
             "vacuum" => QueryCommandRunner.RunVacuum(subArgs, context.JsonOptions, context.CancellationToken),
             "validate-config" => CdidxConfigFile.RunValidate(subArgs, context.JsonOptions),
@@ -272,7 +339,7 @@ internal static partial class ProgramRunner
             "test-extractor" => RunTestExtractor(subArgs, context.JsonOptions),
             _ when IsProjectPathArg(commandName)
                 => IndexCommandRunner.Run(originalArgs, context.JsonOptions),
-            _ => ShowError(originalArgs, $"Unknown command: {commandName}")
+            _ => ShowError(originalArgs, $"Unknown command: {commandName}", context.JsonOptions)
         };
 
     private static int RunRecipesAlias(string[] subArgs, CommandRunContext context)

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -4408,8 +4408,18 @@ internal static partial class ProgramRunner
         return message.StartsWith(prefix, StringComparison.Ordinal) ? message[prefix.Length..] : message;
     }
 
-    private static int ShowError(string[] args, string message)
+    private static int ShowError(string[] args, string message, JsonSerializerOptions jsonOptions)
     {
+        if (ContainsJsonOutputFlag(args))
+        {
+            return CommandErrorWriter.WriteJsonOrHuman(
+                true,
+                jsonOptions,
+                message,
+                CommandExitCodes.UsageError,
+                "run `cdidx --help` to list available commands.");
+        }
+
         CommandErrorWriter.WriteStderr($"Error: {message}");
 
         var input = args[0];

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -4598,32 +4598,50 @@ public static partial class QueryCommandRunner
         }
         if (TryWriteUnexpectedExtraPositionals("excerpt", options))
             return CommandExitCodes.UsageError;
-        if (options.FocusColumn == null && (options.FocusLine.HasValue || cmdArgs.Any(arg => arg == "--focus-length" || arg.StartsWith("--focus-length=", StringComparison.Ordinal))))
+        var focusLengthSpecified = cmdArgs.Any(arg => arg == "--focus-length" || arg.StartsWith("--focus-length=", StringComparison.Ordinal));
+        if (options.FocusColumn == null && (options.FocusLine.HasValue || focusLengthSpecified))
         {
+            var focusError = options.FocusLine.HasValue && focusLengthSpecified
+                ? "--focus-line and --focus-length require --focus-column."
+                : options.FocusLine.HasValue
+                    ? "--focus-line requires --focus-column."
+                    : "--focus-length requires --focus-column.";
             WriteValidationError(
-                "--focus-line and --focus-length require --focus-column.",
+                focusError,
                 "Add `--focus-column <n>` so excerpt knows which token to keep visible inside the clamped line.");
             return CommandExitCodes.UsageError;
         }
 
-        if (options.StartLine == null)
+        var filePathArgument = options.Query;
+        var startLine = options.StartLine;
+        var endLine = options.EndLine;
+        if (startLine == null
+            && TryParseExcerptLocationArgument(options.Query, out var parsedPath, out var parsedStartLine, out var parsedEndLine))
+        {
+            filePathArgument = parsedPath;
+            startLine = parsedStartLine;
+            endLine ??= parsedEndLine;
+        }
+
+        if (startLine == null)
         {
             WriteValidationError(
                 "excerpt requires --start <line>",
-                "Add a starting line number, for example: `cdidx excerpt src/CodeIndex/Program.cs --start 20`.");
+                "Add a starting line number, for example: `cdidx excerpt src/CodeIndex/Program.cs --start 20` or `cdidx excerpt src/CodeIndex/Program.cs:20`.");
             return CommandExitCodes.UsageError;
         }
 
-        var endLine = options.EndLine ?? options.StartLine.Value;
-        if (endLine < options.StartLine.Value)
+        var startLineValue = startLine.Value;
+        var endLineValue = endLine ?? startLineValue;
+        if (endLineValue < startLineValue)
         {
             WriteValidationError(
-                $"--start ({options.StartLine.Value}) must be less than or equal to --end ({endLine}).",
+                $"--start ({startLineValue}) must be less than or equal to --end ({endLineValue}).",
                 "Use `--start` less than or equal to `--end`, or omit `--end` to read a single line.");
             return CommandExitCodes.UsageError;
         }
 
-        var filePath = DbPathResolver.ResolveQueryFilePath(options.DbPath, options.Query, options.DbPathExplicit);
+        var filePath = DbPathResolver.ResolveQueryFilePath(options.DbPath, filePathArgument, options.DbPathExplicit);
         return WithDb(options, jsonOptions, reader =>
         {
             if (options.FocusLine.HasValue)
@@ -4631,8 +4649,8 @@ public static partial class QueryCommandRunner
                 var file = reader.GetFileByPath(filePath);
                 if (file != null)
                 {
-                    var requestedStart = Math.Max(1, options.StartLine.Value - options.ContextBefore);
-                    var requestedEnd = Math.Min(file.Lines, endLine + options.ContextAfter);
+                    var requestedStart = Math.Max(1, startLineValue - options.ContextBefore);
+                    var requestedEnd = Math.Min(file.Lines, endLineValue + options.ContextAfter);
                     if (options.FocusLine.Value < requestedStart || options.FocusLine.Value > requestedEnd)
                     {
                         CommandErrorWriter.WriteStderr($"Error: --focus-line ({options.FocusLine.Value}) must be within the returned excerpt range ({requestedStart}-{requestedEnd}).");
@@ -4644,11 +4662,11 @@ public static partial class QueryCommandRunner
             {
                 var focusLineLength = reader.GetExcerptFocusLineLength(
                     filePath,
-                    options.StartLine.Value,
-                    endLine,
+                    startLineValue,
+                    endLineValue,
                     options.ContextBefore,
                     options.ContextAfter,
-                    options.FocusLine ?? options.StartLine.Value);
+                    options.FocusLine ?? startLineValue);
                 if (focusLineLength.HasValue && options.FocusColumn.Value > focusLineLength.Value)
                 {
                     CommandErrorWriter.WriteStderr($"Error: --focus-column ({options.FocusColumn.Value}) must be within the focused line length ({focusLineLength.Value}).");
@@ -4658,12 +4676,12 @@ public static partial class QueryCommandRunner
 
             var excerpt = reader.GetExcerpt(
                 filePath,
-                options.StartLine.Value,
-                endLine,
+                startLineValue,
+                endLineValue,
                 options.ContextBefore,
                 options.ContextAfter,
                 options.MaxLineWidth,
-                options.FocusLine ?? options.StartLine.Value,
+                options.FocusLine ?? startLineValue,
                 options.FocusColumn,
                 options.FocusLength);
             if (excerpt == null)
@@ -4690,6 +4708,48 @@ public static partial class QueryCommandRunner
             return CommandExitCodes.Success;
         });
     }
+
+    private static bool TryParseExcerptLocationArgument(
+        string value,
+        out string path,
+        out int startLine,
+        out int? endLine)
+    {
+        path = string.Empty;
+        startLine = 0;
+        endLine = null;
+
+        var separator = value.LastIndexOf(':');
+        if (separator <= 0 || separator == value.Length - 1)
+            return false;
+
+        var range = value[(separator + 1)..];
+        var dash = range.IndexOf('-');
+        if (dash < 0)
+        {
+            if (!TryParsePositiveLine(range, out startLine))
+                return false;
+
+            path = value[..separator];
+            return true;
+        }
+
+        if (dash == 0 || dash == range.Length - 1 || range.IndexOf('-', dash + 1) >= 0)
+            return false;
+
+        if (!TryParsePositiveLine(range[..dash], out startLine)
+            || !TryParsePositiveLine(range[(dash + 1)..], out var parsedEndLine))
+        {
+            return false;
+        }
+
+        path = value[..separator];
+        endLine = parsedEndLine;
+        return true;
+    }
+
+    private static bool TryParsePositiveLine(string value, out int line)
+        => int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out line) && line > 0;
 
     private static List<ExcerptSemanticToken> BuildExcerptSemanticTokens(FileExcerptResult excerpt)
     {

--- a/tests/CodeIndex.Tests/CliFlagSchemaTests.cs
+++ b/tests/CodeIndex.Tests/CliFlagSchemaTests.cs
@@ -114,6 +114,14 @@ public class CliFlagSchemaTests
     }
 
     [Fact]
+    public void Goto_AcceptsDocumentedExcludeFilters_Issue3934()
+    {
+        var accepted = CliFlagSchema.GetAcceptedFlagNamesForCommand("goto");
+        Assert.Contains("--exclude-tests", accepted);
+        Assert.Contains("--exclude-path", accepted);
+    }
+
+    [Fact]
     public void UpgradeFlags_SurfaceImplementedSelectionAndJsonOptions()
     {
         var accepted = CliFlagSchema.GetAcceptedFlagNamesForCommand("upgrade");

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -126,6 +126,35 @@ public class ConsoleUiTests
     }
 
     [Fact]
+    public void PrintCommandUsage_SearchIncludesAuditOutputControlFlags_Issue3893()
+    {
+        using var capture = ConsoleCapture.Start(captureOut: true);
+
+        Assert.True(ConsoleUi.PrintCommandUsage("search"));
+
+        var output = capture.Out!.ToString()!;
+        foreach (var flag in new[]
+        {
+            "--unique",
+            "--count-by",
+            "--origin",
+            "--match-origin",
+            "--exclude-origin",
+            "--result-kind",
+            "--search-fields",
+            "--results-only",
+            "--first-per-file",
+            "--sample",
+            "--per-file-limit",
+            "--max-json-bytes",
+            "--next-steps",
+        })
+        {
+            Assert.Contains(flag, output);
+        }
+    }
+
+    [Fact]
     public void PrintUsage_WithoutBanner_HidesAsciiArtAndEasterEggFlags()
     {
         var output = CaptureFullUsageOutput(showBanner: false);

--- a/tests/CodeIndex.Tests/ConsoleUiTests.cs
+++ b/tests/CodeIndex.Tests/ConsoleUiTests.cs
@@ -155,6 +155,45 @@ public class ConsoleUiTests
     }
 
     [Fact]
+    public void PrintCommandUsage_InspectSplitsQueryAndLinePathModes_Issue3916()
+    {
+        using var capture = ConsoleCapture.Start(captureOut: true);
+
+        Assert.True(ConsoleUi.PrintCommandUsage("inspect"));
+
+        var output = capture.Out!.ToString()!;
+        var usageLines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Where(line => line.TrimStart().StartsWith("cdidx inspect", StringComparison.Ordinal))
+            .ToArray();
+        Assert.Contains(usageLines, line => line.Contains("--path <glob>", StringComparison.Ordinal));
+        Assert.Contains(usageLines, line => line.Contains("--path <file> --line <line>", StringComparison.Ordinal));
+        Assert.DoesNotContain(usageLines, line =>
+            line.Contains("--path <glob>", StringComparison.Ordinal)
+            && line.Contains("--path <file>", StringComparison.Ordinal));
+        Assert.Contains("In query mode --path is a glob filter", output);
+    }
+
+    [Fact]
+    public void PrintCommandUsage_DocumentsJsonLineAndBatchContracts_Issue3916()
+    {
+        var (_, referencesStdout, _) = ConsoleCapture.Capture(() =>
+        {
+            ConsoleUi.PrintCommandUsage("references");
+            return 0;
+        });
+        var (_, batchStdout, _) = ConsoleCapture.Capture(() =>
+        {
+            ConsoleUi.PrintCommandUsage("batch");
+            return 0;
+        });
+
+        Assert.Contains("JSON Lines", referencesStdout);
+        Assert.Contains("one JSON object per result", referencesStdout);
+        Assert.Contains("stdin is JSON Lines", batchStdout);
+        Assert.Contains("invalid lines emit per-line JSON errors", batchStdout);
+    }
+
+    [Fact]
     public void PrintUsage_WithoutBanner_HidesAsciiArtAndEasterEggFlags()
     {
         var output = CaptureFullUsageOutput(showBanner: false);
@@ -176,7 +215,8 @@ public class ConsoleUiTests
         Assert.Contains("cdidx search <query>|--query <query>|-- <query>|--recipe <name|name/query>|--list-recipes|--named-query <name>=<query> [--named-query <name>=<query> ...] [--include-query <name>] [--exclude-query <name>] [--cursor <cursor>] [--audit-scope <source|all>] [--show-excluded] [--db <path>] [--json[=ndjson|array]] [--pretty] [--format <text|json|count|compact|csv|tsv|lsp|qf|sarif|issue-drafts>] [--open-issues <path|github|github:owner/name>] [--repo <owner/name>] [--duplicate-confidence <low|medium|high>|--duplicate-threshold <score>] [--issue-title <title>] [--issue-label <label>] [--verbose] [--limit <n>|--top <n>|--max-results <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--exclude-comments] [--exclude-strings] [--exclude-fixtures] [--snippet-lines <n>] [--snippet-focus <leftmost|quality|proximity>] [--max-line-width <n>] [--fts] [--exact|--exact-substring] [--prefix] [--count] [--group-by <file|symbol>] [--since <datetime>] [--no-dedup] [--no-visibility-rank] [--require-before <query>] [--require-after <query>] [--reject-before <query>] [--reject-after <query>] [--guard-window <n>] [--guard-scope <window|same-line>]", output);
         Assert.Contains("cdidx definition <query>|--query <query>|-- <query> [--db <path>] [--json] [--format <text|json|count|compact|csv|tsv|lsp|qf|sarif>] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--kind <kind>] [--visibility <v[,v]>] [--exclude-visibility <v[,v]>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--exact|--exact-name] [--count] [--since <datetime>]", output);
         Assert.Contains("cdidx references <query>|--query <query>|-- <query> [--db <path>] [--json] [--format <text|json|count|compact|csv|tsv|lsp|qf|sarif>] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--kind <kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--snippet-lines <n>] [--max-line-width <n>] [--exact|--exact-name] [--count]", output);
-        Assert.Contains("cdidx inspect <query>|--query <query>|-- <query>|--path <file> --line <line> [--db <path>] [--json] [--format <text|json|compact>] [--pretty] [--compact] [--fields <csv>] [--body-only] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--kind <kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--body-start <line>] [--body-lines <n>|--body-line-count <n>] [--line <line>|--start-line <line>] [--end-line <line>] [--context <n>|--before <n>|--after <n>] [--max-line-width <n>] [--exact|--exact-name]", output);
+        Assert.Contains("cdidx inspect <query>|--query <query>|-- <query> [--db <path>] [--json] [--format <text|json|compact>] [--pretty] [--compact] [--fields <csv>] [--body-only] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--kind <kind>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--body] [--body-start <line>] [--body-lines <n>|--body-line-count <n>] [--context <n>|--before <n>|--after <n>] [--max-line-width <n>] [--exact|--exact-name]", output);
+        Assert.Contains("cdidx inspect --path <file> --line <line> [--end-line <line>] [--db <path>] [--json] [--format <text|json|compact>] [--pretty] [--compact] [--fields <csv>] [--body-only] [--body] [--body-start <line>] [--body-lines <n>|--body-line-count <n>] [--context <n>|--before <n>|--after <n>] [--max-line-width <n>]", output);
         Assert.Contains("--snippet-lines <n>        search/find snippet length (1-20, default: search 8; find 1)", output);
         Assert.Contains("--snippet-focus <mode>     search only: long-line focus mode (leftmost|quality|proximity, default: quality)", output);
         Assert.Contains("--max-line-width <n>       search/references/callers/callees/find/excerpt/impact/inspect only: clamp very long single-line snippet/context/excerpt payloads (`0` disables clamping; default: 512)", output);
@@ -205,7 +245,7 @@ public class ConsoleUiTests
         Assert.Contains("--optimize                 index only: optimize the existing FTS5 table for this project's DB without scanning files", output);
         Assert.Contains("--duration-format <format> Index elapsed time format: `auto` (default), `seconds`, or `hms`; JSON keeps raw elapsed_ms", output);
         Assert.Contains("--ascii                    Use ASCII spinner/progress glyphs", output);
-        Assert.Contains("cdidx excerpt <path> --start <line> [--end <line>] [--before <n>] [--after <n>] [--max-line-width <n>] [--focus-line <line>] [--focus-column <n>] [--focus-length <n>] [--db <path>] [--json] [--verbose]", output);
+        Assert.Contains("cdidx excerpt <path[:line|:start-end]> [--start <line>|--start-line <line>] [--end <line>|--end-line <line>] [--before <n>] [--after <n>] [--max-line-width <n>] [--focus-line <line>] [--focus-column <n>] [--focus-length <n>] [--db <path>] [--json] [--verbose]", output);
         Assert.Contains("--focus-column <n>         find/excerpt: focus a specific 1-based column", output);
         Assert.Contains("--focus-line <line>        find/excerpt: focus a specific line", output);
         Assert.Contains("cdidx map [--db <path>] [--json] [--format <text|json|compact>] [--pretty] [--compact] [--summary-only] [--verbose] [--limit <n>|--top <n>] [--lang <lang>] [--path <glob>] [--exclude-path <glob>] [--exclude-tests] [--bytes] [--sections <tree,languages,hotspots,metrics>] [--depth <n>] [--min-entrypoint-confidence <0.0..1.0>]", output);

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -144,6 +144,56 @@ public class ProgramRunnerTests
         Assert.True(document.RootElement.TryGetProperty("count", out _));
     }
 
+    [Theory]
+    [InlineData("refs", "cdidx references")]
+    [InlineData("stats", "cdidx status")]
+    [InlineData("fold", "cdidx backfill-fold")]
+    public void Run_LegacyAliasHelp_PrintsCommandUsage_Issue3916(string command, string expectedUsage)
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+            [command, "--help"],
+            appVersion: "1.10.0"));
+
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Contains(expectedUsage, stdout);
+        Assert.DoesNotContain("Build or update the index for a project", stdout);
+        Assert.Empty(stderr);
+    }
+
+    [Theory]
+    [InlineData("db", "checkpoint", "cdidx db checkpoint", "creates a filesystem snapshot")]
+    [InlineData("hooks", "install", "cdidx hooks install", ".git/hooks/pre-commit")]
+    public void Run_NestedCommandHelp_PrintsSpecificUsage_Issue3916(
+        string command,
+        string subcommand,
+        string expectedUsage,
+        string expectedNote)
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+            [command, subcommand, "--help"],
+            appVersion: "1.10.0"));
+
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Contains(expectedUsage, stdout);
+        Assert.Contains(expectedNote, stdout);
+        Assert.Empty(stderr);
+    }
+
+    [Fact]
+    public void Run_UnknownCommandHelpJson_ReturnsJsonUsageError_Issue3916()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+            ["no-such-command", "--help", "--json"],
+            appVersion: "1.10.0"));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Empty(stderr);
+        using var document = JsonDocument.Parse(stdout);
+        Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
+        Assert.Contains("Unknown command: no-such-command", document.RootElement.GetProperty("message").GetString(), StringComparison.Ordinal);
+        Assert.DoesNotContain("Build or update the index for a project", stdout);
+    }
+
     [Fact]
     public void RunLanguages_PrettyJson_IndentsOutput_Issue2996()
     {

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -115,6 +115,35 @@ public class ProgramRunnerTests
         Assert.False(ProgramRunner.ContainsJsonOutputFlag(["search", "--", "--json"]));
     }
 
+    [Theory]
+    [InlineData("recipes", "cdidx recipes")]
+    [InlineData("audit", "cdidx audit")]
+    public void Run_SearchAuditAliasHelp_PrintsCommandUsage_Issue3893(string command, string expectedUsage)
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+            [command, "--help"],
+            appVersion: "1.10.0"));
+
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Contains(expectedUsage, stdout);
+        Assert.DoesNotContain("Build or update the index for a project", stdout);
+        Assert.Empty(stderr);
+    }
+
+    [Fact]
+    public void RunRecipesAlias_ListsRecipeJsonObject_Issue3893()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(
+            ["recipes", "--json"],
+            appVersion: "1.10.0"));
+
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Empty(stderr);
+        using var document = JsonDocument.Parse(stdout);
+        Assert.True(document.RootElement.TryGetProperty("recipes", out _));
+        Assert.True(document.RootElement.TryGetProperty("count", out _));
+    }
+
     [Fact]
     public void RunLanguages_PrettyJson_IndentsOutput_Issue2996()
     {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -4215,7 +4215,47 @@ jobs:
                 _jsonOptions));
 
             Assert.Equal(CommandExitCodes.UsageError, exitCode);
-            Assert.Contains("--focus-line and --focus-length require --focus-column", stderr);
+            Assert.Contains("--focus-line requires --focus-column", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunExcerpt_FocusLengthWithoutFocusColumnReturnsSpecificUsageError_Issue3916()
+    {
+        var (exitCode, _, stderr) = CaptureConsole(() => QueryCommandRunner.RunExcerpt(
+            ["dist/data.txt", "--start", "1", "--focus-length", "6"],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Contains("--focus-length requires --focus-column", stderr);
+    }
+
+    [Fact]
+    public void RunExcerpt_AcceptsPathStartEndLocationArgument_Issue3916()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_excerpt_location_range");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(dbPath, "README.md", "markdown", "line one\nline two\nline three\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunExcerpt(
+                ["README.md:2-3", "--db", dbPath, "--json"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = ParseJsonOutput(stdout);
+            var root = document.RootElement;
+            Assert.Equal("README.md", root.GetProperty("path").GetString());
+            Assert.Equal(2, root.GetProperty("start_line").GetInt32());
+            Assert.Equal(3, root.GetProperty("end_line").GetInt32());
+            Assert.Contains("line two", root.GetProperty("content").GetString(), StringComparison.Ordinal);
+            Assert.Contains("line three", root.GetProperty("content").GetString(), StringComparison.Ordinal);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Accept the documented `goto --exclude-tests` / `--exclude-path` filters.
- Document implemented search audit/output controls and add `recipes` / `audit` help/runtime aliases.
- Tighten CLI help contracts for inspect, excerpt, references, batch, db/hooks subcommands, aliases, and JSON unknown-command errors.

## Tests
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ConsoleUiTests|FullyQualifiedName~ProgramRunnerTests|FullyQualifiedName~CliFlagSchemaTests|FullyQualifiedName~RunExcerpt_|FullyQualifiedName~RunSearch_ListRecipes|FullyQualifiedName~RunSearch_SearchFieldsResultsOnly" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- CLI smoke checks for `refs --help`, `db checkpoint --help`, unknown command `--help --json`, and `excerpt path:start-end --json`

## Review
- Attempted `codex exec` adversarial review, but it was blocked before review by the Codex usage limit.
- Performed a manual adversarial review of the local diff against `origin/main`; no blocking findings found.

Fixes #3893
Fixes #3916
Fixes #3934