### PR TITLE
Explain status fields and fix map section payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ fields, including readiness fields and runtime diagnostics such as
 `worktree_head_changed` compares the runtime HEAD with the latest successful
 index stamp from `indexed_head_sha` when available, and falls back to the older
 full-scan-only `indexed_head_commit` only for legacy DBs.
+`status --explain indexed_head_sha` describes the last-successful-index stamp,
+while `status --explain indexed_head_commit` calls out the legacy
+full-scan-only stamp so consumers can prefer `indexed_head_sha` after
+incremental indexing.
 
 Runtime diagnostics under `extractors` include `retained_load_context_count` so
 long-running processes can see how many plugin assembly load contexts are still
@@ -337,6 +341,9 @@ readiness field に加えて、`path_case_sensitive` などの runtime diagnosti
 `worktree_head_changed` は、利用可能な場合は最新の成功 index stamp である
 `indexed_head_sha` と runtime HEAD を比較し、legacy DB だけで従来の
 full-scan 限定 `indexed_head_commit` に fallback します。
+`status --explain indexed_head_sha` は最後に成功した index stamp を説明し、
+`status --explain indexed_head_commit` は legacy 向けの full-scan 限定 stamp であることを
+明示するため、incremental indexing 後の consumer は `indexed_head_sha` を優先できます。
 
 `extractors` の runtime diagnostics は `retained_load_context_count` を含むため、
 長時間実行プロセスは保持中の plugin assembly load context 数を確認できます。

--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ JSON-RPC interface. There is no public library / SDK API. See
 fields for scripts, MCP clients, and release checks. Detailed semantics live in
 the [Developer Guide](DEVELOPER_GUIDE.md#ai-integration); README keeps the field
 names visible so documentation and tests stay synchronized.
+Use `cdidx status --explain <field>` for concise explanations of visible status
+fields, including readiness fields and runtime diagnostics such as
+`path_case_sensitive`.
 
 | Field group | Fields |
 |---|---|
@@ -318,6 +321,8 @@ JSON-RPC interface です。公開 library / SDK API は提供していません
 freshness、compatibility、remediation field を返します。詳細な意味は
 [開発者ガイド](DEVELOPER_GUIDE.md#ai連携) にあり、README では docs と test を
 同期するため field 名を明示します。
+visible な status field の簡潔な説明は `cdidx status --explain <field>` で確認できます。
+readiness field に加えて、`path_case_sensitive` などの runtime diagnostic field も対象です。
 
 | field group | fields |
 |---|---|

--- a/changelog.d/unreleased/3911.fixed.md
+++ b/changelog.d/unreleased/3911.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3911
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerFilesTests.cs
+  - README.md
+---
+
+## English
+
+- **Head freshness fields are now explainable (#3911)** — `status --explain` now documents `indexed_head_sha`, `indexed_head_commit`, and related HEAD drift fields so users can distinguish the latest incremental index stamp from the legacy full-scan-only stamp.
+
+## 日本語
+
+- **HEAD freshness field を `status --explain` で説明できるようになりました (#3911)** — `indexed_head_sha`、`indexed_head_commit`、関連する HEAD drift field の説明を追加し、最新の incremental index stamp と legacy の full-scan 限定 stamp を区別できるようにしました。

--- a/changelog.d/unreleased/3936.fixed.md
+++ b/changelog.d/unreleased/3936.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 3936
+affected:
+  - src/CodeIndex/Cli/CliFlagSchema.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerFilesTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - README.md
+---
+
+## English
+
+- **`status --explain` now covers visible status fields (#3936)** — `status --explain path_case_sensitive` and JSON `known_fields` now include runtime diagnostics in addition to readiness fields, so users can explain fields they see in `status --json`.
+
+## 日本語
+
+- **`status --explain` が visible status field も説明するようになりました (#3936)** — `status --explain path_case_sensitive` と JSON の `known_fields` が readiness field に加えて runtime diagnostics も含むようになり、`status --json` で見える field をそのまま説明できます。

--- a/changelog.d/unreleased/3938.fixed.md
+++ b/changelog.d/unreleased/3938.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3938
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerMapTests.cs
+---
+
+## English
+
+- **`map --sections hotspots --json` now returns its hotspot fields (#3938)** — Section filtering now maps `hotspots` to `top_files`, `symbol_rich_files`, `reference_rich_files`, and `entrypoints`, and the response reports the section-to-property mapping for CLI JSON and MCP structured output.
+
+## 日本語
+
+- **`map --sections hotspots --json` が hotspot field を返すようになりました (#3938)** — Section filter が `hotspots` を `top_files`、`symbol_rich_files`、`reference_rich_files`、`entrypoints` に対応付け、CLI JSON と MCP structured output で section と property の対応も返すようにしました。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -368,7 +368,7 @@ internal static class CliFlagSchema
             new() { Name = "--check", Description = "Verify status freshness/readiness", Commands = Set("status") },
             new() { Name = "--config", Description = "Print effective configuration with source attribution", Commands = Set("status") },
             new() { Name = "--stale-after", ValuePlaceholder = "<duration>", Description = "Status: freshness age threshold (e.g. 30m, 2h, 7d)", Commands = Set("status") },
-            new() { Name = "--explain", ValuePlaceholder = "<field>", Description = "Explain one status readiness field", Commands = Set("status") },
+            new() { Name = "--explain", ValuePlaceholder = "<field>", Description = "Explain one visible status field", Commands = Set("status") },
             new() { Name = "--log-path", Description = "Print the active persistent log directory", Commands = Set("status") },
             new() { Name = "--check-updates", Description = "Check whether a newer cdidx release is available", Commands = Set("status", "upgrade") },
             new() { Name = "--check-only", Description = "Upgrade: only report whether an upgrade is available", Commands = Set("upgrade") },

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -958,7 +958,7 @@ public static class ConsoleUi
         Console.WriteLine("  map                        Show a repo-level overview for AI orientation");
         Console.WriteLine("  inspect <query>            Bundle definition, graph, and nearby symbol context");
         Console.WriteLine("  outline <path>             Show a file outline ordered by line, start column, kind, and name");
-        Console.WriteLine("  status                     Show database statistics; add --check for freshness, --config for effective config, --explain <field> for readiness, or --log-path for logs");
+        Console.WriteLine("  status                     Show database statistics; add --check for freshness, --config for effective config, --explain <field> for field details, or --log-path for logs");
         Console.WriteLine("  workspace                  List manifest members and manage the active workspace");
         Console.WriteLine("  config show                Show resolved workspace config and precedence");
         Console.WriteLine("  upgrade                    Check for and install the latest release via install.sh");

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -5602,22 +5602,12 @@ public static partial class QueryCommandRunner
         }
 
         var keep = new HashSet<string>(RepoMapSummaryJsonProperties, StringComparer.Ordinal);
-        if (MapSectionEnabled(options, "languages"))
-            keep.Add("languages");
-        if (MapSectionEnabled(options, "tree"))
-            keep.Add("modules");
-        if (MapSectionEnabled(options, "hotspots"))
-        {
-            keep.Add("topFiles");
-            keep.Add("symbolRichFiles");
-            keep.Add("referenceRichFiles");
-            keep.Add("entrypoints");
-        }
-        if (MapSectionEnabled(options, "metrics"))
-            keep.Add("largestFiles");
+        foreach (var section in options.MapSections)
+            AddRepoMapSectionJsonProperties(keep, section);
 
         KeepRepoMapJsonProperties(payload, keep);
         payload["sections"] = new JsonArray(options.MapSections.Select(section => JsonValue.Create(section)).ToArray<JsonNode?>());
+        payload["section_properties"] = BuildRepoMapSectionProperties(options.MapSections);
         if (options.ContextAfterExplicit)
             payload["depth"] = options.ContextAfter;
         if (options.Compact && compactTruncation != null)
@@ -5644,10 +5634,41 @@ public static partial class QueryCommandRunner
         "graph_table_available",
     };
 
+    private static readonly IReadOnlyDictionary<string, string[]> RepoMapSectionJsonProperties = new Dictionary<string, string[]>(StringComparer.Ordinal)
+    {
+        ["languages"] = ["languages"],
+        ["tree"] = ["modules"],
+        ["hotspots"] = ["top_files", "symbol_rich_files", "reference_rich_files", "entrypoints"],
+        ["metrics"] = ["largest_files"],
+    };
+
     private static void KeepRepoMapJsonProperties(JsonObject payload, IReadOnlySet<string> keep)
     {
         foreach (var propertyName in payload.Select(property => property.Key).Where(key => !keep.Contains(key)).ToList())
             payload.Remove(propertyName);
+    }
+
+    private static void AddRepoMapSectionJsonProperties(HashSet<string> keep, string section)
+    {
+        if (!RepoMapSectionJsonProperties.TryGetValue(section, out var properties))
+            return;
+
+        foreach (var property in properties)
+            keep.Add(property);
+    }
+
+    private static JsonObject BuildRepoMapSectionProperties(IEnumerable<string> sections)
+    {
+        var payload = new JsonObject();
+        foreach (var section in sections)
+        {
+            if (!RepoMapSectionJsonProperties.TryGetValue(section, out var properties))
+                continue;
+
+            payload[section] = new JsonArray(properties.Select(property => JsonValue.Create(property)).ToArray<JsonNode?>());
+        }
+
+        return payload;
     }
 
     private static int GetCompactSectionLimit(QueryCommandOptions options)

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -327,6 +327,54 @@ public static partial class QueryCommandRunner
         StatusReadinessFields.Concat(
         [
             new(
+                "git_head",
+                "Runtime Git HEAD",
+                "the current workspace Git HEAD commit was resolved at status time.",
+                "the field is absent outside a Git checkout or when Git HEAD cannot be resolved.",
+                "Run inside a Git workspace or pass a database tied to a Git workspace to compare index stamps."),
+            new(
+                "git_is_dirty",
+                "Runtime Git dirty state",
+                "`true` means git status reported uncommitted changes, including untracked files; `false` means no changes were reported.",
+                "the field is absent outside a Git checkout or when dirty-state detection is unavailable.",
+                "Run `git status` in the workspace to inspect uncommitted changes directly."),
+            new(
+                "indexed_head_commit",
+                "Legacy full-scan HEAD stamp",
+                "the index records the Git HEAD from the most recent successful full scan for legacy compatibility.",
+                "this full-scan-only stamp can differ from `indexed_head_sha` after incremental indexing and may be absent in legacy or non-Git indexes.",
+                "Prefer `indexed_head_sha` for current freshness checks; rebuild or run `cdidx index <projectPath>` when only this legacy stamp is available."),
+            new(
+                "worktree_head_changed",
+                "Worktree HEAD drift",
+                "`false` means the runtime HEAD matches the latest index HEAD stamp; `true` means the checkout moved since the index stamp.",
+                "the field is absent when neither `indexed_head_sha` nor the legacy `indexed_head_commit` can be compared with runtime HEAD.",
+                "Run `cdidx index <projectPath>` to refresh the index for the current checkout."),
+            new(
+                "indexed_head_sha",
+                "Latest index HEAD stamp",
+                "the index records the Git HEAD from the last successful index run, including incremental updates.",
+                "the field is absent in legacy indexes, non-Git workspaces, or when the index run could not resolve HEAD.",
+                "Use this field before `indexed_head_commit` when auditing freshness after incremental indexing."),
+            new(
+                "indexed_head_branch",
+                "Latest index branch stamp",
+                "the index records the branch short name captured with `indexed_head_sha`.",
+                "the field is absent for detached HEAD, legacy indexes, non-Git workspaces, or unresolved branch names.",
+                "Use it as context for `indexed_head_sha`; rerun `cdidx index <projectPath>` after switching branches."),
+            new(
+                "indexed_head_timestamp",
+                "Latest index HEAD timestamp",
+                "the index records when `indexed_head_sha` and `indexed_head_branch` were stamped.",
+                "the field is absent in legacy indexes or when the index run could not persist the timestamp.",
+                "Rerun `cdidx index <projectPath>` to refresh the timestamp with the current checkout."),
+            new(
+                "commits_ahead_of_indexed_head",
+                "Commits ahead of indexed HEAD",
+                "`0` means runtime HEAD is not ahead of `indexed_head_sha`; positive values mean the checkout advanced after indexing.",
+                "the field is absent when Git comparison is unavailable or history is not comparable.",
+                "Run `cdidx index <projectPath>` when the value is positive before trusting freshness-sensitive results."),
+            new(
                 "path_case_sensitive",
                 "Filesystem case sensitivity",
                 "`true` means the indexed workspace path comparison is case-sensitive; `false` means case-insensitive.",

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -252,14 +252,14 @@ public static partial class QueryCommandRunner
         "--sections",
         "--fields",
     ];
-    private sealed record StatusReadinessField(
+    private sealed record StatusFieldExplanation(
         string FieldName,
         string Label,
         string ReadyText,
         string DegradedText,
         string Remediation);
 
-    private static readonly StatusReadinessField[] StatusReadinessFields =
+    private static readonly StatusFieldExplanation[] StatusReadinessFields =
     [
         new(
             "graph_table_available",
@@ -322,6 +322,17 @@ public static partial class QueryCommandRunner
             "this DB was written by a newer cdidx, so older readers may degrade instead of trusting newer contract stamps.",
             "Run status with a current cdidx binary, or rebuild the DB with the version you intend to use."),
     ];
+
+    private static readonly StatusFieldExplanation[] StatusExplainFields =
+        StatusReadinessFields.Concat(
+        [
+            new(
+                "path_case_sensitive",
+                "Filesystem case sensitivity",
+                "`true` means the indexed workspace path comparison is case-sensitive; `false` means case-insensitive.",
+                "the field is absent on legacy indexes that predate the workspace case-sensitivity stamp.",
+                "Run `cdidx index <projectPath>` with a current cdidx binary to stamp filesystem case sensitivity."),
+        ]).ToArray();
 
     private static readonly HashSet<string> FlagOnlyOptions =
     [
@@ -13405,11 +13416,11 @@ public static partial class QueryCommandRunner
 
     private static int WriteStatusReadinessExplanation(string fieldName)
     {
-        var field = FindStatusReadinessField(fieldName);
+        var field = FindStatusFieldExplanation(fieldName);
         if (field == null)
         {
-            CommandErrorWriter.WriteStderr($"Error: unknown status readiness field `{fieldName}`.");
-            CommandErrorWriter.WriteStderr($"Hint: use one of: {string.Join(", ", StatusReadinessFields.Select(f => f.FieldName))}.");
+            CommandErrorWriter.WriteStderr($"Error: unknown status field `{fieldName}`.");
+            CommandErrorWriter.WriteStderr($"Hint: use one of: {string.Join(", ", StatusExplainFields.Select(f => f.FieldName))}.");
             return CommandExitCodes.UsageError;
         }
 
@@ -13423,19 +13434,19 @@ public static partial class QueryCommandRunner
 
     private static int WriteStatusReadinessExplanationJson(string fieldName, JsonSerializerOptions jsonOptions)
     {
-        var field = FindStatusReadinessField(fieldName);
+        var field = FindStatusFieldExplanation(fieldName);
         if (field == null)
             return CommandErrorWriter.WriteJsonOrHuman(
                 true,
                 jsonOptions,
-                $"unknown status readiness field `{fieldName}`.",
+                $"unknown status field `{fieldName}`.",
                 CommandExitCodes.UsageError,
-                $"use one of: {string.Join(", ", StatusReadinessFields.Select(f => f.FieldName))}.",
+                $"use one of: {string.Join(", ", StatusExplainFields.Select(f => f.FieldName))}.",
                 errorCode: CommandErrorCodes.UsageError,
                 category: "usage");
 
         var knownFields = new JsonArray();
-        foreach (var knownField in StatusReadinessFields)
+        foreach (var knownField in StatusExplainFields)
             knownFields.Add(knownField.FieldName);
 
         var payload = new JsonObject
@@ -13452,8 +13463,8 @@ public static partial class QueryCommandRunner
         return CommandExitCodes.Success;
     }
 
-    private static StatusReadinessField? FindStatusReadinessField(string fieldName)
-        => StatusReadinessFields.FirstOrDefault(
+    private static StatusFieldExplanation? FindStatusFieldExplanation(string fieldName)
+        => StatusExplainFields.FirstOrDefault(
             field => string.Equals(field.FieldName, fieldName, StringComparison.OrdinalIgnoreCase)
                      || string.Equals(field.Label, fieldName, StringComparison.OrdinalIgnoreCase));
 

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -2846,22 +2846,44 @@ public partial class McpServer
             "projectRoot", "gitHead", "gitIsDirty", "indexed_head_commit", "worktree_head_changed",
             "graphTableAvailable", "limit", "lang", "path", "excludeTests", "depth", "minEntrypointConfidence",
         };
-        if (sections.Contains("languages"))
-            keep.Add("languages");
-        if (sections.Contains("tree") || sections.Contains("modules"))
-            keep.Add("modules");
-        if (sections.Contains("hotspots"))
-        {
-            keep.Add("topFiles");
-            keep.Add("symbolRichFiles");
-            keep.Add("referenceRichFiles");
-            keep.Add("entrypoints");
-        }
-        if (sections.Contains("metrics"))
-            keep.Add("largestFiles");
+        foreach (var section in sections)
+            AddMapSectionStructuredProperties(keep, section);
         foreach (var key in structured.Select(property => property.Key).Where(key => !keep.Contains(key)).ToList())
             structured.Remove(key);
         structured["sections"] = new JsonArray(sections.Select(section => JsonValue.Create(section)).ToArray<JsonNode?>());
+        structured["sectionProperties"] = BuildMapSectionStructuredProperties(sections);
+    }
+
+    private static readonly IReadOnlyDictionary<string, string[]> MapSectionStructuredProperties = new Dictionary<string, string[]>(StringComparer.Ordinal)
+    {
+        ["languages"] = ["languages"],
+        ["tree"] = ["modules"],
+        ["modules"] = ["modules"],
+        ["hotspots"] = ["topFiles", "symbolRichFiles", "referenceRichFiles", "entrypoints"],
+        ["metrics"] = ["largestFiles"],
+    };
+
+    private static void AddMapSectionStructuredProperties(HashSet<string> keep, string section)
+    {
+        if (!MapSectionStructuredProperties.TryGetValue(section, out var properties))
+            return;
+
+        foreach (var property in properties)
+            keep.Add(property);
+    }
+
+    private static JsonObject BuildMapSectionStructuredProperties(IReadOnlySet<string> sections)
+    {
+        var payload = new JsonObject();
+        foreach (var section in sections)
+        {
+            if (!MapSectionStructuredProperties.TryGetValue(section, out var properties))
+                continue;
+
+            payload[section] = new JsonArray(properties.Select(property => JsonValue.Create(property)).ToArray<JsonNode?>());
+        }
+
+        return payload;
     }
 
     private JsonNode ExecuteAnalyzeSymbol(JsonNode? id, JsonNode? args)

--- a/tests/CodeIndex.Tests/QueryCommandRunnerFilesTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerFilesTests.cs
@@ -1236,7 +1236,22 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
-    public void RunStatus_Explain_RejectsUnknownReadinessField()
+    public void RunStatus_Explain_PrintsVisibleStatusFieldDescriptionWithoutDatabase_Issue3936()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+            ["--explain", "path_case_sensitive"],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        Assert.Contains("Filesystem case sensitivity (path_case_sensitive)", stdout);
+        Assert.Contains("case-sensitive", stdout);
+        Assert.Contains("case-insensitive", stdout);
+        Assert.Contains("cdidx index <projectPath>", stdout);
+    }
+
+    [Fact]
+    public void RunStatus_Explain_RejectsUnknownStatusField()
     {
         var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
             ["--explain", "nope"],
@@ -1244,8 +1259,9 @@ public partial class QueryCommandRunnerTests
 
         Assert.Equal(CommandExitCodes.UsageError, exitCode);
         Assert.Equal(string.Empty, stdout);
-        Assert.Contains("unknown status readiness field", stderr);
+        Assert.Contains("unknown status field", stderr);
         Assert.Contains("fold_ready", stderr);
+        Assert.Contains("path_case_sensitive", stderr);
     }
 
     [Fact]
@@ -1266,6 +1282,7 @@ public partial class QueryCommandRunnerTests
         Assert.Contains("ASCII COLLATE NOCASE", json.GetProperty("degraded").GetString());
         Assert.Contains("cdidx backfill-fold", json.GetProperty("remediation").GetString());
         Assert.Contains("fold_ready", json.GetProperty("known_fields").EnumerateArray().Select(item => item.GetString()));
+        Assert.Contains("path_case_sensitive", json.GetProperty("known_fields").EnumerateArray().Select(item => item.GetString()));
     }
 
     [Theory]

--- a/tests/CodeIndex.Tests/QueryCommandRunnerFilesTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerFilesTests.cs
@@ -1251,6 +1251,20 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunStatus_Explain_PrintsHeadFreshnessFieldDescriptionWithoutDatabase_Issue3911()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+            ["--explain", "indexed_head_commit"],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        Assert.Contains("Legacy full-scan HEAD stamp (indexed_head_commit)", stdout);
+        Assert.Contains("full-scan-only", stdout);
+        Assert.Contains("indexed_head_sha", stdout);
+    }
+
+    [Fact]
     public void RunStatus_Explain_RejectsUnknownStatusField()
     {
         var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
@@ -1282,7 +1296,26 @@ public partial class QueryCommandRunnerTests
         Assert.Contains("ASCII COLLATE NOCASE", json.GetProperty("degraded").GetString());
         Assert.Contains("cdidx backfill-fold", json.GetProperty("remediation").GetString());
         Assert.Contains("fold_ready", json.GetProperty("known_fields").EnumerateArray().Select(item => item.GetString()));
+        Assert.Contains("indexed_head_sha", json.GetProperty("known_fields").EnumerateArray().Select(item => item.GetString()));
+        Assert.Contains("indexed_head_commit", json.GetProperty("known_fields").EnumerateArray().Select(item => item.GetString()));
         Assert.Contains("path_case_sensitive", json.GetProperty("known_fields").EnumerateArray().Select(item => item.GetString()));
+    }
+
+    [Fact]
+    public void RunStatus_ExplainJson_PrintsHeadFreshnessFieldDescription_Issue3911()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunStatus(
+            ["--explain", "indexed_head_sha", "--json"],
+            _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Equal(string.Empty, stderr);
+        using var document = ParseJsonOutput(stdout);
+        var json = document.RootElement;
+        Assert.Equal("indexed_head_sha", json.GetProperty("field").GetString());
+        Assert.Equal("Latest index HEAD stamp", json.GetProperty("label").GetString());
+        Assert.Contains("including incremental updates", json.GetProperty("ready").GetString());
+        Assert.Contains("indexed_head_commit", json.GetProperty("remediation").GetString());
     }
 
     [Theory]

--- a/tests/CodeIndex.Tests/QueryCommandRunnerMapTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerMapTests.cs
@@ -211,6 +211,62 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunMap_SectionsHotspotsJson_MapsSectionToReturnedProperties_Issue3938()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_map_hotspots_section");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            for (var i = 0; i < QueryCommandRunner.DefaultCompactSectionLimit + 2; i++)
+            {
+                TestProjectHelper.InsertIndexedFile(
+                    dbPath,
+                    $"src/module{i}/App{i}.cs",
+                    "csharp",
+                    $"namespace Module{i}; public class App{i} {{ public static void Main() {{ }} public void Run() {{ }} }}\n");
+            }
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunMap(
+                ["--db", dbPath, "--sections", "hotspots", "--compact", "--limit", "2", "--json"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+            var mappedProperties = json
+                .GetProperty("section_properties")
+                .GetProperty("hotspots")
+                .EnumerateArray()
+                .Select(item => item.GetString())
+                .ToArray();
+            var truncationProperties = json
+                .GetProperty("truncation")
+                .GetProperty("sections")
+                .EnumerateObject()
+                .Select(property => property.Name)
+                .ToArray();
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(["hotspots"], json.GetProperty("sections").EnumerateArray().Select(item => item.GetString()).ToArray());
+            Assert.Equal(["top_files", "symbol_rich_files", "reference_rich_files", "entrypoints"], mappedProperties);
+            Assert.True(json.TryGetProperty("top_files", out _));
+            Assert.True(json.TryGetProperty("symbol_rich_files", out _));
+            Assert.True(json.TryGetProperty("reference_rich_files", out _));
+            Assert.True(json.TryGetProperty("entrypoints", out _));
+            Assert.False(json.TryGetProperty("languages", out _));
+            Assert.False(json.TryGetProperty("modules", out _));
+            Assert.False(json.TryGetProperty("largest_files", out _));
+            Assert.Equal(
+                mappedProperties.OrderBy(property => property, StringComparer.Ordinal),
+                truncationProperties.OrderBy(property => property, StringComparer.Ordinal));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunMap_WithJsonIncludesWorkspaceMetadataForProjectDb()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_query_runner_map");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -105,7 +105,7 @@ public partial class QueryCommandRunnerTests
         Assert.Equal(string.Empty, stderr);
         using var document = ParseJsonOutput(stdout);
         Assert.Equal("error", document.RootElement.GetProperty("status").GetString());
-        Assert.Equal("unknown status readiness field `invalid`.", document.RootElement.GetProperty("message").GetString());
+        Assert.Equal("unknown status field `invalid`.", document.RootElement.GetProperty("message").GetString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Expand `status --explain` so visible status JSON fields such as `path_case_sensitive` can be explained, not only readiness fields.
- Add explanations for HEAD freshness fields, including the distinction between `indexed_head_sha` and legacy full-scan-only `indexed_head_commit`.
- Map `map --sections hotspots --json --compact` section filtering to the actual returned JSON properties, and expose section-to-property metadata for CLI JSON and MCP structured output.

## Validation

- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter 'FullyQualifiedName~RunStatus_Explain|FullyQualifiedName~RunMap_SectionsHotspotsJson_MapsSectionToReturnedProperties' -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll map --sections hotspots --json --compact --limit 2`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --explain indexed_head_sha --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll --help`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll --help-flags`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search --exact-substring --query "Explain one status readiness field" --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search --exact-substring --query "--explain <field> for readiness" --json`

## Documentation and Changelog

- Updated `README.md` English and Japanese status contract sections.
- Added bilingual changelog fragments:
  - `changelog.d/unreleased/3911.fixed.md`
  - `changelog.d/unreleased/3936.fixed.md`
  - `changelog.d/unreleased/3938.fixed.md`

## Review

- Ran adversarial review on `origin/main..HEAD`; it found stale readiness-only `--explain` help text, which is fixed in this branch.
- Separate `codex exec` review was attempted but interrupted because its sandbox could not read the local checkout and drifted to a different remote branch.

## Follow-up Candidates

- None.

Fixes #3911
Fixes #3936
Fixes #3938