### PR TITLE
Fix validate-config JSON handling

### DIFF
--- a/changelog.d/unreleased/3892.fixed.md
+++ b/changelog.d/unreleased/3892.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 3892
+affected:
+  - src/CodeIndex/Cli/CdidxConfigFile.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Cli/ConsoleUi.cs
+  - tests/CodeIndex.Tests/CdidxConfigFileTests.cs
+---
+
+## English
+
+- **`validate-config` no longer crashes when no config file exists (#3892)** — `validate-config --json` now accepts JSON mode, returns `valid: true` with `path: null` for no-config workspaces, and emits structured JSON errors for validation or argument failures in JSON mode.
+
+## 日本語
+
+- **config ファイルがない場合でも `validate-config` がクラッシュしなくなりました (#3892)** — `validate-config --json` は JSON mode を受け付け、config がない workspace では `valid: true` と `path: null` を返し、JSON mode での検証エラーや引数エラーは構造化 JSON error として出力します。

--- a/src/CodeIndex/Cli/CdidxConfigFile.cs
+++ b/src/CodeIndex/Cli/CdidxConfigFile.cs
@@ -628,7 +628,7 @@ internal static class CdidxConfigFile
                 jsonOptions,
                 result.Error ?? "configuration file validation failed.",
                 CommandExitCodes.UsageError,
-                $"fix or remove `{FileName}`.");
+                "fix or remove the discovered config file.");
         }
 
         var payload = new ValidateConfigJsonResult(true, result.Path);

--- a/src/CodeIndex/Cli/CdidxConfigFile.cs
+++ b/src/CodeIndex/Cli/CdidxConfigFile.cs
@@ -588,25 +588,53 @@ internal static class CdidxConfigFile
 
     internal static int RunValidate(string[] args, JsonSerializerOptions jsonOptions)
     {
-        if (args.Length > 0)
+        var wantsJson = args.Any(static arg => arg == "--json" || arg.StartsWith("--json=", StringComparison.Ordinal));
+        var json = false;
+        var remaining = new List<string>();
+        foreach (var arg in args)
         {
-            CommandErrorWriter.Write("validate-config does not accept positional arguments.", "run `cdidx validate-config` from the workspace whose config should be validated.");
-            return CommandExitCodes.UsageError;
+            if (arg == "--json")
+            {
+                json = true;
+                continue;
+            }
+
+            if (arg.StartsWith("--json=", StringComparison.Ordinal))
+            {
+                return CommandErrorWriter.WriteJsonOrHuman(
+                    true,
+                    jsonOptions,
+                    "validate-config supports --json only; --json=<format> is not supported.",
+                    CommandExitCodes.InvalidArgument,
+                    "use `cdidx validate-config --json`.");
+            }
+
+            remaining.Add(arg);
         }
+
+        if (remaining.Count > 0)
+            return CommandErrorWriter.WriteJsonOrHuman(
+                wantsJson,
+                jsonOptions,
+                "validate-config does not accept positional arguments.",
+                CommandExitCodes.UsageError,
+                "run `cdidx validate-config` from the workspace whose config should be validated.");
 
         var result = Load(Environment.CurrentDirectory, name => name == DisableEnvVar ? null : Environment.GetEnvironmentVariable(name));
         if (result.Failed)
         {
-            CommandErrorWriter.WriteStderr(result.Error);
-            return CommandExitCodes.UsageError;
+            return CommandErrorWriter.WriteJsonOrHuman(
+                json,
+                jsonOptions,
+                result.Error ?? "configuration file validation failed.",
+                CommandExitCodes.UsageError,
+                $"fix or remove `{FileName}`.");
         }
 
-        var payload = new Dictionary<string, object?>
-        {
-            ["valid"] = true,
-            ["path"] = result.Path,
-        };
-        Console.WriteLine(JsonSerializer.Serialize(payload, jsonOptions));
+        var payload = new ValidateConfigJsonResult(true, result.Path);
+        Console.WriteLine(JsonSerializer.Serialize(
+            payload,
+            CliJsonSerializerContextFactory.Create(jsonOptions).ValidateConfigJsonResult));
         return CommandExitCodes.Success;
     }
 

--- a/src/CodeIndex/Cli/ConsoleUi.cs
+++ b/src/CodeIndex/Cli/ConsoleUi.cs
@@ -107,7 +107,7 @@ public static class ConsoleUi
         ("status", "cdidx status [--db <path>] [--json] [--verbose] [--check[=workspace,fold,graph,issues,hotspot,csharp,sql,newer]] [--stale-after <duration>] [--explain <field>] [--log-path] [--config] [--check-updates]"),
         ("workspace", "cdidx workspace <list|status|use|current> [name] [--json]"),
         ("config", "cdidx config show [--json]"),
-        ("validate-config", "cdidx validate-config"),
+        ("validate-config", "cdidx validate-config [--json]"),
         ("doctor", "cdidx doctor [--json] [--redact-paths] [--env-inventory]"),
         ("db", "cdidx db integrity|--integrity-check [--db <path>] [--json]"),
         ("db", $"cdidx db schema [--type <table|index|trigger|view>] [--name <object>] [--limit <n<={DbCommandRunner.SchemaEntryLimit}>] [--max-sql-chars <n<={DbCommandRunner.SchemaSqlTextLimit}>] [--summary-only] [--include-internal|--exclude-internal] [--db <path>] [--json]"),

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -648,6 +648,11 @@ internal sealed record VersionInfoJsonResult(
     [property: JsonPropertyName("build_date")] string BuildDate,
     [property: JsonPropertyName("dirty")] string Dirty);
 
+internal sealed record ValidateConfigJsonResult(
+    [property: JsonPropertyName("valid")] bool Valid,
+    [property: JsonPropertyName("path")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.Never)] string? Path);
+
 [JsonSourceGenerationOptions(
     WriteIndented = false,
     PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
@@ -854,6 +859,7 @@ internal sealed record VersionInfoJsonResult(
 [JsonSerializable(typeof(UnusedSymbolResult))]
 [JsonSerializable(typeof(CodeIndex.Models.UpdateCheckResult))]
 [JsonSerializable(typeof(UpgradeJsonResult))]
+[JsonSerializable(typeof(ValidateConfigJsonResult))]
 [JsonSerializable(typeof(VacuumResult))]
 [JsonSerializable(typeof(VersionInfoJsonResult))]
 [JsonSerializable(typeof(WorkspaceListJsonResult))]

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -131,7 +131,7 @@ internal static partial class ProgramRunner
         // 環境変数を読む処理より先に `.cdidxrc.json` を読み込み、ログ位置 / debug / MCP ゲート
         // などが config を反映できるようにする (#1571)。スキーマ違反は黙って無視せず exit する。
         var configResult = CdidxConfigFile.Load(configStartDirectory ?? Environment.CurrentDirectory);
-        if (configResult.Failed && !IsConfigShowCommand(args))
+        if (configResult.Failed && !IsConfigShowCommand(args) && !IsValidateConfigCommand(args))
         {
             return CommandErrorWriter.Write(
                 StripErrorPrefix(configResult.Error ?? "configuration file validation failed."),
@@ -262,6 +262,26 @@ internal static partial class ProgramRunner
         return commandIndex + 1 < args.Count
                && string.Equals(args[commandIndex], "config", StringComparison.Ordinal)
                && string.Equals(args[commandIndex + 1], "show", StringComparison.Ordinal);
+    }
+
+    private static bool IsValidateConfigCommand(IReadOnlyList<string> args)
+    {
+        var commandIndex = 0;
+        while (commandIndex < args.Count && args[commandIndex].StartsWith("--", StringComparison.Ordinal))
+        {
+            var option = args[commandIndex];
+            var optionName = option.Split('=', 2)[0];
+            commandIndex++;
+            if (!option.Contains('=', StringComparison.Ordinal)
+                && TopLevelValueOptionNames.Contains(optionName)
+                && commandIndex < args.Count)
+            {
+                commandIndex++;
+            }
+        }
+
+        return commandIndex < args.Count
+               && string.Equals(args[commandIndex], "validate-config", StringComparison.Ordinal);
     }
 
     private static int RunTestExtractor(string[] args, JsonSerializerOptions jsonOptions)

--- a/tests/CodeIndex.Tests/CdidxConfigFileTests.cs
+++ b/tests/CodeIndex.Tests/CdidxConfigFileTests.cs
@@ -8,6 +8,8 @@ namespace CodeIndex.Tests;
 [Collection("SQLite pool sensitive")]
 public class CdidxConfigFileTests
 {
+    private readonly JsonSerializerOptions _jsonOptions = ProgramRunner.CreateDefaultJsonOptions();
+
     [Fact]
     public void LoadAndApply_NoFile_NoOp()
     {
@@ -23,6 +25,71 @@ public class CdidxConfigFileTests
             Assert.Empty(result.Settings);
         }
         finally { TestProjectHelper.DeleteDirectory(dir); }
+    }
+
+    [Fact]
+    public void RunValidate_NoConfigJson_ReturnsValidWithNullPath_Issue3892()
+    {
+        var dir = CreateTempDir();
+        var previous = Environment.CurrentDirectory;
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(dir, ".git"));
+            Environment.CurrentDirectory = dir;
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => CdidxConfigFile.RunValidate(["--json"], _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Empty(stderr);
+            using var document = JsonDocument.Parse(stdout);
+            var payload = document.RootElement;
+            Assert.True(payload.GetProperty("valid").GetBoolean());
+            Assert.Equal(JsonValueKind.Null, payload.GetProperty("path").ValueKind);
+        }
+        finally
+        {
+            Environment.CurrentDirectory = previous;
+            TestProjectHelper.DeleteDirectory(dir);
+        }
+    }
+
+    [Fact]
+    public void RunValidate_PositionalJson_ReturnsStructuredError_Issue3892()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() => CdidxConfigFile.RunValidate(["extra", "--json"], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.UsageError, exitCode);
+        Assert.Empty(stderr);
+        using var document = JsonDocument.Parse(stdout);
+        var payload = document.RootElement;
+        Assert.Equal("error", payload.GetProperty("status").GetString());
+        Assert.Contains("does not accept positional arguments", payload.GetProperty("message").GetString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RunValidate_InvalidConfigJson_ReturnsStructuredErrorThroughProgramRunner_Issue3892()
+    {
+        var dir = CreateTempDir();
+        var previous = Environment.CurrentDirectory;
+        try
+        {
+            File.WriteAllText(Path.Combine(dir, CdidxConfigFile.FileName), "{ invalid json");
+            Environment.CurrentDirectory = dir;
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => ProgramRunner.Run(["validate-config", "--json"], _jsonOptions, appVersion: "test"));
+
+            Assert.Equal(CommandExitCodes.UsageError, exitCode);
+            Assert.Empty(stderr);
+            using var document = JsonDocument.Parse(stdout);
+            var payload = document.RootElement;
+            Assert.Equal("error", payload.GetProperty("status").GetString());
+            Assert.Contains("Invalid JSON", payload.GetProperty("message").GetString(), StringComparison.Ordinal);
+        }
+        finally
+        {
+            Environment.CurrentDirectory = previous;
+            TestProjectHelper.DeleteDirectory(dir);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Fix `validate-config` JSON serialization by replacing the dictionary payload with a source-generated `ValidateConfigJsonResult`, preserving `path: null` for no-config workspaces.
- Accept `validate-config --json`, return structured JSON errors for JSON-mode argument and validation failures, and let `validate-config` handle invalid config files instead of being stopped by config preflight.
- Update CLI help usage and add the bilingual changelog fragment.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~CdidxConfigFileTests"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexCommandRunnerTests.SymbolExtractionWorker_CapturesStdoutAndForwardsStderrDiagnostics"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll validate-config --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll validate-config extra --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll validate-config --json=array`

`dotnet test` was also attempted for the full suite. It first reported `IndexCommandRunnerTests.SymbolExtractionWorker_CapturesStdoutAndForwardsStderrDiagnostics`; the targeted rerun passed, and the remaining full run was interrupted after a long no-output period.

## Documentation / Changelog
- Updated CLI help usage for `validate-config [--json]`.
- Added `changelog.d/unreleased/3892.fixed.md`.

## Review
- `codex exec` adversarial review and `codex exec review --base origin/main` were attempted but blocked because the nested Codex execution backend aborted shell commands with exit 134.
- Local adversarial review found one misleading validation hint; fixed in `fa544cccc`.
- No remaining blocking/actionable issues found.

## Follow-up Candidates
- None.

Fixes #3892
