### PR TITLE
Normalize CLI JSON output contracts

### DIFF
--- a/changelog.d/unreleased/3896.fixed.md
+++ b/changelog.d/unreleased/3896.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 3896
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.Batch.cs
+  - src/CodeIndex/Cli/SuggestionsCommandRunner.cs
+  - src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+  - src/CodeIndex/Models/FileIssue.cs
+---
+
+## English
+
+- **JSON-mode query, batch, suggestions, and validate output is now consistently machine-readable (#3896)** — `find --json=array`, invalid regex errors, batch JSON parse errors, status/languages/validate argument errors, empty suggestion lists, missing suggestions, `validate --format count --json`, and BOM validation findings now emit parseable JSON contracts.
+
+## 日本語
+
+- **JSON モードの query / batch / suggestions / validate 出力を機械可読形式に統一しました (#3896)** — `find --json=array`、不正 regex エラー、batch JSON parse エラー、status / languages / validate の引数エラー、空の suggestions list、存在しない suggestion、`validate --format count --json`、BOM 検証結果が parse 可能な JSON contract を返すようになりました。

--- a/changelog.d/unreleased/3955.fixed.md
+++ b/changelog.d/unreleased/3955.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3955
+affected:
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+  - tests/CodeIndex.Tests/ProgramCliTests.cs
+---
+
+## English
+
+- **Utility commands now reject unsupported JSON forms with structured errors (#3955)** — `license --json`, `license --json=array`, and `completions ... --json` now return JSON error objects instead of falling back to human text or ambiguous option handling.
+
+## 日本語
+
+- **utility command が未対応の JSON 形式を構造化エラーで拒否するようになりました (#3955)** — `license --json`、`license --json=array`、`completions ... --json` は human text や曖昧な option handling に戻らず、JSON error object を返します。

--- a/changelog.d/unreleased/3968.internal.md
+++ b/changelog.d/unreleased/3968.internal.md
@@ -1,0 +1,15 @@
+---
+category: internal
+issues:
+  - 3968
+affected:
+  - tests/CodeIndex.Tests/ProgramCliTests.cs
+---
+
+## English
+
+- **Added JSON contract coverage for CLI utility error paths (#3968)** — tests now parse structured JSON from utility unsupported-option cases so `license`, `completions`, and `config show` keep their machine-readable error contracts.
+
+## 日本語
+
+- **CLI utility error path の JSON contract coverage を追加しました (#3968)** — `license`、`completions`、`config show` が機械可読 error contract を維持するよう、utility の unsupported-option ケースで構造化 JSON を parse するテストを追加しました。

--- a/changelog.d/unreleased/3980.internal.md
+++ b/changelog.d/unreleased/3980.internal.md
@@ -1,0 +1,17 @@
+---
+category: internal
+issues:
+  - 3980
+affected:
+  - src/CodeIndex/Cli/CommandOutputWriter.cs
+  - src/CodeIndex/Cli/CommandErrorWriter.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+---
+
+## English
+
+- **Centralized touched CLI stdout contracts behind output helpers (#3980)** — `CommandOutputWriter` now owns shared stdout emission for JSON/text helpers, and touched error and count payloads route through output helpers instead of ad hoc stdout serialization.
+
+## 日本語
+
+- **今回触れた CLI stdout contract を output helper 経由に集約しました (#3980)** — `CommandOutputWriter` が JSON / text helper の共有 stdout emission を担い、今回触れた error と count payload は個別の stdout serialization ではなく output helper を経由します。

--- a/src/CodeIndex/Cli/CommandErrorWriter.cs
+++ b/src/CodeIndex/Cli/CommandErrorWriter.cs
@@ -8,7 +8,7 @@ internal static class CommandErrorWriter
     private const int SanitizedExceptionTypeNameLimit = 120;
 
     internal static void WriteStdout(string message = "")
-        => Console.WriteLine(message);
+        => CommandOutputWriter.WriteLine(message);
 
     internal static void WriteStderr(string? message = "")
         => Console.Error.WriteLine(message);

--- a/src/CodeIndex/Cli/CommandOutputWriter.cs
+++ b/src/CodeIndex/Cli/CommandOutputWriter.cs
@@ -1,0 +1,33 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization.Metadata;
+
+namespace CodeIndex.Cli;
+
+internal static class CommandOutputWriter
+{
+    internal static void WriteLine(string message = "")
+        => Console.WriteLine(message);
+
+    internal static void WriteJson<T>(T value, JsonTypeInfo<T> jsonTypeInfo)
+        => Console.WriteLine(JsonSerializer.Serialize(value, jsonTypeInfo));
+
+    internal static void WriteJsonNode(JsonNode node, JsonSerializerOptions jsonOptions)
+    {
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream, new JsonWriterOptions
+        {
+            Encoder = jsonOptions.Encoder,
+            Indented = jsonOptions.WriteIndented,
+        }))
+        {
+            node.WriteTo(writer);
+        }
+
+        Console.WriteLine(Encoding.UTF8.GetString(stream.ToArray()));
+    }
+
+    internal static void WriteRawJson(string json)
+        => Console.WriteLine(json);
+}

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -734,6 +734,7 @@ internal sealed record VersionInfoJsonResult(
 [JsonSerializable(typeof(List<CliJsonMessage>))]
 [JsonSerializable(typeof(List<DefinitionResult>))]
 [JsonSerializable(typeof(List<FileDependencyResult>))]
+[JsonSerializable(typeof(List<FileFindResult>))]
 [JsonSerializable(typeof(List<FileIssue>))]
 [JsonSerializable(typeof(List<FileResult>))]
 [JsonSerializable(typeof(List<GroupedSymbolHotspotJsonResult>))]

--- a/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
@@ -72,6 +72,21 @@ internal static partial class ProgramRunner
     {
         if (args[0] is "--license" or "license")
         {
+            var wantsJson = ContainsJsonOutputFlag(args.Skip(1));
+            if (wantsJson)
+            {
+                exitCode = CommandErrorWriter.WriteJsonOrHuman(
+                    true,
+                    context.JsonOptions,
+                    "license does not support --json or --json=<format>.",
+                    CommandExitCodes.UsageError,
+                    "rerun without --json; license output is human-readable text.",
+                    usage: "cdidx license");
+                GlobalToolLog.Info($"command_complete exit_code={exitCode} license_json_unsupported=true");
+                EmitCommandMetric("license", args, context.StartTimestamp, context.Stopwatch, exitCode);
+                return true;
+            }
+
             if (args[0] == "license" && args.Length > 1 && ArgHelper.WantsHelp(args.AsSpan(1)))
             {
                 ConsoleUi.PrintCommandUsage("license");
@@ -99,7 +114,7 @@ internal static partial class ProgramRunner
                 return true;
             }
 
-            exitCode = RunCompletions(args[1..], args[0] == "completions" ? "completions" : "--completions");
+            exitCode = RunCompletions(args[1..], context.JsonOptions, args[0] == "completions" ? "completions" : "--completions");
             GlobalToolLog.Info($"command_complete exit_code={exitCode} command=completions");
             EmitCommandMetric("completions", args, context.StartTimestamp, context.Stopwatch, exitCode);
             return true;

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -4361,21 +4361,24 @@ internal static partial class ProgramRunner
         return $"cdidx v{metadata.Version} (commit {commit}, built {buildDate}, {dirty}){suffix}";
     }
 
-    private static int RunCompletions(string[] cmdArgs, string commandName = "--completions")
+    private static int RunCompletions(string[] cmdArgs, JsonSerializerOptions jsonOptions, string commandName = "--completions")
     {
         var usage = $"cdidx {commandName} <shell>";
+        var wantsJson = ContainsJsonOutputFlag(cmdArgs);
+        if (wantsJson)
+            return CommandErrorWriter.WriteJsonOrHuman(
+                true,
+                jsonOptions,
+                "--json is not supported for completions.",
+                CommandExitCodes.UsageError,
+                "rerun with one of `bash`, `zsh`, `fish`, or `powershell`; completions output is already a shell script.",
+                usage);
+
         if (cmdArgs.Length == 0)
             return CommandErrorWriter.Write(
                 $"{commandName} requires a shell value.",
                 CommandExitCodes.UsageError,
                 "rerun with one of `bash`, `zsh`, `fish`, or `powershell`.",
-                usage);
-
-        if (cmdArgs[0] == "--json")
-            return CommandErrorWriter.Write(
-                "--json is not supported for completions.",
-                CommandExitCodes.UsageError,
-                "rerun with one of `bash`, `zsh`, `fish`, or `powershell`; completions output is already a shell script.",
                 usage);
 
         if (cmdArgs[0].StartsWith("-", StringComparison.Ordinal))

--- a/src/CodeIndex/Cli/QueryCommandRunner.Batch.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.Batch.cs
@@ -88,7 +88,7 @@ public static partial class QueryCommandRunner
                 if (string.IsNullOrWhiteSpace(line))
                     continue;
 
-                if (!TryParseBatchLine(line, lineNumber, out var commandName, out var subArgs, out var parseExitCode))
+                if (!TryParseBatchLine(line, lineNumber, jsonOptions, out var commandName, out var subArgs, out var parseExitCode))
                 {
                     lineErrors++;
                     if (firstFailure == CommandExitCodes.Success)
@@ -170,7 +170,7 @@ public static partial class QueryCommandRunner
         }
     }
 
-    private static bool TryParseBatchLine(string line, int lineNumber, out string commandName, out string[] subArgs, out int exitCode)
+    private static bool TryParseBatchLine(string line, int lineNumber, JsonSerializerOptions jsonOptions, out string commandName, out string[] subArgs, out int exitCode)
     {
         commandName = string.Empty;
         subArgs = [];
@@ -213,7 +213,14 @@ public static partial class QueryCommandRunner
         }
         catch (JsonException)
         {
-            CommandErrorWriter.WriteStderr($"Error [{CommandErrorCodes.UsageError}]: batch line {lineNumber} {SafeDiagnosticFormatter.FormatCategoryType("invalid_batch_json", nameof(JsonException))}.");
+            CommandErrorWriter.WriteJsonOrHuman(
+                true,
+                jsonOptions,
+                $"batch line {lineNumber} {SafeDiagnosticFormatter.FormatCategoryType("invalid_batch_json", nameof(JsonException))}.",
+                CommandExitCodes.UsageError,
+                "ensure each batch input line is a JSON string array.",
+                errorCode: CommandErrorCodes.UsageError,
+                category: "invalid_batch_json");
             return false;
         }
     }

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -4909,7 +4909,7 @@ public static partial class QueryCommandRunner
                 {
                     return ex is RegexMatchTimeoutException timeout
                         ? WriteFindRegexTimeoutError(timeout, jsonOptions, options.Json)
-                        : WriteFindInvalidRegexError(ex);
+                        : WriteFindInvalidRegexError(ex, jsonOptions, options.Json);
                 }
                 if (counts.Count == 0)
                 {
@@ -4961,7 +4961,7 @@ public static partial class QueryCommandRunner
             }
             catch (ArgumentException ex) when (options.Regex)
             {
-                return WriteFindInvalidRegexError(ex);
+                return WriteFindInvalidRegexError(ex, jsonOptions, options.Json);
             }
             catch (RegexMatchTimeoutException ex) when (options.Regex)
             {
@@ -4973,6 +4973,13 @@ public static partial class QueryCommandRunner
                 var candidateFileCount = findResults.Scan.CandidateFiles;
                 if (options.Json)
                 {
+                    if (options.OutputFormat == OutputFormatJson && options.JsonOutputFormat == JsonOutputFormatArray)
+                    {
+                        CommandOutputWriter.WriteJson(
+                            new List<FileFindResult>(),
+                            CliJsonSerializerContextFactory.Create(jsonOptions).ListFileFindResult);
+                        return ZeroResultExitCode(options);
+                    }
                     if (TryWriteEmptyFormattedResult(options, jsonOptions))
                         return ZeroResultExitCode(options);
                     var payload = BuildJsonZeroResultPayload(reader, jsonOptions, resultsKey: "results", queryOptions: options, extraFields: payload =>
@@ -5029,6 +5036,13 @@ public static partial class QueryCommandRunner
                     WriteSarif(results.Select(r => (r.Path, r.Line, r.Column, $"find match: {options.Query}", "find")), jsonOptions);
                     return CommandExitCodes.Success;
                 }
+                if (options.OutputFormat == OutputFormatJson && options.JsonOutputFormat == JsonOutputFormatArray)
+                {
+                    CommandOutputWriter.WriteJson(
+                        results,
+                        CliJsonSerializerContextFactory.Create(jsonOptions).ListFileFindResult);
+                    return CommandExitCodes.Success;
+                }
                 foreach (var r in results)
                     Console.WriteLine(JsonSerializer.Serialize(r, CliJsonSerializerContextFactory.Create(jsonOptions).FileFindResult));
             }
@@ -5048,11 +5062,15 @@ public static partial class QueryCommandRunner
         });
     }
 
-    private static int WriteFindInvalidRegexError(Exception ex)
-    {
-        CommandErrorWriter.WriteStderr($"Error: invalid regular expression: {ex.Message}");
-        return CommandExitCodes.UsageError;
-    }
+    private static int WriteFindInvalidRegexError(Exception ex, JsonSerializerOptions jsonOptions, bool json)
+        => CommandErrorWriter.WriteJsonOrHuman(
+            json,
+            jsonOptions,
+            $"invalid regular expression: {ex.Message}",
+            CommandExitCodes.UsageError,
+            "fix the pattern passed with --regex, or omit --regex to run a literal text search.",
+            errorCode: CommandErrorCodes.UsageError,
+            category: "invalid_regex");
 
     internal static int WriteFindRegexTimeoutError(RegexMatchTimeoutException ex, JsonSerializerOptions jsonOptions, bool json)
     {
@@ -6296,7 +6314,7 @@ public static partial class QueryCommandRunner
             validateDefaultMaxLineWidth: false);
         if (TryWriteUnsupportedOptionError("status", cmdArgs, CliFlagSchema.GetAcceptedFlagNamesForCommand("status")))
             return CommandExitCodes.UsageError;
-        if (TryWriteParseError(options, "status"))
+        if (TryWriteParseError(options, "status", jsonOptions))
             return CommandExitCodes.UsageError;
         if (TryWriteUnexpectedPositionals("status", options))
             return CommandExitCodes.UsageError;
@@ -6329,7 +6347,7 @@ public static partial class QueryCommandRunner
         if (options.StatusExplainField != null)
         {
             if (options.Json)
-                return WriteStatusReadinessExplanationJson(options.StatusExplainField);
+                return WriteStatusReadinessExplanationJson(options.StatusExplainField, jsonOptions);
             return WriteStatusReadinessExplanation(options.StatusExplainField);
         }
 
@@ -8831,17 +8849,19 @@ public static partial class QueryCommandRunner
             validateDefaultMaxLineWidth: false);
         if (TryWriteUnsupportedOptionError("validate", cmdArgs, CliFlagSchema.GetAcceptedFlagNamesForCommand("validate")))
             return CommandExitCodes.UsageError;
-        if (TryWriteParseError(options, "validate"))
+        if (TryWriteParseError(options, "validate", jsonOptions))
             return CommandExitCodes.UsageError;
         if (TryWriteUnexpectedPositionals("validate", options))
             return CommandExitCodes.UsageError;
         if (options.Severity != null && !AllValidValidateSeverities.Contains(options.Severity, StringComparer.Ordinal))
         {
-            CommandErrorWriter.Write(
+            return CommandErrorWriter.WriteJsonOrHuman(
+                options.Json,
+                jsonOptions,
                 $"unsupported validate severity '{options.Severity}'.",
+                CommandExitCodes.UsageError,
                 "use one of: info, warning, error.",
                 "cdidx validate [--severity <info|warning|error>]");
-            return CommandExitCodes.UsageError;
         }
 
         return WithDb(options, jsonOptions, reader =>
@@ -8851,6 +8871,11 @@ public static partial class QueryCommandRunner
                 : (int?)null;
             var issues = reader.GetIssues(options.Kind, options.PathPatterns, issueLimit, options.Severity);
             var issuesAvailable = reader._hasIssuesTable;
+            if (options.CountOnly || options.OutputFormat == OutputFormatCount)
+            {
+                WriteFormattedCount(issues.Count, jsonOptions);
+                return CommandExitCodes.Success;
+            }
             if (issues.Count == 0)
             {
                 if (options.Json)
@@ -8941,7 +8966,7 @@ public static partial class QueryCommandRunner
             validateDefaultMaxLineWidth: false);
         if (TryWriteUnsupportedOptionError("languages", cmdArgs, CliFlagSchema.GetAcceptedFlagNamesForCommand("languages")))
             return CommandExitCodes.UsageError;
-        if (TryWriteParseError(options, "languages"))
+        if (TryWriteParseError(options, "languages", jsonOptions))
             return CommandExitCodes.UsageError;
         if (TryWriteUnexpectedPositionals("languages", options))
             return CommandExitCodes.UsageError;
@@ -11920,26 +11945,55 @@ public static partial class QueryCommandRunner
     }
 
     private static bool TryWriteParseError(QueryCommandOptions options, string commandName)
+        => TryWriteParseError(options, commandName, jsonOptions: null);
+
+    private static bool TryWriteParseError(QueryCommandOptions options, string commandName, JsonSerializerOptions? jsonOptions)
     {
         var dbPathError = BuildExplicitDbPathParseError(options);
         if (options.ParseError == null && dbPathError == null)
             return false;
 
         var primaryError = options.ParseError ?? dbPathError!;
-        CommandErrorWriter.Write(
-            StripErrorPrefix(primaryError),
-            primaryError == dbPathError && options.ParseError == null
-                ? "create or refresh the index with `cdidx index <projectPath>` (or `cdidx .`) and then rerun this command."
-                : "fix the invalid or missing option value, then rerun with the command shape below.",
-            GetUsageLineOrThrow(commandName),
-            ExtractErrorCode(primaryError));
+        var primaryHint = primaryError == dbPathError && options.ParseError == null
+            ? "create or refresh the index with `cdidx index <projectPath>` (or `cdidx .`) and then rerun this command."
+            : "fix the invalid or missing option value, then rerun with the command shape below.";
+        WriteParseError(primaryError, primaryHint, commandName, options, jsonOptions);
         if (options.ParseError != null && dbPathError != null)
-            CommandErrorWriter.Write(
-                StripErrorPrefix(dbPathError),
+            WriteParseError(
+                dbPathError,
                 "create or refresh the index with `cdidx index <projectPath>` (or `cdidx .`) and then rerun this command.",
-                GetUsageLineOrThrow(commandName),
-                ExtractErrorCode(dbPathError));
+                commandName,
+                options,
+                jsonOptions);
         return true;
+    }
+
+    private static void WriteParseError(
+        string error,
+        string hint,
+        string commandName,
+        QueryCommandOptions options,
+        JsonSerializerOptions? jsonOptions)
+    {
+        if (options.Json && jsonOptions != null)
+        {
+            CommandErrorWriter.WriteJsonOrHuman(
+                true,
+                jsonOptions,
+                StripErrorPrefix(error),
+                CommandExitCodes.UsageError,
+                hint,
+                GetUsageLineOrThrow(commandName),
+                ExtractErrorCode(error),
+                category: "usage");
+            return;
+        }
+
+        CommandErrorWriter.Write(
+            StripErrorPrefix(error),
+            hint,
+            GetUsageLineOrThrow(commandName),
+            ExtractErrorCode(error));
     }
 
     private static string? BuildExplicitDbPathParseError(QueryCommandOptions options)
@@ -13007,15 +13061,18 @@ public static partial class QueryCommandRunner
         return CommandExitCodes.Success;
     }
 
-    private static int WriteStatusReadinessExplanationJson(string fieldName)
+    private static int WriteStatusReadinessExplanationJson(string fieldName, JsonSerializerOptions jsonOptions)
     {
         var field = FindStatusReadinessField(fieldName);
         if (field == null)
-        {
-            CommandErrorWriter.WriteStderr($"Error: unknown status readiness field `{fieldName}`.");
-            CommandErrorWriter.WriteStderr($"Hint: use one of: {string.Join(", ", StatusReadinessFields.Select(f => f.FieldName))}.");
-            return CommandExitCodes.UsageError;
-        }
+            return CommandErrorWriter.WriteJsonOrHuman(
+                true,
+                jsonOptions,
+                $"unknown status readiness field `{fieldName}`.",
+                CommandExitCodes.UsageError,
+                $"use one of: {string.Join(", ", StatusReadinessFields.Select(f => f.FieldName))}.",
+                errorCode: CommandErrorCodes.UsageError,
+                category: "usage");
 
         var knownFields = new JsonArray();
         foreach (var knownField in StatusReadinessFields)
@@ -13031,7 +13088,7 @@ public static partial class QueryCommandRunner
             ["remediation"] = field.Remediation,
             ["known_fields"] = knownFields,
         };
-        Console.WriteLine(payload.ToJsonString());
+        CommandOutputWriter.WriteJsonNode(payload, jsonOptions);
         return CommandExitCodes.Success;
     }
 

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -3168,11 +3168,11 @@ public static partial class QueryCommandRunner
     }
 
     private static void WriteFormattedCount(int count, JsonSerializerOptions jsonOptions)
-        => Console.WriteLine(new JsonObject
+        => CommandOutputWriter.WriteJsonNode(new JsonObject
         {
             ["count"] = count,
             ["total_estimated"] = count,
-        }.ToJsonString(jsonOptions));
+        }, jsonOptions);
 
     private static void WriteCompactLocations(IEnumerable<FormattedLocation> locations, JsonSerializerOptions jsonOptions)
     {

--- a/src/CodeIndex/Cli/SuggestionsCommandRunner.cs
+++ b/src/CodeIndex/Cli/SuggestionsCommandRunner.cs
@@ -31,19 +31,17 @@ internal static class SuggestionsCommandRunner
         var options = Parse(args[1..]);
         if (options.Error != null)
         {
-            CommandErrorWriter.WriteStderr(options.Error);
-            CommandErrorWriter.WriteStderr(Usage);
-            return CommandExitCodes.UsageError;
+            return WriteUsageError(StripErrorPrefix(options.Error), options.Json, jsonOptions);
         }
         if ((options.DuplicateConfidenceSpecified || options.DuplicateThresholdSpecified)
             && (verb != "export" || options.ExportFormat != "issue-drafts"))
-            return WriteUsageError("--duplicate-confidence and --duplicate-threshold can only be used with `suggestions export --format issue-drafts`.");
+            return WriteUsageError("--duplicate-confidence and --duplicate-threshold can only be used with `suggestions export --format issue-drafts`.", options.Json, jsonOptions);
         if (options.OpenIssuesPath != null && (verb != "export" || options.ExportFormat != "issue-drafts"))
-            return WriteUsageError("--open-issues can only be used with `suggestions export --format issue-drafts`.");
+            return WriteUsageError("--open-issues can only be used with `suggestions export --format issue-drafts`.", options.Json, jsonOptions);
         if (options.OpenIssuesRepository != null && (verb != "export" || options.ExportFormat != "issue-drafts"))
-            return WriteUsageError("--repo can only be used with `suggestions export --format issue-drafts --open-issues github`.");
+            return WriteUsageError("--repo can only be used with `suggestions export --format issue-drafts --open-issues github`.", options.Json, jsonOptions);
         if (verb == "show" && options.HasPagination)
-            return WriteUsageError("--limit and --offset can only be used with `suggestions list` or `suggestions export`.");
+            return WriteUsageError("--limit and --offset can only be used with `suggestions list` or `suggestions export`.", options.Json, jsonOptions);
 
         var store = CreateStore(options.DbPath);
         var records = ApplyFilters(store.LoadAll(), options)
@@ -59,7 +57,7 @@ internal static class SuggestionsCommandRunner
             "list" => RunList(outputRecords, options, jsonOptions),
             "show" => RunShow(records, options, jsonOptions),
             "export" => RunExport(outputRecords, options, jsonOptions, cancellationToken),
-            _ => WriteUsageError($"Unknown suggestions subcommand: {verb}")
+            _ => WriteUsageError($"Unknown suggestions subcommand: {verb}", options.Json, jsonOptions)
         };
     }
 
@@ -67,11 +65,17 @@ internal static class SuggestionsCommandRunner
     {
         if (options.Json)
         {
+            if (records.Count == 0)
+            {
+                CommandOutputWriter.WriteRawJson("[]");
+                return CommandExitCodes.Success;
+            }
+
             foreach (var item in records.Select(ToListItem))
             {
-                Console.WriteLine(JsonSerializer.Serialize(
+                CommandOutputWriter.WriteJson(
                     item,
-                    CliJsonSerializerContextFactory.Create(jsonOptions).SuggestionListItemJsonResult));
+                    CliJsonSerializerContextFactory.Create(jsonOptions).SuggestionListItemJsonResult);
             }
             return CommandExitCodes.Success;
         }
@@ -96,20 +100,22 @@ internal static class SuggestionsCommandRunner
     private static int RunShow(List<SuggestionRecord> records, Options options, JsonSerializerOptions jsonOptions)
     {
         if (string.IsNullOrWhiteSpace(options.Id))
-            return WriteUsageError("suggestions show requires an id.");
+            return WriteUsageError("suggestions show requires an id.", options.Json, jsonOptions);
 
         var record = ResolveById(records, options.Id);
         if (record == null)
-        {
-            CommandErrorWriter.WriteStderr($"Suggestion not found: {options.Id}");
-            return CommandExitCodes.NotFound;
-        }
+            return CommandErrorWriter.WriteJsonOrHuman(
+                options.Json,
+                jsonOptions,
+                $"Suggestion not found: {options.Id}",
+                CommandExitCodes.NotFound,
+                "run `cdidx suggestions list --json` to inspect available suggestion ids.");
 
         if (options.Json)
         {
-            Console.WriteLine(JsonSerializer.Serialize(
+            CommandOutputWriter.WriteJson(
                 ToDetail(record),
-                CliJsonSerializerContextFactory.Create(jsonOptions).SuggestionDetailJsonResult));
+                CliJsonSerializerContextFactory.Create(jsonOptions).SuggestionDetailJsonResult);
             return CommandExitCodes.Success;
         }
 
@@ -169,9 +175,9 @@ internal static class SuggestionsCommandRunner
             JsonOutputContract.ApiVersion,
             records.Count,
             records.Select(ToExportDetail).ToList());
-        Console.WriteLine(JsonSerializer.Serialize(
+        CommandOutputWriter.WriteJson(
             payload,
-            CliJsonSerializerContextFactory.Create(jsonOptions).SuggestionExportJsonResult));
+            CliJsonSerializerContextFactory.Create(jsonOptions).SuggestionExportJsonResult);
         return CommandExitCodes.Success;
     }
 
@@ -188,7 +194,7 @@ internal static class SuggestionsCommandRunner
             .GetAwaiter()
             .GetResult();
         if (!preflightResult.Loaded)
-            return WriteUsageError(preflightResult.Error!);
+            return WriteUsageError(preflightResult.Error!, options.Json, jsonOptions);
         var preflight = preflightResult.Preflight;
 
         var drafts = records.Select(record => ToIssueDraft(record, preflight, options)).ToList();
@@ -202,9 +208,9 @@ internal static class SuggestionsCommandRunner
                 options.DuplicateConfidence,
                 options.DuplicateThreshold),
             drafts);
-        Console.WriteLine(JsonSerializer.Serialize(
+        CommandOutputWriter.WriteJson(
             payload,
-            CliJsonSerializerContextFactory.Create(jsonOptions).SuggestionIssueDraftExportJsonResult));
+            CliJsonSerializerContextFactory.Create(jsonOptions).SuggestionIssueDraftExportJsonResult);
         return CommandExitCodes.Success;
     }
 
@@ -616,6 +622,20 @@ internal static class SuggestionsCommandRunner
         CommandErrorWriter.WriteStderr(Usage);
         return CommandExitCodes.UsageError;
     }
+
+    private static int WriteUsageError(string message, bool json, JsonSerializerOptions jsonOptions)
+        => CommandErrorWriter.WriteJsonOrHuman(
+            json,
+            jsonOptions,
+            message,
+            CommandExitCodes.UsageError,
+            CommandErrorWriter.DefaultHint,
+            Usage);
+
+    private static string StripErrorPrefix(string message)
+        => message.StartsWith("Error: ", StringComparison.Ordinal)
+            ? message["Error: ".Length..]
+            : message;
 
     private static Options Parse(string[] args)
     {

--- a/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
+++ b/src/CodeIndex/Indexer/Scanning/FileIndexer.cs
@@ -4091,6 +4091,8 @@ public class FileIndexer
             Message = utf16BigEndian
                 ? "UTF-16 BE BOM detected (decoded as UTF-16)"
                 : "UTF-16 LE BOM detected (decoded as UTF-16)",
+            Origin = FileIssue.OriginByteOrderMark,
+            Severity = FileIssue.SeverityWarning,
         });
     }
 
@@ -4196,6 +4198,8 @@ public class FileIndexer
                 Kind = "bom",
                 Line = 1,
                 Message = "UTF-8 BOM marker detected",
+                Origin = FileIssue.OriginByteOrderMark,
+                Severity = FileIssue.SeverityWarning,
             });
         }
 

--- a/src/CodeIndex/Models/FileIssue.cs
+++ b/src/CodeIndex/Models/FileIssue.cs
@@ -8,6 +8,7 @@ public class FileIssue
 {
     public const string OriginSourceLiteral = "source_literal";
     public const string OriginDecodeReplacement = "decode_replacement";
+    public const string OriginByteOrderMark = "byte_order_mark";
     public const string SeverityInfo = "info";
     public const string SeverityWarning = "warning";
 

--- a/tests/CodeIndex.Tests/ProgramCliTests.cs
+++ b/tests/CodeIndex.Tests/ProgramCliTests.cs
@@ -856,6 +856,22 @@ public class ProgramCliTests
     }
 
     [Fact]
+    public void Suggestions_ListJsonEmptyReturnsArray_Issue3896()
+    {
+        using var fixture = SuggestionFixture.Create();
+
+        var (exitCode, stdout, stderr) = RunCliInSubprocess([
+            "suggestions", "list", "--db", fixture.DbPath, "--json"
+        ]);
+
+        Assert.Equal(0, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        using var doc = JsonDocument.Parse(stdout);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+        Assert.Equal(0, doc.RootElement.GetArrayLength());
+    }
+
+    [Fact]
     public void Suggestions_ListUsesSharedDataDirResolutionWhenDbIsOmitted()
     {
         using var fixture = SuggestionFixture.Create();
@@ -891,6 +907,20 @@ public class ProgramCliTests
         Assert.Equal(0, doc.RootElement.GetProperty("submit_attempt_count").GetInt32());
         Assert.False(doc.RootElement.TryGetProperty("last_submit_attempt", out _));
         Assert.False(doc.RootElement.TryGetProperty("last_submit_error", out _));
+    }
+
+    [Fact]
+    public void Suggestions_ShowJsonMissingIdReturnsStructuredError_Issue3896()
+    {
+        using var fixture = SuggestionFixture.Create();
+
+        var (exitCode, stdout, stderr) = RunCliInSubprocess(["suggestions", "show", "missing", "--db", fixture.DbPath, "--json"]);
+
+        Assert.Equal(CommandExitCodes.NotFound, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        using var doc = JsonDocument.Parse(stdout);
+        Assert.Equal("error", doc.RootElement.GetProperty("status").GetString());
+        Assert.Equal("Suggestion not found: missing", doc.RootElement.GetProperty("message").GetString());
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ProgramCliTests.cs
+++ b/tests/CodeIndex.Tests/ProgramCliTests.cs
@@ -282,16 +282,16 @@ public class ProgramCliTests
     }
 
     [Fact]
-    public void Completions_OptionLikeShellTokenReturnsUsageError()
+    public void Completions_JsonFlagReturnsStructuredUnsupportedError()
     {
         var (exitCode, stdout, stderr) = RunCliInSubprocess(["--completions", "--json"]);
 
         Assert.Equal(1, exitCode);
-        Assert.Equal(string.Empty, stdout);
-        Assert.Contains("--json is not supported for completions", stderr);
-        Assert.Contains("powershell", stderr);
-        Assert.Contains("Usage: cdidx --completions <shell>", stderr);
-        Assert.DoesNotContain("Unknown shell", stderr);
+        Assert.Equal(string.Empty, stderr);
+        using var document = JsonDocument.Parse(stdout);
+        Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
+        Assert.Equal("--json is not supported for completions.", document.RootElement.GetProperty("message").GetString());
+        Assert.Contains("powershell", document.RootElement.GetProperty("hint").GetString());
     }
 
     [Theory]
@@ -765,7 +765,6 @@ public class ProgramCliTests
 
     [Theory]
     [InlineData("completions")]
-    [InlineData("completions", "--json")]
     [InlineData("completions", "bash", "extra")]
     public void CompletionsCommand_ErrorsUseCommandUsage(params string[] args)
     {
@@ -775,8 +774,6 @@ public class ProgramCliTests
         Assert.Equal(string.Empty, stdout);
         Assert.Contains("Usage: cdidx completions <shell>", stderr);
         Assert.DoesNotContain("Usage: cdidx --completions <shell>", stderr);
-        if (args is ["completions", "--json"])
-            Assert.Contains("--json is not supported for completions", stderr);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ProgramCliTests.cs
+++ b/tests/CodeIndex.Tests/ProgramCliTests.cs
@@ -776,6 +776,23 @@ public class ProgramCliTests
         Assert.DoesNotContain("Usage: cdidx --completions <shell>", stderr);
     }
 
+    [Theory]
+    [InlineData(CommandExitCodes.UsageError, "license does not support --json or --json=<format>.", "license", "--json")]
+    [InlineData(CommandExitCodes.UsageError, "license does not support --json or --json=<format>.", "license", "--json=array")]
+    [InlineData(CommandExitCodes.UsageError, "--json is not supported for completions.", "completions", "--json")]
+    [InlineData(CommandExitCodes.UsageError, "--json is not supported for completions.", "completions", "zsh", "--json")]
+    [InlineData(CommandExitCodes.InvalidArgument, "config show supports --json only; --json=<format> is not supported.", "config", "show", "--json=array")]
+    public void UtilityCommands_JsonFlagsReturnStructuredUnsupportedErrors(int expectedExitCode, string expectedMessage, params string[] args)
+    {
+        var (exitCode, stdout, stderr) = RunCliInSubprocess(args);
+
+        Assert.Equal(expectedExitCode, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        using var document = JsonDocument.Parse(stdout);
+        Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
+        Assert.Equal(expectedMessage, document.RootElement.GetProperty("message").GetString());
+    }
+
     [Fact]
     public void Mcp_JsonFlagReturnsExplicitUnsupportedError()
     {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -5605,6 +5605,64 @@ jobs:
     }
 
     [Fact]
+    public void RunFind_AllScopeJsonArrayEmitsSingleArray_Issue3896()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_find_json_array_3896");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/todo.txt",
+                "text",
+                "TODO: keep this visible\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+                ["TODO", "--db", dbPath, "--all", "--json=array"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = ParseJsonOutput(stdout);
+            var root = document.RootElement;
+            Assert.Equal(JsonValueKind.Array, root.ValueKind);
+            var result = Assert.Single(root.EnumerateArray());
+            Assert.Equal("src/todo.txt", result.GetProperty("path").GetString());
+            Assert.Equal(1, result.GetProperty("line").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunFind_RegexJsonErrorIsStructured_Issue3896()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_find_regex_json_3896");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(dbPath, "src/text.txt", "text", "needle\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunFind(
+                ["[", "--db", dbPath, "--all", "--regex", "--json"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = ParseJsonOutput(stdout);
+            Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
+            Assert.Contains("invalid regular expression", document.RootElement.GetProperty("message").GetString());
+            Assert.Equal("invalid_regex", document.RootElement.GetProperty("category").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunFind_AllScopeCountJsonIncludesScanSummary_Issue3560()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_find_all_count_json_3560");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -95,6 +95,34 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunStatus_ExplainUnknownJsonReturnsStructuredError_Issue3896()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+            ["--json", "--explain", "invalid"],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        using var document = ParseJsonOutput(stdout);
+        Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
+        Assert.Equal("unknown status readiness field `invalid`.", document.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
+    public void RunLanguages_InvalidCapabilityJsonReturnsStructuredError_Issue3896()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunLanguages(
+            ["--capability", "invalid", "--json"],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        using var document = ParseJsonOutput(stdout);
+        Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
+        Assert.Contains("unsupported --capability value 'invalid'", document.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
     public void ParseArgs_AllowsZeroMaxLineWidth()
     {
         var options = QueryCommandRunner.ParseArgs(["RunSearch", "--max-line-width", "0"], jsonDefault: false, allowNamedQuery: true);
@@ -966,10 +994,12 @@ public partial class QueryCommandRunnerTests
                 () => QueryCommandRunner.RunBatch(["--db", dbPath], _jsonOptions));
 
             Assert.Equal(CommandExitCodes.UsageError, exitCode);
-            Assert.Equal(string.Empty, stdout);
-            Assert.Contains("invalid_batch_json: JsonException", stderr, StringComparison.Ordinal);
-            Assert.DoesNotContain(secret, stderr, StringComparison.Ordinal);
-            Assert.DoesNotContain("not valid JSON", stderr, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal(string.Empty, stderr);
+            using var document = ParseJsonOutput(stdout);
+            Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
+            Assert.Contains("invalid_batch_json: JsonException", document.RootElement.GetProperty("message").GetString(), StringComparison.Ordinal);
+            Assert.DoesNotContain(secret, stdout, StringComparison.Ordinal);
+            Assert.DoesNotContain("not valid JSON", stdout, StringComparison.OrdinalIgnoreCase);
         }
         finally
         {
@@ -1070,8 +1100,10 @@ public partial class QueryCommandRunnerTests
                 () => QueryCommandRunner.RunBatch(["--db", dbPath], _jsonOptions));
 
             Assert.Equal(CommandExitCodes.UsageError, exitCode);
-            Assert.Equal(string.Empty, stdout);
-            Assert.Contains("invalid_batch_json: JsonException", stderr);
+            Assert.Equal(string.Empty, stderr);
+            using var document = ParseJsonOutput(stdout);
+            Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
+            Assert.Contains("invalid_batch_json: JsonException", document.RootElement.GetProperty("message").GetString());
         }
         finally
         {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerValidateTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerValidateTests.cs
@@ -104,6 +104,8 @@ public partial class QueryCommandRunnerTests
             Assert.Equal(JsonValueKind.Array, root.ValueKind);
             Assert.Equal(1, root.GetArrayLength());
             Assert.Equal("bom", root[0].GetProperty("kind").GetString());
+            Assert.Equal(FileIssue.OriginByteOrderMark, root[0].GetProperty("origin").GetString());
+            Assert.Equal(FileIssue.SeverityWarning, root[0].GetProperty("severity").GetString());
         }
         finally
         {
@@ -148,6 +150,56 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunValidate_FormatCountThenJsonKeepsCountShape_Issue3896()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_validate_count_json_3896");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            File.WriteAllBytes(
+                Path.Combine(projectRoot, "src", "bom.cs"),
+                [0xEF, 0xBB, 0xBF, .. System.Text.Encoding.UTF8.GetBytes("class Bom {}\n")]);
+
+            var (indexExitCode, _, indexStderr) = CaptureConsole(() => IndexCommandRunner.Run(
+                [projectRoot, "--db", dbPath, "--json", "--quiet"],
+                _jsonOptions));
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(string.Empty, indexStderr);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunValidate(
+                ["--db", dbPath, "--format", "count", "--json"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = ParseJsonOutput(stdout);
+            var root = document.RootElement;
+            Assert.Equal(1, root.GetProperty("count").GetInt32());
+            Assert.Equal(1, root.GetProperty("total_estimated").GetInt32());
+            Assert.False(root.TryGetProperty("issues", out _));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunValidate_InvalidSeverityJsonReturnsStructuredError_Issue3896()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunValidate(
+            ["--severity", "invalid", "--json"],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        using var document = ParseJsonOutput(stdout);
+        Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
+        Assert.Equal("unsupported validate severity 'invalid'.", document.RootElement.GetProperty("message").GetString());
+    }
+
+    [Fact]
     public void RunValidate_KindFilterNarrowsIssues()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_validate_kind_filter");
@@ -179,6 +231,8 @@ public partial class QueryCommandRunnerTests
             Assert.Equal(string.Empty, stderr);
             Assert.Equal(1, json.GetProperty("count").GetInt32());
             Assert.Equal("bom", json.GetProperty("issues")[0].GetProperty("kind").GetString());
+            Assert.Equal(FileIssue.OriginByteOrderMark, json.GetProperty("issues")[0].GetProperty("origin").GetString());
+            Assert.Equal(FileIssue.SeverityWarning, json.GetProperty("issues")[0].GetProperty("severity").GetString());
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Normalize JSON-mode edge outputs for query, batch, suggestions, and validate paths so requested JSON modes stay parseable.
- Reject unsupported utility-command JSON forms with structured errors and add JSON contract coverage for those cases.
- Add a shared `CommandOutputWriter` for the stdout contracts touched by this work.

## Validation

- `dotnet build CodeIndex.sln -c Debug --no-restore`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -f net8.0 --no-build --filter "FullyQualifiedName~Issue3896|FullyQualifiedName~Issue3010|FullyQualifiedName~Issue3425|FullyQualifiedName~Issue3022|FullyQualifiedName~UtilityCommands_JsonFlagsReturnStructuredUnsupportedErrors|FullyQualifiedName~Completions_JsonFlagReturnsStructuredUnsupportedError|FullyQualifiedName~RunStatus_ExplainJson_PrintsMachineReadableDescription"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Debug -f net9.0 --no-build --filter "FullyQualifiedName~Issue3896|FullyQualifiedName~Issue3010|FullyQualifiedName~Issue3425|FullyQualifiedName~Issue3022|FullyQualifiedName~UtilityCommands_JsonFlagsReturnStructuredUnsupportedErrors|FullyQualifiedName~Completions_JsonFlagReturnsStructuredUnsupportedError|FullyQualifiedName~RunStatus_ExplainJson_PrintsMachineReadableDescription"`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog

- Added `changelog.d/unreleased/3896.fixed.md`
- Added `changelog.d/unreleased/3955.fixed.md`
- Added `changelog.d/unreleased/3968.internal.md`
- Added `changelog.d/unreleased/3980.internal.md`
- Did not modify `AGENTS.md`, `CLAUDE.md`, or `AGENT_GUIDE.md`.

## Follow-up Candidates

None.

Fixes #3896
Fixes #3955
Fixes #3968
Fixes #3980
