### PR TITLE
Fix cancellation handling across index and MCP paths

### DIFF
--- a/changelog.d/unreleased/3928.fixed.md
+++ b/changelog.d/unreleased/3928.fixed.md
@@ -1,0 +1,21 @@
+---
+category: fixed
+issues:
+  - 3928
+affected:
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Maintenance.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - src/CodeIndex/Mcp/HttpMcpTransport.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+---
+
+## English
+
+- **Cancellation now propagates through more long-running paths (#3928)** — index and backfill database writes, MCP HTTP response writes, and export/import archive copies now honor the caller cancellation token so interrupted operations stop earlier instead of continuing on non-cancellable paths.
+
+## 日本語
+
+- **長時間実行される経路で cancellation がより伝播するようになりました (#3928)** — インデックスと backfill のDB書き込み、MCP HTTP応答書き込み、export/importアーカイブコピーが呼び出し元の cancellation token を尊重し、中断後もキャンセル不能な経路で処理が続きにくいようにしました。

--- a/changelog.d/unreleased/3946.fixed.md
+++ b/changelog.d/unreleased/3946.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3946
+affected:
+  - src/CodeIndex/Mcp/AuditLogSink.cs
+  - tests/CodeIndex.Tests/AuditLogSinkTests.cs
+---
+
+## English
+
+- **Audit log idle waits now accept cancellation (#3946)** — MCP audit-log drain waits use the existing completion signal with a cancellation-aware overload so shutdown and tests can stop waiting without polling or wall-clock sleep loops.
+
+## 日本語
+
+- **監査ログの idle 待機がキャンセルを受け取れるようになりました (#3946)** — MCP 監査ログの drain 待機は既存の完了シグナルに cancellation-aware overload を追加し、shutdown やテストが polling や wall-clock sleep loop なしで待機を止められるようになりました。

--- a/changelog.d/unreleased/3952.fixed.md
+++ b/changelog.d/unreleased/3952.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3952
+affected:
+  - src/CodeIndex/Database/DbConnectionFactory.cs
+  - tests/CodeIndex.Tests/DatabaseTests.cs
+---
+
+## English
+
+- **SQLite retry backoff no longer uses `Thread.Sleep` (#3952)** — transient DB-open retries now wait through a bounded wait primitive that keeps cancellation behavior consistent and removes the remaining production blocking sleep.
+
+## 日本語
+
+- **SQLite retry backoff が `Thread.Sleep` を使わなくなりました (#3952)** — 一時的な DB open retry は bounded wait primitive で待機するようになり、キャンセル挙動を揃えつつ production に残っていた blocking sleep を除去しました。

--- a/changelog.d/unreleased/3969.fixed.md
+++ b/changelog.d/unreleased/3969.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3969
+affected:
+  - src/CodeIndex/Cli/GitHelper.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/GitHelperTests.cs
+---
+
+## English
+
+- **Long-running process waits now separate cancellation from timeouts (#3969)** — git process waits pass the caller token into `WaitForExitAsync`, while the MCP HTTP shutdown boundary now uses a bounded dispose wait with diagnostics instead of an unbounded synchronous wait.
+
+## 日本語
+
+- **長時間の process wait で cancellation と timeout を分離しました (#3969)** — git process wait は呼び出し元 token を `WaitForExitAsync` に渡し、MCP HTTP の shutdown 境界は無期限の同期待ちではなく診断付きの bounded dispose wait を使うようになりました。

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -1212,9 +1212,6 @@ internal static class ExportImportCommandRunner
         IProgress<long>? progress = null)
         => CopyToWithLimit(source, target, maxBytes, DatabaseEntryName, cancellationToken, progress);
 
-    private static long CopyToWithLimit(Stream source, Stream target, long maxBytes, string entryName)
-        => CopyToWithLimit(source, target, maxBytes, entryName, CancellationToken.None);
-
     private static long CopyToWithLimit(
         Stream source,
         Stream target,

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -1153,16 +1153,24 @@ public static class GitHelper
         TimeSpan timeout,
         CancellationToken cancellationToken)
     {
-        var exitTask = process.WaitForExitAsync(CancellationToken.None);
-        var delayTask = Task.Delay(NormalizePositiveTimeout(timeout), cancellationToken);
-        var completed = await Task.WhenAny(exitTask, delayTask).ConfigureAwait(false);
+        var exitTask = process.WaitForExitAsync(cancellationToken);
+        var timeoutTask = Task.Delay(NormalizePositiveTimeout(timeout), CancellationToken.None);
+        var cancellationTask = Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        var completed = await Task.WhenAny(exitTask, timeoutTask, cancellationTask).ConfigureAwait(false);
         if (completed == exitTask)
         {
-            await exitTask.ConfigureAwait(false);
-            return new GitExitWaitResult(true, false);
+            try
+            {
+                await exitTask.ConfigureAwait(false);
+                return new GitExitWaitResult(true, false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new GitExitWaitResult(false, true);
+            }
         }
 
-        return new GitExitWaitResult(false, cancellationToken.IsCancellationRequested);
+        return new GitExitWaitResult(false, completed == cancellationTask || cancellationToken.IsCancellationRequested);
     }
 
     private static string ReadCaptured(StringBuilder builder)

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -864,7 +864,7 @@ public static partial class IndexCommandRunner
         // full-scan の書き込み全体を outer transaction に入れ、中断時に batch marker /
         // readiness clear / purge / per-file write をまとめて rollback する。
         ThrowIfFullScanCancelled(0, files.Count);
-        using var fullScanTxn = writer.BeginTransaction();
+        using var fullScanTxn = writer.BeginTransaction(cancellationToken, "full scan write phase");
         writer.MarkBatchInProgress();
         writer.ClearReadyFlags();
         writer.ClearHotspotFamilyReady();
@@ -1395,7 +1395,7 @@ public static partial class IndexCommandRunner
 
                         if (writer.HasFileAtPath(currentJsonIndexFile))
                         {
-                            using var deleteTxn = writer.BeginTransaction();
+                            using var deleteTxn = writer.BeginTransaction(cancellationToken, "full scan delete skipped file");
                             if (writer.DeleteFileByPath(currentJsonIndexFile))
                             {
                                 WriteProjectRootOnce();
@@ -1483,7 +1483,7 @@ public static partial class IndexCommandRunner
                         continue;
                     }
 
-                    using var txn = writer.BeginTransaction();
+                    using var txn = writer.BeginTransaction(cancellationToken, "full scan file");
                     if (!startedWithNoIndexedFiles)
                         writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
                     var fileId = writer.UpsertFile(record, cleanExistingData: !startedWithNoIndexedFiles);
@@ -1497,9 +1497,9 @@ public static partial class IndexCommandRunner
                     var generatedSuppressionIssue = indexer.BuildGeneratedCodeExtractionSkippedIssue(record.Path);
                     if (generatedSuppressionIssue != null)
                     {
-                        writer.InsertChunks(chunks);
-                        writer.InsertSymbols([]);
-                        writer.InsertReferences([]);
+                        writer.InsertChunks(chunks, cancellationToken);
+                        writer.InsertSymbols([], cancellationToken);
+                        writer.InsertReferences([], cancellationToken);
                         var generatedIssues = AppendIssueIfMissing(
                             item.Issues ?? ValidateWorkItemContent(item, record),
                             generatedSuppressionIssue);
@@ -1544,8 +1544,8 @@ public static partial class IndexCommandRunner
                         IReadOnlyList<FileIssue> capIssues = symbolRegexTimeoutIssue == null
                             ? [issue]
                             : AppendIssue([symbolRegexTimeoutIssue], issue);
-                        writer.InsertSymbols([]);
-                        writer.InsertReferences([]);
+                        writer.InsertSymbols([], cancellationToken);
+                        writer.InsertReferences([], cancellationToken);
                         writer.InsertIssues(fileId, capIssues);
                         if (options.Verbose)
                             WriteIndexVerboseStatus($"  [SKIP] {record.Path} ({issue.Message})");
@@ -1574,8 +1574,8 @@ public static partial class IndexCommandRunner
                         IReadOnlyList<FileIssue> capIssues = symbolRegexTimeoutIssue == null
                             ? [issue]
                             : AppendIssue([symbolRegexTimeoutIssue], issue);
-                        writer.InsertSymbols([]);
-                        writer.InsertReferences([]);
+                        writer.InsertSymbols([], cancellationToken);
+                        writer.InsertReferences([], cancellationToken);
                         writer.InsertIssues(fileId, capIssues);
                         if (options.Verbose)
                             WriteIndexVerboseStatus($"  [SKIP] {record.Path} ({issue.Message})");
@@ -1591,9 +1591,9 @@ public static partial class IndexCommandRunner
                         currentJsonIndexFile = null;
                         continue;
                     }
-                    writer.InsertChunks(chunks);
+                    writer.InsertChunks(chunks, cancellationToken);
                     FileIndexer.ValidateSymbolLineRanges(record, symbols);
-                    writer.InsertSymbols(symbols);
+                    writer.InsertSymbols(symbols, cancellationToken);
                     if (symbolRegexTimeoutIssue != null)
                     {
                         var baseIssues = item.Issues ?? ValidateWorkItemContent(item, record);
@@ -1651,7 +1651,7 @@ public static partial class IndexCommandRunner
                             item = item with { Issues = AppendIssue(baseIssues, issue) };
                         }
                     }
-                    writer.InsertReferences(references, refreshMutualRecursionFlags: false);
+                    writer.InsertReferences(references, refreshMutualRecursionFlags: false, cancellationToken);
                     if (references.Count > 0)
                         mutualRecursionRefreshNeeded = true;
                     currentJsonIndexFile = FormatIndexPhasePath(record.Path, "validating");

--- a/src/CodeIndex/Cli/IndexCommandRunner.Maintenance.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Maintenance.cs
@@ -205,7 +205,7 @@ public static partial class IndexCommandRunner
                 // Row rewrites commit before the final FoldReady stamp so interrupted
                 // backfills can resume from the remaining rows.
                 // 行更新は FoldReady stamp より前に永続化し、中断後に残り行から再開できるようにする。
-                using var transaction = writer.BeginTransaction();
+                using var transaction = writer.BeginTransaction(backfillCancellation.Token, "backfill fold readiness stamp");
                 verified = writer.MarkFoldReady();
                 if (!verified)
                 {

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -309,7 +309,7 @@ public static partial class IndexCommandRunner
         {
             DemoteReadinessOnce();
 
-            using var purgeTxn = writer.BeginTransaction();
+            using var purgeTxn = writer.BeginTransaction(cancellationToken, "update purge unsupported references");
             purgedRefs = writer.PurgeUnsupportedReferences(supportedGraphLanguages);
             if (purgedRefs > 0)
                 purgeTxn.Commit();
@@ -348,7 +348,7 @@ public static partial class IndexCommandRunner
                         }
 
                         DemoteReadinessOnce();
-                        using var deleteTxn = writer.BeginTransaction();
+                        using var deleteTxn = writer.BeginTransaction(cancellationToken, "update delete missing target");
                         if (writer.DeleteFileByPath(dbPath))
                         {
                             WriteProjectRootOnce();
@@ -394,7 +394,7 @@ public static partial class IndexCommandRunner
                         }
 
                         DemoteReadinessOnce();
-                        using var deleteTxn = writer.BeginTransaction();
+                        using var deleteTxn = writer.BeginTransaction(cancellationToken, "update delete skipped path");
                         if (writer.DeleteFileByPath(dbPath))
                         {
                             WriteProjectRootOnce();
@@ -438,7 +438,7 @@ public static partial class IndexCommandRunner
                         if (writer.HasFileAtPath(dbPath))
                         {
                             DemoteReadinessOnce();
-                            using var deleteTxn = writer.BeginTransaction();
+                            using var deleteTxn = writer.BeginTransaction(cancellationToken, "update delete missing during probe");
                             if (writer.DeleteFileByPath(dbPath))
                             {
                                 WriteProjectRootOnce();
@@ -476,7 +476,7 @@ public static partial class IndexCommandRunner
                     {
                         if (!writer.HasFileAtPath(dbPath))
                         {
-                            using var purgeTxn = writer.BeginTransaction();
+                            using var purgeTxn = writer.BeginTransaction(cancellationToken, "update purge unsupported renamed target");
                             var purged = projectRootWritten
                                 ? writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, dbPath)
                                 : 0;
@@ -508,7 +508,7 @@ public static partial class IndexCommandRunner
                         }
 
                         DemoteReadinessOnce();
-                        using var deleteTxn = writer.BeginTransaction();
+                        using var deleteTxn = writer.BeginTransaction(cancellationToken, "update delete unsupported target");
                         if (writer.DeleteFileByPath(dbPath))
                         {
                             WriteProjectRootOnce();
@@ -640,7 +640,7 @@ public static partial class IndexCommandRunner
                     }
                     if (existingId != null)
                     {
-                        using var purgeTxn = writer.BeginTransaction();
+                        using var purgeTxn = writer.BeginTransaction(cancellationToken, "update purge unchanged stale paths");
                         var purged = writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum)
                             + (projectRootWritten
                                 ? writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, record.Path)
@@ -668,7 +668,7 @@ public static partial class IndexCommandRunner
                     DemoteReadinessOnce();
                     writer.MarkBatchInProgress();
                     fileBatchMarked = true;
-                    using var txn = writer.BeginTransaction();
+                    using var txn = writer.BeginTransaction(cancellationToken, "update file");
                     writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
                     if (projectRootWritten)
                         writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, record.Path);
@@ -679,9 +679,9 @@ public static partial class IndexCommandRunner
                     var generatedSuppressionIssue = indexer.BuildGeneratedCodeExtractionSkippedIssue(record.Path);
                     if (generatedSuppressionIssue != null)
                     {
-                        writer.InsertChunks(chunks);
-                        writer.InsertSymbols([]);
-                        writer.InsertReferences([]);
+                        writer.InsertChunks(chunks, cancellationToken);
+                        writer.InsertSymbols([], cancellationToken);
+                        writer.InsertReferences([], cancellationToken);
                         currentUpdatePath = FormatIndexPhasePath(relPath, "validating");
                         var generatedIssues = AppendIssueIfMissing(
                             FileIndexer.ValidateContent(record.Path, rawBytes, content, record.Lang, loaded.Inspection, loaded.HasOversizeLine),
@@ -717,8 +717,8 @@ public static partial class IndexCommandRunner
                         IReadOnlyList<FileIssue> capIssues = symbolRegexTimeoutIssue == null
                             ? [issue]
                             : AppendIssue([symbolRegexTimeoutIssue], issue);
-                        writer.InsertSymbols([]);
-                        writer.InsertReferences([]);
+                        writer.InsertSymbols([], cancellationToken);
+                        writer.InsertReferences([], cancellationToken);
                         writer.InsertIssues(fileId, capIssues);
                         writer.ClearBatchInProgress();
                         txn.Commit();
@@ -738,8 +738,8 @@ public static partial class IndexCommandRunner
                         IReadOnlyList<FileIssue> capIssues = symbolRegexTimeoutIssue == null
                             ? [issue]
                             : AppendIssue([symbolRegexTimeoutIssue], issue);
-                        writer.InsertSymbols([]);
-                        writer.InsertReferences([]);
+                        writer.InsertSymbols([], cancellationToken);
+                        writer.InsertReferences([], cancellationToken);
                         writer.InsertIssues(fileId, capIssues);
                         writer.ClearBatchInProgress();
                         txn.Commit();
@@ -749,9 +749,9 @@ public static partial class IndexCommandRunner
                         WriteUpdateVerboseStatus($"  [SKIP] {relPath} ({issue.Message})");
                         continue;
                     }
-                    writer.InsertChunks(chunks);
+                    writer.InsertChunks(chunks, cancellationToken);
                     FileIndexer.ValidateSymbolLineRanges(record, symbols);
-                    writer.InsertSymbols(symbols);
+                    writer.InsertSymbols(symbols, cancellationToken);
                     currentUpdatePath = FormatIndexPhasePath(relPath, "references");
                     List<ReferenceRecord> references;
                     FileIssue? referenceRegexTimeoutIssue;
@@ -778,7 +778,7 @@ public static partial class IndexCommandRunner
                         referenceCapIssue = BuildReferenceCountExceededIssue(record.Path, references.Count, options.MaxReferencesPerFile);
                         references = [];
                     }
-                    writer.InsertReferences(references);
+                    writer.InsertReferences(references, cancellationToken);
                     // Validate content for encoding issues / エンコーディング問題を検証
                     currentUpdatePath = FormatIndexPhasePath(relPath, "validating");
                     IReadOnlyList<FileIssue> issues = FileIndexer.ValidateContent(record.Path, rawBytes, content, record.Lang, loaded.Inspection, loaded.HasOversizeLine);
@@ -822,16 +822,16 @@ public static partial class IndexCommandRunner
 
                         DemoteReadinessOnce();
                         writer.MarkBatchInProgress();
-                        using var txn = writer.BeginTransaction();
+                        using var txn = writer.BeginTransaction(cancellationToken, "update skipped binary");
                         var skippedRecord = indexer.BuildSkippedFileRecord(absPath);
                         writer.PurgeStaleFilesSharingChecksum(projectRoot, skippedRecord.Path, skippedRecord.Checksum);
                         if (projectRootWritten)
                             writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, skippedRecord.Path);
                         WriteProjectRootOnce();
                         var fileId = writer.UpsertFile(skippedRecord);
-                        writer.InsertChunks([]);
-                        writer.InsertSymbols([]);
-                        writer.InsertReferences([]);
+                        writer.InsertChunks([], cancellationToken);
+                        writer.InsertSymbols([], cancellationToken);
+                        writer.InsertReferences([], cancellationToken);
                         writer.InsertIssues(fileId, [BuildNullByteIssue(binaryFile)]);
                         writer.ClearBatchInProgress();
                         txn.Commit();
@@ -848,16 +848,16 @@ public static partial class IndexCommandRunner
 
                         DemoteReadinessOnce();
                         writer.MarkBatchInProgress();
-                        using var txn = writer.BeginTransaction();
+                        using var txn = writer.BeginTransaction(cancellationToken, "update skipped oversized file");
                         var skippedRecord = indexer.BuildSkippedFileRecord(absPath);
                         writer.PurgeStaleFilesSharingChecksum(projectRoot, skippedRecord.Path, skippedRecord.Checksum);
                         if (projectRootWritten)
                             writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, skippedRecord.Path);
                         WriteProjectRootOnce();
                         var fileId = writer.UpsertFile(skippedRecord);
-                        writer.InsertChunks([]);
-                        writer.InsertSymbols([]);
-                        writer.InsertReferences([]);
+                        writer.InsertChunks([], cancellationToken);
+                        writer.InsertSymbols([], cancellationToken);
+                        writer.InsertReferences([], cancellationToken);
                         writer.InsertIssues(fileId,
                         [
                             new FileIssue
@@ -894,7 +894,7 @@ public static partial class IndexCommandRunner
                         if (writer.HasFileAtPath(dbPath))
                         {
                             DemoteReadinessOnce();
-                            using var deleteTxn = writer.BeginTransaction();
+                            using var deleteTxn = writer.BeginTransaction(cancellationToken, "update delete missing during write");
                             if (writer.DeleteFileByPath(dbPath))
                             {
                                 WriteProjectRootOnce();
@@ -974,7 +974,7 @@ public static partial class IndexCommandRunner
         if (readinessDemoted && errors == 0)
         {
             writer.MarkBatchInProgress();
-            using var readinessTxn = writer.BeginTransaction();
+            using var readinessTxn = writer.BeginTransaction(cancellationToken, "update readiness restamp");
             // Restore each readiness bit independently based on what the DB carried BEFORE
             // ClearReadyFlags wiped them. A pre-#86 DB (user_version=3, i.e. Graph+Issues but
             // no Fold) must keep Graph+Issues after a successful partial update, even though
@@ -1029,7 +1029,7 @@ public static partial class IndexCommandRunner
             // boundary. If the process dies after SetMeta but before commit, SQLite rolls back
             // the version stamp along with any maintenance rows, so readers never see a partial
             // family_key/container_qualified_name state as authoritative (#1488).
-            using (var hotspotFamilyTxn = writer.BeginTransaction())
+            using (var hotspotFamilyTxn = writer.BeginTransaction(cancellationToken, "update hotspot-family restamp"))
             {
                 writer.RebuildTypeScriptAugmentationReferences(projectRoot);
                 RestampHotspotFamilyTrustForUpdate(

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -48,6 +48,7 @@ internal static partial class ProgramRunner
     };
     private static readonly TimeSpan InstallerRunTimeout = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan InstallerKillWaitTimeout = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan McpHttpDisposeTimeout = TimeSpan.FromSeconds(5);
     private static readonly HashSet<string> NonLogGlobalOptionNames =
         CliFlagSchema.GetTopLevelGlobalOptionNames(includeLogOptions: false);
     private static readonly HashSet<string> TopLevelValueOptionNames =
@@ -2819,10 +2820,35 @@ internal static partial class ProgramRunner
         }
         finally
         {
-            transport.DisposeAsync().AsTask().GetAwaiter().GetResult();
+            DisposeMcpHttpTransport(transport);
         }
 
         return CommandExitCodes.Success;
+    }
+
+    private static void DisposeMcpHttpTransport(HttpMcpTransport transport)
+    {
+        try
+        {
+            var disposeTask = transport.DisposeAsync().AsTask();
+            if (disposeTask.Wait(McpHttpDisposeTimeout))
+                return;
+
+            var message = $"MCP HTTP transport disposal did not finish within {FormatDuration(McpHttpDisposeTimeout)}.";
+            GlobalToolLog.Error("mcp_http_transport_dispose_timeout " + message);
+            CommandErrorWriter.WriteStderr("Warning: " + message);
+        }
+        catch (AggregateException ex)
+        {
+            var inner = ex.Flatten().InnerExceptions.FirstOrDefault() ?? ex;
+            GlobalToolLog.Error("mcp_http_transport_dispose_failed " + GlobalToolLog.FormatExceptionChain(inner));
+            CommandErrorWriter.WriteStderr($"Warning: MCP HTTP transport disposal failed ({inner.GetType().Name}: {inner.Message}).");
+        }
+        catch (Exception ex)
+        {
+            GlobalToolLog.Error("mcp_http_transport_dispose_failed " + GlobalToolLog.FormatExceptionChain(ex));
+            CommandErrorWriter.WriteStderr($"Warning: MCP HTTP transport disposal failed ({ex.GetType().Name}: {ex.Message}).");
+        }
     }
 
     private static void LogHttpMcpRequest(HttpMcpTransport.HttpRequestLogRecord record)

--- a/src/CodeIndex/Database/DbConnectionFactory.cs
+++ b/src/CodeIndex/Database/DbConnectionFactory.cs
@@ -203,14 +203,24 @@ internal static class DbConnectionFactory
             return;
         }
 
-        if (!cancellationToken.CanBeCanceled)
+        WaitForRetryDelay(milliseconds, cancellationToken);
+    }
+
+    private static void WaitForRetryDelay(int milliseconds, CancellationToken cancellationToken)
+    {
+        if (milliseconds <= 0)
         {
-            System.Threading.Thread.Sleep(milliseconds);
+            cancellationToken.ThrowIfCancellationRequested();
             return;
         }
 
-        if (cancellationToken.WaitHandle.WaitOne(milliseconds))
-            cancellationToken.ThrowIfCancellationRequested();
-    }
+        using var delay = new ManualResetEventSlim(initialState: false);
+        if (cancellationToken.CanBeCanceled)
+        {
+            delay.Wait(milliseconds, cancellationToken);
+            return;
+        }
 
+        delay.Wait(milliseconds);
+    }
 }

--- a/src/CodeIndex/Mcp/AuditLogSink.cs
+++ b/src/CodeIndex/Mcp/AuditLogSink.cs
@@ -331,7 +331,13 @@ internal sealed class AuditLogSink : IDisposable
     }
 
     internal bool WaitForIdle(TimeSpan timeout)
-        => Interlocked.Read(ref _pendingRecordCount) <= 0 || _idleEvent.Wait(timeout);
+        => WaitForIdle(timeout, CancellationToken.None);
+
+    internal bool WaitForIdle(TimeSpan timeout, CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Interlocked.Read(ref _pendingRecordCount) <= 0 || _idleEvent.Wait(timeout, cancellationToken);
+    }
 
     private static int ResolveQueueCapacity(int? queueCapacity)
     {

--- a/src/CodeIndex/Mcp/HttpMcpTransport.cs
+++ b/src/CodeIndex/Mcp/HttpMcpTransport.cs
@@ -528,7 +528,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
 
     private async Task HandleContextAsync(HttpListenerContext context, CancellationToken cancellationToken)
     {
-        var request = BeginRequest(context);
+        var request = BeginRequest(context, cancellationToken);
 
         if (!await TryAuthorizeAsync(request).ConfigureAwait(false))
             return;
@@ -827,13 +827,14 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
         byte[] bytes,
         TimeSpan timeout,
         string timeoutCategory,
-        Action onTimeout)
+        Action onTimeout,
+        CancellationToken cancellationToken = default)
     {
-        using var writeScope = OperationTimeoutScope.Create(timeoutCategory, timeout, CancellationToken.None);
+        using var writeScope = OperationTimeoutScope.Create(timeoutCategory, timeout, cancellationToken);
         await AwaitOutputOperationAsync(
             stream.WriteAsync(bytes.AsMemory(), writeScope.Token).AsTask(),
             writeScope,
-            CancellationToken.None,
+            cancellationToken,
             timeoutCategory,
             timeout,
             onTimeout).ConfigureAwait(false);
@@ -1003,6 +1004,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     {
         try
         {
+            var cancellationToken = request?.CancellationToken ?? CancellationToken.None;
             context.Response.StatusCode = statusCode;
             context.Response.ContentType = "text/plain; charset=utf-8";
             var bytes = Encoding.UTF8.GetBytes(body);
@@ -1010,7 +1012,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
             await WriteResponseBytesAsync(
                 context.Response,
                 bytes,
-                CancellationToken.None,
+                cancellationToken,
                 "plain-text response body timeout",
                 OperationTimeoutCategories.HttpResponseWrite).ConfigureAwait(false);
             CloseOutputStreamOrThrow(context.Response.OutputStream, "plain-text response body");
@@ -1034,6 +1036,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     {
         try
         {
+            var cancellationToken = request?.CancellationToken ?? CancellationToken.None;
             context.Response.StatusCode = statusCode;
             context.Response.ContentType = "application/json; charset=utf-8";
             var bytes = Encoding.UTF8.GetBytes(body);
@@ -1041,7 +1044,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
             await WriteResponseBytesAsync(
                 context.Response,
                 bytes,
-                CancellationToken.None,
+                cancellationToken,
                 "json response body timeout",
                 OperationTimeoutCategories.HttpResponseWrite).ConfigureAwait(false);
             CloseOutputStreamOrThrow(context.Response.OutputStream, "json response body");
@@ -1466,7 +1469,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
         string? RejectionReason,
         string? Diagnostic);
 
-    private PendingRequest BeginRequest(HttpListenerContext context)
+    private PendingRequest BeginRequest(HttpListenerContext context, CancellationToken cancellationToken = default)
     {
         var remotePeer = context.Request.RemoteEndPoint is { } endpoint
             ? endpoint.ToString()
@@ -1476,7 +1479,8 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
             Guid.NewGuid().ToString("N"),
             LimitRequestLogField(remotePeer) ?? "<unknown>",
             LimitRequestLogField(context.Request.HttpMethod) ?? string.Empty,
-            LimitRequestLogField(context.Request.Url?.AbsolutePath ?? "/") ?? "/");
+            LimitRequestLogField(context.Request.Url?.AbsolutePath ?? "/") ?? "/",
+            cancellationToken);
     }
 
     internal static string? LimitRequestLogField(string? value)
@@ -1584,16 +1588,19 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     {
         private readonly long _startedTimestamp = System.Diagnostics.Stopwatch.GetTimestamp();
 
-        internal PendingRequest(HttpListenerContext context, string correlationId, string remotePeer, string method, string path)
+        internal PendingRequest(HttpListenerContext context, string correlationId, string remotePeer, string method, string path, CancellationToken cancellationToken)
         {
             Context = context;
             CorrelationId = correlationId;
             RemotePeer = remotePeer;
             Method = method;
             Path = path;
+            CancellationToken = cancellationToken;
         }
 
         internal HttpListenerContext Context { get; }
+
+        internal CancellationToken CancellationToken { get; }
 
         internal string CorrelationId { get; }
 

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -5998,15 +5998,15 @@ public partial class McpServer
                 writer.MarkBatchInProgress();
                 fileBatchMarked = true;
                 MarkSymbolKindFilterMetaIncompleteOnce();
-                using var txn = writer.BeginTransaction();
+                using var txn = writer.BeginTransaction(requestToken, "mcp index file");
                 var fileId = writer.UpsertFile(record);
                 var chunks = ChunkSplitter.SplitNormalized(fileId, content, loaded.HasOversizeLine);
                 var generatedSuppressionIssue = indexer.BuildGeneratedCodeExtractionSkippedIssue(record.Path);
                 if (generatedSuppressionIssue != null)
                 {
-                    writer.InsertChunks(chunks);
-                    writer.InsertSymbols([]);
-                    writer.InsertReferences([]);
+                    writer.InsertChunks(chunks, requestToken);
+                    writer.InsertSymbols([], requestToken);
+                    writer.InsertReferences([], requestToken);
                     var issues = IndexCommandRunner.AppendIssueIfMissing(
                         FileIndexer.ValidateContent(record.Path, rawBytes, content, record.Lang, loaded.Inspection, loaded.HasOversizeLine),
                         generatedSuppressionIssue);
@@ -6043,14 +6043,14 @@ public partial class McpServer
                     IReadOnlyList<FileIssue> capIssues = symbolRegexTimeoutIssue == null
                         ? [issue]
                         : IndexCommandRunner.AppendIssue([symbolRegexTimeoutIssue], issue);
-                    writer.InsertSymbols([]);
-                    writer.InsertReferences([]);
+                    writer.InsertSymbols([], requestToken);
+                    writer.InsertReferences([], requestToken);
                     writer.InsertIssues(fileId, capIssues);
                 }
                 else
                 {
-                    writer.InsertChunks(chunks);
-                    writer.InsertSymbols(symbols);
+                    writer.InsertChunks(chunks, requestToken);
+                    writer.InsertSymbols(symbols, requestToken);
                     List<ReferenceRecord> references;
                     FileIssue? regexTimeoutIssue;
                     using (var regexTimeouts = BoundedRegex.CaptureTimeouts(record.Lang, "reference_extraction"))
@@ -6074,7 +6074,7 @@ public partial class McpServer
                         referenceCapIssue = BuildMcpReferenceCountExceededIssue(record.Path, references.Count, maxReferencesPerFile);
                         references = [];
                     }
-                    writer.InsertReferences(references);
+                    writer.InsertReferences(references, requestToken);
                     // Keep MCP index parity with CLI index: persist file-level validation issues too.
                     // MCPインデックスもCLIインデックスと同等に、ファイル検証issueを保存する。
                     IReadOnlyList<FileIssue> issues = FileIndexer.ValidateContent(record.Path, rawBytes, content, record.Lang, loaded.Inspection, loaded.HasOversizeLine);
@@ -6096,11 +6096,11 @@ public partial class McpServer
                 try
                 {
                     var skippedRecord = indexer.BuildSkippedFileRecord(filePath);
-                    using var txn = writer.BeginTransaction();
+                    using var txn = writer.BeginTransaction(requestToken, "mcp index skipped binary");
                     var fileId = writer.UpsertFile(skippedRecord);
-                    writer.InsertChunks([]);
-                    writer.InsertSymbols([]);
-                    writer.InsertReferences([]);
+                    writer.InsertChunks([], requestToken);
+                    writer.InsertSymbols([], requestToken);
+                    writer.InsertReferences([], requestToken);
                     writer.InsertIssues(fileId, [IndexCommandRunner.BuildNullByteIssue(ex)]);
                     WriteProjectRootOnce();
                     txn.Commit();
@@ -6121,7 +6121,7 @@ public partial class McpServer
                     var relativePath = FileIndexer.NormalizePathSeparators(Path.GetRelativePath(projectPath, filePath));
                     if (writer.HasFileAtPath(relativePath))
                     {
-                        using var txn = writer.BeginTransaction();
+                        using var txn = writer.BeginTransaction(requestToken, "mcp index delete missing file");
                         writer.DeleteFileByPath(relativePath);
                         WriteProjectRootOnce();
                         txn.Commit();
@@ -6166,7 +6166,7 @@ public partial class McpServer
         {
             await EmitProgressNotificationAsync(progressToken, processed, files.Count, "Finalizing index metadata.").ConfigureAwait(false);
             writer.MarkBatchInProgress();
-            using var readinessTxn = writer.BeginTransaction();
+            using var readinessTxn = writer.BeginTransaction(requestToken, "mcp index readiness");
             writer.MarkGraphReady();
             writer.MarkIssuesReady();
             writer.MarkSqlGraphContractReady();

--- a/tests/CodeIndex.Tests/AuditLogSinkTests.cs
+++ b/tests/CodeIndex.Tests/AuditLogSinkTests.cs
@@ -750,6 +750,40 @@ public class AuditLogSinkTests
         }
     }
 
+    [Fact]
+    public void WaitForIdle_CancelledTokenStopsWaiting_Issue3946()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"cdidx_audit_idle_cancel_{Guid.NewGuid():N}.jsonl");
+        using var writerEntered = new ManualResetEventSlim();
+        using var releaseWriter = new ManualResetEventSlim();
+        using var waitCancellation = new CancellationTokenSource();
+        try
+        {
+            using var sink = new AuditLogSink(path, AuditLogSink.DefaultMaxBytes, includeValues: false);
+            sink.BeforeWriteForTests = () =>
+            {
+                writerEntered.Set();
+                releaseWriter.Wait();
+            };
+
+            sink.Record(CreateAuditEvent("search"));
+            Assert.True(writerEntered.Wait(TimeSpan.FromSeconds(5)), "audit writer should enter the blocking hook");
+
+            waitCancellation.Cancel();
+            Assert.Throws<OperationCanceledException>(() =>
+                sink.WaitForIdle(TimeSpan.FromSeconds(5), waitCancellation.Token));
+
+            releaseWriter.Set();
+            WaitForAuditLogIdle(sink);
+        }
+        finally
+        {
+            releaseWriter.Set();
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
     private static void WaitForAuditLogIdle(AuditLogSink sink)
         => Assert.True(
             sink.WaitForIdle(TimeSpan.FromSeconds(5)),

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -52,6 +52,18 @@ public class DatabaseTests : IDisposable
     }
 
     [Fact]
+    public void SleepBeforeRetry_CancellationDuringDefaultWaitStopsPromptly_Issue3952()
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+        var stopwatch = Stopwatch.StartNew();
+
+        Assert.Throws<OperationCanceledException>(() =>
+            DbConnectionFactory.SleepBeforeRetry(5_000, sleep: null, cts.Token));
+
+        Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2), $"Retry wait took {stopwatch.Elapsed}.");
+    }
+
+    [Fact]
     public void Search_ExactSymbolBoostPrefersChunkContainingSymbol_Issue1977()
     {
         var fileId = InsertSearchFile(

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -668,6 +668,47 @@ public class GitHelperTests : IDisposable
     }
 
     [Fact]
+    public void RunGitCapturingResult_CallerCancellationStopsProcessWait_Issue3969()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var repoDir = Path.Combine(_tempDir, "repo-git-caller-cancel");
+        Directory.CreateDirectory(repoDir);
+        var fakeGitDir = Path.Combine(_tempDir, "fake-git-caller-cancel");
+        Directory.CreateDirectory(fakeGitDir);
+        WriteFakeGitThatHangsForAnyCommand(fakeGitDir);
+
+        var oldGitExecutablePath = GitHelper.GitExecutablePathOverride;
+        var oldTimeout = GitHelper.GitCommandTimeout;
+        GitHelper.GitExecutablePathOverride = Path.Combine(fakeGitDir, "git");
+        GitHelper.GitCommandTimeout = TimeSpan.FromSeconds(5);
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+            var stopwatch = Stopwatch.StartNew();
+
+            var ex = Assert.Throws<OperationCanceledException>(() =>
+                GitHelper.RunGitCapturingResultForTests(
+                    repoDir,
+                    gitEnvironmentOverrides: null,
+                    cts.Token,
+                    "status"));
+
+            stopwatch.Stop();
+            Assert.Equal(cts.Token, ex.CancellationToken);
+            Assert.True(
+                stopwatch.Elapsed < GitCancellationWallClockLimit,
+                $"Caller cancellation took {stopwatch.Elapsed}, expected less than {GitCancellationWallClockLimit}.");
+        }
+        finally
+        {
+            GitHelper.GitCommandTimeout = oldTimeout;
+            GitHelper.GitExecutablePathOverride = oldGitExecutablePath;
+        }
+    }
+
+    [Fact]
     public void RunGitCapturingResult_StartFailureReportsStructuredRedactedDiagnostic_Issue3434()
     {
         if (OperatingSystem.IsWindows())

--- a/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+++ b/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
@@ -75,6 +75,26 @@ public class HttpMcpTransportTests : IDisposable
     }
 
     [Fact]
+    public async Task HttpTransport_ResponseWriteCancellationPropagatesCallerToken_Issue3928()
+    {
+        using var stream = new NonCancellableHangingStream(hangWrite: true, hangFlush: false);
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(25));
+        var abortCount = 0;
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            HttpMcpTransport.WriteBytesWithTimeoutForTestsAsync(
+                stream,
+                [1, 2, 3],
+                TimeSpan.FromSeconds(5),
+                OperationTimeoutCategories.HttpResponseWrite,
+                () => abortCount++,
+                cts.Token));
+
+        Assert.Equal(0, abortCount);
+        Assert.Equal(1, stream.WriteCalls);
+    }
+
+    [Fact]
     public async Task HttpTransport_SseFlushTimeout_AbortsNonCooperativeFlush_Issue3990()
     {
         using var stream = new NonCancellableHangingStream(hangWrite: false, hangFlush: true);


### PR DESCRIPTION
## Summary

- Propagate cancellation through audit idle waits, index/backfill database write transactions, MCP HTTP response writes, export/import archive copies, and git process waits.
- Replace the remaining production SQLite retry `Thread.Sleep` path with a cancellation-aware bounded wait.
- Bound the MCP HTTP transport dispose sync boundary and add diagnostics for timeout/failure during shutdown.

## Validation

- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~AuditLogSinkTests|FullyQualifiedName~HttpMcpTransportTests|FullyQualifiedName~GitHelperTests|FullyQualifiedName~SleepBeforeRetry_CancellationDuringDefaultWaitStopsPromptly_Issue3952" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Note: a full `dotnet test CodeIndex.sln --no-build -p:UseSharedCompilation=false` run was attempted, but it produced no additional output for more than 8 minutes and was terminated. The targeted suites above pass on both net8.0 and net9.0.

## Documentation and Changelog

- `changelog.d/unreleased/3928.fixed.md`
- `changelog.d/unreleased/3946.fixed.md`
- `changelog.d/unreleased/3952.fixed.md`
- `changelog.d/unreleased/3969.fixed.md`

## Follow-up Candidates

None.

Fixes #3928
Fixes #3946
Fixes #3952
Fixes #3969
