### PR TITLE
Centralize filesystem boundary checks

### DIFF
--- a/changelog.d/unreleased/3970.fixed.md
+++ b/changelog.d/unreleased/3970.fixed.md
@@ -1,0 +1,27 @@
+---
+category: fixed
+issues:
+  - 3970
+affected:
+  - src/CodeIndex/Cli/FileSystemBoundary.cs
+  - src/CodeIndex/Cli/DataDirectorySecurity.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Cli/DbCommandRunner.cs
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - src/CodeIndex/Cli/PrivateLogFile.cs
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.Discovery.cs
+  - src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.PatternConfig.cs
+  - src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.PluginLoading.cs
+  - src/CodeIndex/Mcp/McpPathBoundary.cs
+  - tests/CodeIndex.Tests/ExtractorPluginRegistryTests.cs
+  - tests/CodeIndex.Tests/FileSystemBoundaryTests.cs
+---
+
+## English
+
+- **Filesystem boundary checks now share common cleanup and reparse-point primitives (#3970)** — sensitive-state directories, private logs, cleanup targets, scanner probes, plugin discovery, pattern configs, import/export temp cleanup, and MCP path boundaries now use shared normalization, descendant, and symlink/reparse-point helpers so the policy is easier to audit and less likely to drift.
+
+## 日本語
+
+- **filesystem 境界チェックが cleanup と reparse point の共通 primitive を使うようになりました (#3970)** — sensitive state directory、private log、cleanup target、scanner probe、plugin discovery、pattern config、import/export の temp cleanup、MCP path boundary が共有の正規化・子孫判定・symlink/reparse point helper を使うようになり、policy を監査しやすく drift しにくくしました。

--- a/changelog.d/unreleased/3970.fixed.md
+++ b/changelog.d/unreleased/3970.fixed.md
@@ -24,4 +24,4 @@ affected:
 
 ## 日本語
 
-- **filesystem 境界チェックが cleanup と reparse point の共通 primitive を使うようになりました (#3970)** — sensitive state directory、private log、cleanup target、scanner probe、plugin discovery、pattern config、import/export の temp cleanup、MCP path boundary が共有の正規化・子孫判定・symlink/reparse point helper を使うようになり、policy を監査しやすく drift しにくくしました。
+- **ファイルシステム境界チェックが、クリーンアップと再解析ポイントの共通プリミティブを使うようになりました (#3970)** — 機密状態ディレクトリ、プライベートログ、クリーンアップ対象、スキャナーの属性確認、プラグイン検出、パターン設定、インポート/エクスポートの一時ディレクトリ削除、MCP のパス境界が共有の正規化・子孫判定・シンボリックリンク/再解析ポイントヘルパーを使うようになり、方針を監査しやすく、乖離しにくくしました。

--- a/src/CodeIndex/Cli/DataDirectorySecurity.cs
+++ b/src/CodeIndex/Cli/DataDirectorySecurity.cs
@@ -107,7 +107,7 @@ internal static class DataDirectorySecurity
             return;
 
         var root = ResolveSensitiveTempFallbackRootDirectory();
-        if (!IsSameDirectory(path, root) && !IsDirectoryDescendant(path, root))
+        if (!FileSystemBoundary.IsSameOrDescendant(root, path))
             return;
 
         RejectUnsafeDirectoryTarget(root);
@@ -121,7 +121,7 @@ internal static class DataDirectorySecurity
         try
         {
             var attributes = File.GetAttributes(path);
-            if ((attributes & FileAttributes.ReparsePoint) != 0)
+            if (FileSystemBoundary.IsSymlinkOrReparsePoint(attributes))
             {
                 throw new IOException(
                     $"Refusing to use symbolic link or reparse point directory {ConsoleUi.FormatBoundedValue(path)} for sensitive cdidx state.");
@@ -153,42 +153,15 @@ internal static class DataDirectorySecurity
     {
         try
         {
-            var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? StringComparison.OrdinalIgnoreCase
-                : StringComparison.Ordinal;
-            return string.Equals(NormalizeDirectory(left), NormalizeDirectory(right), comparison);
+            var normalizedLeft = FileSystemBoundary.NormalizeDirectoryPath(left);
+            var normalizedRight = FileSystemBoundary.NormalizeDirectoryPath(right);
+            return string.Equals(normalizedLeft, normalizedRight, PathCasing.ComparisonFor(normalizedLeft));
         }
-        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or PathTooLongException)
+        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or PathTooLongException or CodeIndexException)
         {
             return false;
         }
     }
-
-    private static bool IsDirectoryDescendant(string path, string ancestor)
-    {
-        try
-        {
-            var normalizedPath = NormalizeDirectory(path);
-            var normalizedAncestor = NormalizeDirectory(ancestor);
-            var comparison = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-                ? StringComparison.OrdinalIgnoreCase
-                : StringComparison.Ordinal;
-
-            return normalizedPath.Length > normalizedAncestor.Length
-                && normalizedPath.StartsWith(normalizedAncestor, comparison)
-                && IsDirectorySeparator(normalizedPath[normalizedAncestor.Length]);
-        }
-        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or PathTooLongException)
-        {
-            return false;
-        }
-    }
-
-    private static bool IsDirectorySeparator(char value)
-        => value == Path.DirectorySeparatorChar || value == Path.AltDirectorySeparatorChar;
-
-    private static string NormalizeDirectory(string path)
-        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
     private static string GetTempPath() => Path.GetTempPath();
 

--- a/src/CodeIndex/Cli/DataDirectorySecurity.cs
+++ b/src/CodeIndex/Cli/DataDirectorySecurity.cs
@@ -107,7 +107,7 @@ internal static class DataDirectorySecurity
             return;
 
         var root = ResolveSensitiveTempFallbackRootDirectory();
-        if (!FileSystemBoundary.IsSameOrDescendant(root, path))
+        if (!IsSameOrDescendantDirectory(root, path))
             return;
 
         RejectUnsafeDirectoryTarget(root);
@@ -129,6 +129,18 @@ internal static class DataDirectorySecurity
         }
         catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
         {
+        }
+    }
+
+    private static bool IsSameOrDescendantDirectory(string parent, string child)
+    {
+        try
+        {
+            return FileSystemBoundary.IsSameOrDescendant(parent, child);
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or PathTooLongException or CodeIndexException)
+        {
+            return false;
         }
     }
 

--- a/src/CodeIndex/Cli/DbCommandRunner.cs
+++ b/src/CodeIndex/Cli/DbCommandRunner.cs
@@ -1697,48 +1697,17 @@ public static class DbCommandRunner
         out string fullPath,
         out string failureReason)
     {
-        fullPath = string.Empty;
-        failureReason = string.Empty;
-        try
-        {
-            fullPath = PathCasing.NormalizeBoundaryPath(path);
-            var normalizedRoot = PathCasing.NormalizeBoundaryPath(safeRoot);
-            if (string.Equals(fullPath, normalizedRoot, PathCasing.ComparisonFor(normalizedRoot))
-                || !PathCasing.IsPathEqualOrParent(normalizedRoot, fullPath))
-            {
-                failureReason = "target is outside the expected cleanup root";
-                return false;
-            }
-
-            if (!Path.GetFileName(fullPath).StartsWith(expectedNamePrefix, StringComparison.Ordinal))
-            {
-                failureReason = "target name does not match the expected temporary-directory prefix";
-                return false;
-            }
-
-            var longPath = LongPath.EnsureWindowsPrefix(fullPath);
-            if (Directory.Exists(longPath))
-            {
-                var attributes = File.GetAttributes(longPath);
-                if ((attributes & (FileAttributes.ReparsePoint | FileAttributes.Device)) != 0)
-                {
-                    failureReason = "target is not a regular temporary directory";
-                    return false;
-                }
-            }
-            else if (File.Exists(longPath))
-            {
-                failureReason = "target is not a directory";
-                return false;
-            }
-
-            return true;
-        }
-        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or UnauthorizedAccessException or PathTooLongException)
-        {
-            failureReason = "target path is invalid";
-            return false;
-        }
+        var options = new DirectoryCleanupBoundaryOptions(
+            expectedNamePrefix,
+            "target is outside the expected cleanup root",
+            "target name does not match the expected temporary-directory prefix",
+            "target is not a regular temporary directory");
+        return FileSystemBoundary.TryValidateDirectoryCleanupTarget(
+            path,
+            safeRoot,
+            options,
+            out fullPath,
+            out failureReason);
     }
 
     internal static DbCommandOptions ParseArgs(string[] args)

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using CodeIndex.Database;
+using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
 
 namespace CodeIndex.Cli;
@@ -283,7 +284,7 @@ internal static class ExportImportCommandRunner
                 DeleteSqliteSidecars(tempPath, "import temporary database sidecar");
             }
             if (tempDirectory != null)
-                TryDeleteDirectoryIfEmpty(tempDirectory, "import temporary directory");
+                TryDeleteDirectoryIfEmpty(tempDirectory, "import temporary directory", Path.GetTempPath(), "codeindex-import-");
         }
     }
 
@@ -390,7 +391,7 @@ internal static class ExportImportCommandRunner
                 DeleteSqliteSidecars(snapshotPath, "export temporary database sidecar");
             }
             if (snapshotDirectory != null)
-                TryDeleteDirectoryIfEmpty(snapshotDirectory, "export temporary directory");
+                TryDeleteDirectoryIfEmpty(snapshotDirectory, "export temporary directory", Path.GetTempPath(), "codeindex-export-");
         }
     }
 
@@ -1480,14 +1481,30 @@ internal static class ExportImportCommandRunner
         }
     }
 
-    private static void TryDeleteDirectoryIfEmpty(string path, string? cleanupDescription = null)
+    private static void TryDeleteDirectoryIfEmpty(
+        string path,
+        string? cleanupDescription,
+        string safeRoot,
+        string expectedNamePrefix)
     {
         try
         {
-            if (!Directory.Exists(path) || CodeIndex.FileSystemTraversalPolicy.HasAnyFileSystemEntry(path))
+            var options = new DirectoryCleanupBoundaryOptions(
+                expectedNamePrefix,
+                "target is outside the expected cleanup root",
+                "target name does not match the expected temporary-directory prefix",
+                "target is not a regular temporary directory");
+            if (!FileSystemBoundary.TryValidateDirectoryCleanupTarget(path, safeRoot, options, out var fullPath, out var validationFailure))
+            {
+                if (!string.IsNullOrWhiteSpace(cleanupDescription))
+                    CommandErrorWriter.WriteStderr($"Warning: skipped deleting {cleanupDescription} {ConsoleUi.FormatBoundedValue(path)} ({validationFailure}).");
+                return;
+            }
+
+            if (!Directory.Exists(LongPath.EnsureWindowsPrefix(fullPath)) || CodeIndex.FileSystemTraversalPolicy.HasAnyFileSystemEntry(fullPath))
                 return;
 
-            Directory.Delete(path);
+            Directory.Delete(LongPath.EnsureWindowsPrefix(fullPath));
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or ArgumentException or NotSupportedException or PathTooLongException)
         {

--- a/src/CodeIndex/Cli/FileSystemBoundary.cs
+++ b/src/CodeIndex/Cli/FileSystemBoundary.cs
@@ -1,0 +1,144 @@
+using CodeIndex.Indexer;
+
+namespace CodeIndex.Cli;
+
+internal enum FileSystemBoundaryProbeStatus
+{
+    Found,
+    Missing,
+    PermissionDenied,
+    IoError,
+    InvalidPath,
+}
+
+internal readonly record struct DirectoryCleanupBoundaryOptions(
+    string ExpectedNamePrefix,
+    string OutsideRootReason,
+    string PrefixMismatchReason,
+    string UnsafeDirectoryReason,
+    string NotDirectoryReason = "target is not a directory",
+    string InvalidPathReason = "target path is invalid");
+
+internal static class FileSystemBoundary
+{
+    internal static string NormalizeDirectoryPath(string path)
+        => PathCasing.NormalizeBoundaryPath(path);
+
+    internal static bool IsSameOrDescendant(string parent, string child)
+        => PathCasing.IsPathEqualOrParent(
+            NormalizeDirectoryPath(parent),
+            NormalizeDirectoryPath(child));
+
+    internal static bool IsStrictDescendant(string parent, string child)
+    {
+        var normalizedParent = NormalizeDirectoryPath(parent);
+        var normalizedChild = NormalizeDirectoryPath(child);
+        return !string.Equals(normalizedParent, normalizedChild, PathCasing.ComparisonFor(normalizedParent))
+            && PathCasing.IsPathEqualOrParent(normalizedParent, normalizedChild);
+    }
+
+    internal static bool IsSymlinkOrReparsePoint(FileAttributes attributes)
+        => (attributes & FileAttributes.ReparsePoint) != 0;
+
+    internal static bool IsDevice(FileAttributes attributes)
+        => (attributes & FileAttributes.Device) != 0;
+
+    internal static bool IsSymlinkOrReparsePoint(FileSystemInfo info)
+        => IsSymlinkOrReparsePoint(info.Attributes) || !string.IsNullOrEmpty(info.LinkTarget);
+
+    internal static bool IsSymlinkReparsePointOrDevice(FileSystemInfo info)
+        => IsSymlinkOrReparsePoint(info) || IsDevice(info.Attributes);
+
+    internal static FileSystemBoundaryProbeStatus TryGetAttributes(string path, out FileAttributes attributes)
+    {
+        attributes = default;
+        try
+        {
+            attributes = File.GetAttributes(LongPath.EnsureWindowsPrefix(path));
+            return FileSystemBoundaryProbeStatus.Found;
+        }
+        catch (FileNotFoundException)
+        {
+            return FileSystemBoundaryProbeStatus.Missing;
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return FileSystemBoundaryProbeStatus.Missing;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return FileSystemBoundaryProbeStatus.PermissionDenied;
+        }
+        catch (IOException)
+        {
+            return FileSystemBoundaryProbeStatus.IoError;
+        }
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        {
+            return FileSystemBoundaryProbeStatus.InvalidPath;
+        }
+    }
+
+    internal static string ClassifyProbeFailure(Exception exception) =>
+        exception switch
+        {
+            UnauthorizedAccessException => "permission_denied",
+            FileNotFoundException or DirectoryNotFoundException => "not_found",
+            ArgumentException or PathTooLongException => "invalid_path",
+            NotSupportedException => "not_supported",
+            IOException => "io_error",
+            _ => "operation_failed",
+        };
+
+    internal static bool TryValidateDirectoryCleanupTarget(
+        string path,
+        string safeRoot,
+        DirectoryCleanupBoundaryOptions options,
+        out string fullPath,
+        out string failureReason)
+    {
+        fullPath = string.Empty;
+        failureReason = string.Empty;
+        try
+        {
+            fullPath = NormalizeDirectoryPath(path);
+            var normalizedRoot = NormalizeDirectoryPath(safeRoot);
+            if (string.Equals(fullPath, normalizedRoot, PathCasing.ComparisonFor(normalizedRoot))
+                || !PathCasing.IsPathEqualOrParent(normalizedRoot, fullPath))
+            {
+                failureReason = options.OutsideRootReason;
+                return false;
+            }
+
+            if (!Path.GetFileName(fullPath).StartsWith(options.ExpectedNamePrefix, StringComparison.Ordinal))
+            {
+                failureReason = options.PrefixMismatchReason;
+                return false;
+            }
+
+            var longPath = LongPath.EnsureWindowsPrefix(fullPath);
+            if (Directory.Exists(longPath))
+            {
+                var directoryInfo = new DirectoryInfo(fullPath);
+                directoryInfo.Refresh();
+                if (IsSymlinkReparsePointOrDevice(directoryInfo))
+                {
+                    failureReason = options.UnsafeDirectoryReason;
+                    return false;
+                }
+            }
+            else if (File.Exists(longPath))
+            {
+                failureReason = options.NotDirectoryReason;
+                return false;
+            }
+
+            return true;
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or UnauthorizedAccessException or PathTooLongException or CodeIndexException)
+        {
+            failureReason = options.InvalidPathReason;
+            return false;
+        }
+    }
+}

--- a/src/CodeIndex/Cli/PrivateLogFile.cs
+++ b/src/CodeIndex/Cli/PrivateLogFile.cs
@@ -275,7 +275,7 @@ internal static class PrivateLogFile
         try
         {
             var attributes = File.GetAttributes(LongPath.EnsureWindowsPrefix(path));
-            if ((attributes & FileAttributes.ReparsePoint) != 0)
+            if (FileSystemBoundary.IsSymlinkOrReparsePoint(attributes))
                 throw new IOException("Refusing to use private log target because it is a symbolic link or reparse point.");
         }
         catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
@@ -283,15 +283,8 @@ internal static class PrivateLogFile
         }
     }
 
-    private static string ClassifyFailure(Exception exception) =>
-        exception switch
-        {
-            UnauthorizedAccessException => "permission_denied",
-            FileNotFoundException or DirectoryNotFoundException => "not_found",
-            NotSupportedException => "not_supported",
-            IOException => "io_error",
-            _ => "operation_failed",
-        };
+    private static string ClassifyFailure(Exception exception)
+        => FileSystemBoundary.ClassifyProbeFailure(exception);
 
     private static string FormatDiagnosticTarget(string path)
     {

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -3902,60 +3902,17 @@ internal static partial class ProgramRunner
         out string fullPath,
         out string failureReason)
     {
-        fullPath = string.Empty;
-        failureReason = string.Empty;
-        try
-        {
-            fullPath = NormalizeCleanupBoundaryPath(Path.GetFullPath(path));
-            var tempRoot = NormalizeCleanupBoundaryPath(Path.GetTempPath());
-            if (string.Equals(fullPath, tempRoot, PathCasing.ComparisonFor(tempRoot))
-                || !PathCasing.IsPathEqualOrParent(tempRoot, fullPath))
-            {
-                failureReason = "target is outside the expected cleanup root";
-                return false;
-            }
-
-            if (!Path.GetFileName(fullPath).StartsWith(UpgradeInstallerDirectoryPrefix, StringComparison.Ordinal))
-            {
-                failureReason = "target name does not match the expected upgrade temporary-directory prefix";
-                return false;
-            }
-
-            var longPath = LongPath.EnsureWindowsPrefix(fullPath);
-            if (Directory.Exists(longPath))
-            {
-                var directoryInfo = new DirectoryInfo(fullPath);
-                directoryInfo.Refresh();
-                var attributes = directoryInfo.Attributes;
-                if ((attributes & (FileAttributes.ReparsePoint | FileAttributes.Device)) != 0
-                    || !string.IsNullOrEmpty(directoryInfo.LinkTarget))
-                {
-                    failureReason = "target is a symbolic link, reparse point, or device";
-                    return false;
-                }
-            }
-            else if (File.Exists(longPath))
-            {
-                failureReason = "target is not a directory";
-                return false;
-            }
-
-            return true;
-        }
-        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException or UnauthorizedAccessException or PathTooLongException)
-        {
-            failureReason = "target path is invalid";
-            return false;
-        }
-    }
-
-    private static string NormalizeCleanupBoundaryPath(string path)
-    {
-        var fullPath = Path.GetFullPath(path);
-        var root = Path.GetPathRoot(fullPath);
-        if (!string.IsNullOrEmpty(root) && string.Equals(fullPath, root, StringComparison.Ordinal))
-            return fullPath;
-        return fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var options = new DirectoryCleanupBoundaryOptions(
+            UpgradeInstallerDirectoryPrefix,
+            "target is outside the expected cleanup root",
+            "target name does not match the expected upgrade temporary-directory prefix",
+            "target is a symbolic link, reparse point, or device");
+        return FileSystemBoundary.TryValidateDirectoryCleanupTarget(
+            path,
+            Path.GetTempPath(),
+            options,
+            out fullPath,
+            out failureReason);
     }
 
     private static UpgradeJsonResult CreateUpgradeJsonResult(

--- a/src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.Discovery.cs
+++ b/src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.Discovery.cs
@@ -1,3 +1,4 @@
+using CodeIndex.Cli;
 using CodeIndex.Diagnostics;
 
 namespace CodeIndex.Indexer.Extensibility;
@@ -254,8 +255,7 @@ public static partial class ExtractorPluginRegistry
         try
         {
             var info = new DirectoryInfo(directory);
-            return (info.Attributes & FileAttributes.ReparsePoint) != 0
-                   || !string.IsNullOrEmpty(info.LinkTarget);
+            return FileSystemBoundary.IsSymlinkOrReparsePoint(info);
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
         {

--- a/src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.PatternConfig.cs
+++ b/src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.PatternConfig.cs
@@ -1,6 +1,7 @@
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
+using CodeIndex.Cli;
 using CodeIndex.Diagnostics;
 using Microsoft.Win32.SafeHandles;
 using Regex = CodeIndex.Indexer.BoundedRegex;
@@ -169,7 +170,7 @@ public static partial class ExtractorPluginRegistry
             return null;
         }
 
-        if ((attributes & FileAttributes.ReparsePoint) != 0 || !string.IsNullOrEmpty(fileInfo.LinkTarget))
+        if (FileSystemBoundary.IsSymlinkOrReparsePoint(fileInfo))
         {
             ReportPatternConfigRejected(path, "symbolic links and reparse points are not supported");
             return null;

--- a/src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.PluginLoading.cs
+++ b/src/CodeIndex/Indexer/Extensibility/ExtractorPluginRegistry.PluginLoading.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using CodeIndex.Cli;
 
 namespace CodeIndex.Indexer.Extensibility;
 
@@ -165,6 +166,19 @@ public static partial class ExtractorPluginRegistry
                 "Plugin assembly skipped: path is a directory.",
                 countsAsSkippedFile: true,
                 category: "plugin_path_is_directory");
+            return false;
+        }
+
+        if (FileSystemBoundary.IsSymlinkOrReparsePoint(fileInfo))
+        {
+            RecordDiagnostic(
+                "plugin",
+                fullPath,
+                typeName: null,
+                severity: "error",
+                "Plugin assembly skipped: symbolic links and reparse points are not supported.",
+                countsAsSkippedFile: true,
+                category: "plugin_reparse_point");
             return false;
         }
 

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -1447,52 +1447,29 @@ public class FileIndexer
     // skip 対象属性扱いにする。
     private static bool HasSkippedAttributes(string path)
     {
-        try
+        return FileSystemBoundary.TryGetAttributes(path, out var attributes) switch
         {
-            var attributes = File.GetAttributes(LongPath.EnsureWindowsPrefix(path));
-            return HasSkippedAttributes(attributes);
-        }
-        catch (FileNotFoundException)
-        {
-            return true;
-        }
-        catch (DirectoryNotFoundException)
-        {
-            return true;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return false;
-        }
-        catch (IOException)
-        {
-            return false;
-        }
+            FileSystemBoundaryProbeStatus.Found => HasSkippedAttributes(attributes),
+            FileSystemBoundaryProbeStatus.Missing => true,
+            _ => false,
+        };
     }
 
     private static bool IsReparsePoint(string path)
     {
-        try
-        {
-            return (File.GetAttributes(LongPath.EnsureWindowsPrefix(path)) & FileAttributes.ReparsePoint) != 0;
-        }
-        catch (FileNotFoundException)
-        {
-            return false;
-        }
-        catch (DirectoryNotFoundException)
-        {
-            return false;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return false;
-        }
-        catch (IOException)
-        {
-            return false;
-        }
+        return FileSystemBoundary.TryGetAttributes(path, out var attributes) == FileSystemBoundaryProbeStatus.Found
+            && FileSystemBoundary.IsSymlinkOrReparsePoint(attributes);
     }
+
+    private static FileProbeStatus ToFileProbeStatus(FileSystemBoundaryProbeStatus status)
+        => status switch
+        {
+            FileSystemBoundaryProbeStatus.Missing => FileProbeStatus.Missing,
+            FileSystemBoundaryProbeStatus.PermissionDenied or FileSystemBoundaryProbeStatus.IoError => OperatingSystem.IsWindows()
+                ? FileProbeStatus.Supported
+                : FileProbeStatus.ProbeFailed,
+            _ => FileProbeStatus.ProbeFailed,
+        };
 
     private bool ShouldSkipDirectoryLink(string subDir, List<ScanError> errors, HashSet<string> danglingSymlinks)
     {
@@ -1612,33 +1589,11 @@ public class FileIndexer
         // File.GetAttributes は .NET 上で lstat 相当（symlink target を辿らない）なので、
         // Unix の stat() が target を辿る前に symlink policy を適用できる。Windows では
         // broad scan で OS 管理 cache を索引しないよう Hidden/System も引き続き弾く。
-        FileAttributes attributes;
-        try
-        {
-            attributes = File.GetAttributes(LongPath.EnsureWindowsPrefix(filePath));
-        }
-        catch (FileNotFoundException)
-        {
-            return FileProbeStatus.Missing;
-        }
-        catch (DirectoryNotFoundException)
-        {
-            return FileProbeStatus.Missing;
-        }
-        catch (UnauthorizedAccessException)
-        {
-            return OperatingSystem.IsWindows()
-                ? FileProbeStatus.Supported
-                : FileProbeStatus.ProbeFailed;
-        }
-        catch (IOException)
-        {
-            return OperatingSystem.IsWindows()
-                ? FileProbeStatus.Supported
-                : FileProbeStatus.ProbeFailed;
-        }
+        var probeStatus = FileSystemBoundary.TryGetAttributes(filePath, out var attributes);
+        if (probeStatus != FileSystemBoundaryProbeStatus.Found)
+            return ToFileProbeStatus(probeStatus);
 
-        if ((attributes & FileAttributes.ReparsePoint) != 0)
+        if (FileSystemBoundary.IsSymlinkOrReparsePoint(attributes))
             return GetFileSymlinkIndexability(filePath, symlinkPolicy, projectRoot);
 
         if (HasSkippedAttributes(attributes))

--- a/src/CodeIndex/Mcp/McpPathBoundary.cs
+++ b/src/CodeIndex/Mcp/McpPathBoundary.cs
@@ -32,10 +32,10 @@ internal static class McpPathBoundary
 
     internal static bool IsPathWithinDirectory(string parentPath, string childPath)
     {
-        var parent = NormalizeDirectoryBoundaryPath(ResolveExistingDirectoryPath(parentPath));
-        var child = NormalizeDirectoryBoundaryPath(ResolveExistingDirectoryPath(childPath));
+        var parent = ResolveExistingDirectoryPath(parentPath);
+        var child = ResolveExistingDirectoryPath(childPath);
 
-        return PathCasing.IsPathEqualOrParent(parent, child);
+        return FileSystemBoundary.IsSameOrDescendant(parent, child);
     }
 
     internal static string? TryResolveRootPath(string? root)
@@ -47,14 +47,14 @@ internal static class McpPathBoundary
             if (!string.Equals(uri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase))
                 return null;
             return PathUriNormalizer.TryNormalizeFileUriPath(root, out var normalized, out _)
-                ? NormalizeDirectoryBoundaryPath(normalized)
+                ? FileSystemBoundary.NormalizeDirectoryPath(normalized)
                 : null;
         }
         try
         {
-            return NormalizeDirectoryBoundaryPath(root);
+            return FileSystemBoundary.NormalizeDirectoryPath(root);
         }
-        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException)
+        catch (Exception ex) when (ex is ArgumentException or NotSupportedException or PathTooLongException or CodeIndexException)
         {
             return null;
         }
@@ -98,14 +98,5 @@ internal static class McpPathBoundary
         }
 
         return Path.GetFullPath(current);
-    }
-
-    private static string NormalizeDirectoryBoundaryPath(string path)
-    {
-        var fullPath = Path.GetFullPath(path);
-        var root = Path.GetPathRoot(fullPath);
-        if (!string.IsNullOrEmpty(root) && string.Equals(fullPath, root, StringComparison.Ordinal))
-            return fullPath;
-        return fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
     }
 }

--- a/tests/CodeIndex.Tests/ExtractorPluginRegistryTests.cs
+++ b/tests/CodeIndex.Tests/ExtractorPluginRegistryTests.cs
@@ -209,6 +209,45 @@ public class ExtractorPluginRegistryTests
     }
 
     [Fact]
+    public void LoadPlugin_RejectsSymlinkAssemblyCandidate_Issue3970()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = TestProjectHelper.CreateTempProject("extractor_registry_plugin_symlink_3970");
+        lock (TestConsoleLock.Gate)
+        {
+            var target = Path.Combine(projectRoot, "target.dll");
+            var link = Path.Combine(projectRoot, "link.dll");
+            try
+            {
+                ExtractorPluginRegistry.ResetForTests();
+                File.WriteAllText(target, "not a real dll");
+                File.CreateSymbolicLink(link, target);
+
+                ExtractorPluginRegistry.LoadPluginForTests(link);
+                var status = ExtractorPluginRegistry.GetStatusSnapshot();
+
+                Assert.Equal(0, status.PluginAssemblyCount);
+                Assert.Equal(1, status.SkippedFileCount);
+                var diagnostic = Assert.Single(status.Diagnostics!);
+                Assert.Equal("plugin", diagnostic.Kind);
+                Assert.Equal("error", diagnostic.Severity);
+                Assert.Equal("plugin_reparse_point", diagnostic.Category);
+                Assert.Equal("link.dll", diagnostic.Path);
+                Assert.Contains("symbolic links and reparse points", diagnostic.Message, StringComparison.Ordinal);
+            }
+            finally
+            {
+                ExtractorPluginRegistry.ResetForTests();
+                if (File.Exists(link))
+                    File.Delete(link);
+                TestProjectHelper.DeleteDirectory(projectRoot);
+            }
+        }
+    }
+
+    [Fact]
     public void LoadPlugin_ReportsSanitizedAssemblyLoadCategory_3414()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("extractor_registry_plugin_load_category");

--- a/tests/CodeIndex.Tests/FileSystemBoundaryTests.cs
+++ b/tests/CodeIndex.Tests/FileSystemBoundaryTests.cs
@@ -1,0 +1,113 @@
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+public class FileSystemBoundaryTests
+{
+    [Fact]
+    public void TryValidateDirectoryCleanupTarget_RejectsSiblingWithSharedPrefix_Issue3970()
+    {
+        var parent = Path.Combine(Path.GetTempPath(), $"cdidx-boundary-{Guid.NewGuid():N}");
+        var sibling = parent + "-sibling";
+        var target = Path.Combine(sibling, "cleanup-target");
+
+        var valid = FileSystemBoundary.TryValidateDirectoryCleanupTarget(
+            target,
+            parent,
+            CreateOptions(),
+            out _,
+            out var failureReason);
+
+        Assert.False(valid);
+        Assert.Equal("outside", failureReason);
+    }
+
+    [Fact]
+    public void TryValidateDirectoryCleanupTarget_UsesPathCasingProbe_Issue3970()
+    {
+        var previousProbe = PathCasing.IgnoreCaseProbeForTesting;
+        try
+        {
+            PathCasing.ResetCacheForTests();
+            PathCasing.IgnoreCaseProbeForTesting = _ => true;
+            var root = Path.Combine(Path.GetTempPath(), $"CDIDX-BOUNDARY-{Guid.NewGuid():N}");
+            var target = Path.Combine(root.ToLowerInvariant(), "cleanup-target");
+
+            var valid = FileSystemBoundary.TryValidateDirectoryCleanupTarget(
+                target,
+                root,
+                CreateOptions(),
+                out _,
+                out var failureReason);
+
+            Assert.True(valid, failureReason);
+        }
+        finally
+        {
+            PathCasing.IgnoreCaseProbeForTesting = previousProbe;
+            PathCasing.ResetCacheForTests();
+        }
+    }
+
+    [Fact]
+    public void TryValidateDirectoryCleanupTarget_RejectsSymlinkDirectory_Issue3970()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var safeRoot = Path.Combine(Path.GetTempPath(), $"cdidx_boundary_safe_{Guid.NewGuid():N}");
+        var externalRoot = Path.Combine(Path.GetTempPath(), $"cdidx_boundary_external_{Guid.NewGuid():N}");
+        var link = Path.Combine(safeRoot, "cleanup-link");
+        try
+        {
+            Directory.CreateDirectory(safeRoot);
+            Directory.CreateDirectory(externalRoot);
+            Directory.CreateSymbolicLink(link, externalRoot);
+
+            var valid = FileSystemBoundary.TryValidateDirectoryCleanupTarget(
+                link,
+                safeRoot,
+                CreateOptions(),
+                out _,
+                out var failureReason);
+
+            Assert.False(valid);
+            Assert.Equal("unsafe", failureReason);
+        }
+        finally
+        {
+            DeletePathOrSymlink(link);
+            TestProjectHelper.DeleteDirectory(safeRoot);
+            TestProjectHelper.DeleteDirectory(externalRoot);
+        }
+    }
+
+    private static DirectoryCleanupBoundaryOptions CreateOptions()
+        => new(
+            "cleanup-",
+            "outside",
+            "prefix",
+            "unsafe");
+
+    private static void DeletePathOrSymlink(string path)
+    {
+        try
+        {
+            var attributes = File.GetAttributes(path);
+            if ((attributes & FileAttributes.ReparsePoint) != 0)
+            {
+                File.Delete(path);
+                return;
+            }
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            return;
+        }
+
+        if (Directory.Exists(path))
+            Directory.Delete(path, recursive: true);
+        else if (File.Exists(path))
+            File.Delete(path);
+    }
+}


### PR DESCRIPTION
## Summary
- Add a shared `FileSystemBoundary` helper for path normalization, descendant checks, attribute probing, and symlink/reparse-point detection.
- Route sensitive-state, private log, cleanup target, scanner, plugin discovery/config/loading, import/export temp cleanup, and MCP boundary checks through the shared helper.
- Add regression coverage for cleanup boundary checks and plugin assembly symlink rejection.
- Add changelog fragment `changelog.d/unreleased/3970.fixed.md`.

## Validation
- `dotnet build CodeIndex.sln -c Debug -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false --filter FullyQualifiedName~FileSystemBoundaryTests`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false --filter FullyQualifiedName~TryValidateUpgradeInstallerDirectoryCleanupTarget`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false --filter FullyQualifiedName~ExtractorPluginRegistryTests`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false --filter FullyQualifiedName~ScanFiles_SkipsDirectorySymlinkPointingAtAncestor`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false --filter FullyQualifiedName~ToolsCall_Index_SymlinkEscapingCurrentDirectory_ReturnsError`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -p:UseSharedCompilation=false --filter FullyQualifiedName~Extract_ConfiguredPatternYaml_RejectsSymlinkedConfigWithDiagnostic`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `make lint`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Review
- Adversarial review result: No blocking/actionable issues found.
- `codex exec review --base origin/main` could not complete in this environment: the default model run hit usage limits, and the `gpt-5.3-codex-spark` retry exited 143 after repeated internal tool execution failures.

Fixes #3970