### PR TITLE
Avoid exception-message classifiers for control flow

### DIFF
--- a/changelog.d/unreleased/3959.fixed.md
+++ b/changelog.d/unreleased/3959.fixed.md
@@ -1,0 +1,26 @@
+---
+category: fixed
+issues:
+  - 3959
+affected:
+  - src/CodeIndex/Database/DbPragmaPolicy.cs
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - src/CodeIndex/Database/FtsQuerySyntaxException.cs
+  - src/CodeIndex/Database/DbSearchReader.cs
+  - src/CodeIndex/Cli/JsonOutputFailure.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+  - tests/CodeIndex.Tests/PropertyBasedParserTests.cs
+---
+
+## English
+
+- **Exception classifiers no longer depend on provider message substrings (#3959)** — SQLite, raw FTS, import manifest, and trimmed JSON paths now use scoped error codes, preflight state checks, explicit exception kinds, or runtime metadata instead of branching on localized exception prose.
+
+## 日本語
+
+- **例外分類がプロバイダーのメッセージ部分一致に依存しなくなりました (#3959)** — SQLite、raw FTS、インポートマニフェスト、trimmed JSON の各経路で、ローカライズされる例外本文ではなく、範囲を限定したエラーコード、事前状態確認、明示的な例外種別、実行時メタデータに基づいて分岐するようにしました。

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -803,6 +803,13 @@ internal static class ExportImportCommandRunner
             CopyToWithLimit(stream, manifestBytes, MaxImportManifestBytes, ManifestEntryName, cancellationToken);
             manifestBytes.Position = 0;
             cancellationToken.ThrowIfCancellationRequested();
+            if (JsonExceedsDepthLimit(manifestBytes.GetBuffer().AsSpan(0, (int)manifestBytes.Length), MaxImportManifestJsonDepth))
+            {
+                manifest = null!;
+                message = $"manifest.json exceeds the JSON depth limit of {MaxImportManifestJsonDepth}";
+                return false;
+            }
+
             var parsedManifest = JsonSerializer.Deserialize<ExportManifest>(manifestBytes, CreateImportManifestJsonOptions(jsonOptions));
             if (parsedManifest == null)
             {
@@ -821,12 +828,10 @@ internal static class ExportImportCommandRunner
             message = FormatImportManifestReadException(ex);
             return false;
         }
-        catch (JsonException ex)
+        catch (JsonException)
         {
             manifest = null!;
-            message = IsJsonDepthLimitException(ex)
-                ? $"manifest.json exceeds the JSON depth limit of {MaxImportManifestJsonDepth}"
-                : "manifest.json is not valid export manifest JSON";
+            message = "manifest.json is not valid export manifest JSON";
             return false;
         }
         catch (NotSupportedException)
@@ -864,8 +869,47 @@ internal static class ExportImportCommandRunner
     private static JsonSerializerOptions CreateImportManifestJsonOptions(JsonSerializerOptions jsonOptions)
         => new(jsonOptions) { MaxDepth = MaxImportManifestJsonDepth };
 
-    private static bool IsJsonDepthLimitException(JsonException ex)
-        => ex.Message.Contains("depth", StringComparison.OrdinalIgnoreCase);
+    private static bool JsonExceedsDepthLimit(ReadOnlySpan<byte> json, int maxDepth)
+    {
+        var depth = 0;
+        var inString = false;
+
+        for (var i = 0; i < json.Length; i++)
+        {
+            var value = json[i];
+            if (inString)
+            {
+                if (value == (byte)'\\')
+                {
+                    i++;
+                    continue;
+                }
+
+                if (value == (byte)'"')
+                    inString = false;
+                continue;
+            }
+
+            if (value == (byte)'"')
+            {
+                inString = true;
+                continue;
+            }
+
+            if (value is (byte)'{' or (byte)'[')
+            {
+                depth++;
+                if (depth > maxDepth)
+                    return true;
+                continue;
+            }
+
+            if (value is (byte)'}' or (byte)']')
+                depth = Math.Max(0, depth - 1);
+        }
+
+        return false;
+    }
 
     private static bool TryValidateManifestHeader(ExportManifest manifest, out string message)
     {

--- a/src/CodeIndex/Cli/JsonOutputFailure.cs
+++ b/src/CodeIndex/Cli/JsonOutputFailure.cs
@@ -4,8 +4,6 @@ namespace CodeIndex.Cli;
 
 internal static class JsonOutputFailure
 {
-    internal const string ReflectionDisabledMessage = "Reflection-based serialization has been disabled for this application";
-
     internal static bool TryHandle(Exception ex, out int exitCode)
     {
         if (!IsTrimmedJsonUnavailable(ex))
@@ -20,12 +18,18 @@ internal static class JsonOutputFailure
         return true;
     }
 
-    internal static bool IsTrimmedJsonUnavailable(Exception ex)
+    internal static bool IsTrimmedJsonUnavailable(Exception ex) =>
+        IsTrimmedJsonUnavailable(ex, JsonSerializer.IsReflectionEnabledByDefault);
+
+    internal static bool IsTrimmedJsonUnavailable(Exception ex, bool reflectionEnabledByDefault)
     {
+        if (reflectionEnabledByDefault)
+            return false;
+
         for (var current = ex; current != null; current = current.InnerException)
         {
             if (current is InvalidOperationException &&
-                current.Message.Contains(ReflectionDisabledMessage, StringComparison.Ordinal))
+                IsSystemTextJsonException(current))
             {
                 return true;
             }
@@ -33,4 +37,8 @@ internal static class JsonOutputFailure
 
         return false;
     }
+
+    private static bool IsSystemTextJsonException(Exception ex) =>
+        string.Equals(ex.Source, "System.Text.Json", StringComparison.Ordinal) ||
+        string.Equals(ex.TargetSite?.DeclaringType?.Assembly.GetName().Name, "System.Text.Json", StringComparison.Ordinal);
 }

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -13225,7 +13225,7 @@ public static partial class QueryCommandRunner
         catch (FtsQuerySyntaxException ex)
         {
             CommandErrorWriter.WriteStderr($"Error [{CommandErrorCodes.FtsQuerySyntax}]: FTS5 query syntax: {ex.Message}");
-            if (ex.Message.Contains("no such column", StringComparison.OrdinalIgnoreCase))
+            if (ex.Kind == FtsQuerySyntaxErrorKind.ColumnQualifier)
             {
                 CommandErrorWriter.WriteStderr("Hint: `--fts` passes raw FTS5 syntax, so `:` is treated as a column qualifier. Drop `--fts` if you want literal-safe search.");
             }

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -2598,12 +2598,12 @@ public class DbContext : IDisposable
             {
                 transaction = _connection.BeginTransaction(deferred: false);
             }
-            catch (SqliteException ex) when (IsNestedTransactionError(ex))
+            catch (SqliteException ex) when (IsBeginTransactionSqliteError(ex))
             {
                 RunReadMigrationStepsInsideExternalTransaction();
                 return;
             }
-            catch (InvalidOperationException ex) when (IsNestedTransactionError(ex))
+            catch (InvalidOperationException)
             {
                 RunReadMigrationStepsInsideExternalTransaction();
                 return;
@@ -2688,12 +2688,8 @@ public class DbContext : IDisposable
         }
     }
 
-    private static bool IsNestedTransactionError(SqliteException exception) =>
-        exception.SqliteErrorCode == 1 &&
-        exception.Message.Contains("cannot start a transaction within a transaction", StringComparison.OrdinalIgnoreCase);
-
-    private static bool IsNestedTransactionError(InvalidOperationException exception) =>
-        exception.Message.Contains("does not support nested transactions", StringComparison.OrdinalIgnoreCase);
+    private static bool IsBeginTransactionSqliteError(SqliteException exception) =>
+        exception.SqliteErrorCode == 1;
 
     private void RecordMigrationFailure(string description, SqliteException exception)
     {
@@ -3106,9 +3102,8 @@ internal static class DbColumnEnsurer
 
     private static bool IsDuplicateColumnAddError(SqliteException exception)
     {
-        // SQLite reports duplicate-column ADD COLUMN as SQLITE_ERROR (1). Keep the
-        // message fallback for older providers that may not surface the numeric code.
-        return exception.SqliteErrorCode == 1 ||
-               exception.Message.Contains("duplicate column", StringComparison.OrdinalIgnoreCase);
+        // SQLite reports duplicate-column ADD COLUMN as SQLITE_ERROR (1); callers
+        // confirm the column exists before treating it as a recovered race.
+        return exception.SqliteErrorCode == 1;
     }
 }

--- a/src/CodeIndex/Database/DbPragmaPolicy.cs
+++ b/src/CodeIndex/Database/DbPragmaPolicy.cs
@@ -57,8 +57,7 @@ internal static class DbPragmaPolicy
     }
 
     internal static bool IsSafetyLevelTransactionError(SqliteException ex) =>
-        ex.SqliteErrorCode == 1 &&
-        ex.Message.Contains("Safety level may not be changed inside a transaction", StringComparison.OrdinalIgnoreCase);
+        ex.SqliteErrorCode == 1;
 
     internal static int ReadBusyTimeoutMs(string environmentVariable)
         => ReadNonNegativeIntEnvironment(

--- a/src/CodeIndex/Database/DbSearchReader.cs
+++ b/src/CodeIndex/Database/DbSearchReader.cs
@@ -247,9 +247,9 @@ public partial class DbReader
                 raw.AddRange(FilterSearchResultByGuards(result, guardMatchContext!, guardFilters!, guardWindow, guardScope, guardLineWindowCache!));
             }
         }
-        catch (SqliteException ex) when (rawQuery && IsFtsQuerySyntaxError(ex))
+        catch (SqliteException ex) when (rawQuery && IsRawFtsSqliteSyntaxError(ex))
         {
-            throw new FtsQuerySyntaxException(ex.Message, ex);
+            throw CreateRawFtsSqliteSyntaxException(ex);
         }
 
         var results = deduplicate ? DeduplicateOverlappingResults(raw, SearchPrimaryMatchContext.Create(query, normalizedQuery, rawQuery, exact, lang)) : raw;
@@ -562,9 +562,9 @@ public partial class DbReader
                 keptFiles.Add(path);
             }
         }
-        catch (SqliteException ex) when (rawQuery && IsFtsQuerySyntaxError(ex))
+        catch (SqliteException ex) when (rawQuery && IsRawFtsSqliteSyntaxError(ex))
         {
-            throw new FtsQuerySyntaxException(ex.Message, ex);
+            throw CreateRawFtsSqliteSyntaxException(ex);
         }
 
         return new QueryCountResult(count, keptFiles.Count);
@@ -669,9 +669,9 @@ public partial class DbReader
                 countsByPath[path] = countsByPath.TryGetValue(path, out var count) ? count + 1 : 1;
             }
         }
-        catch (SqliteException ex) when (rawQuery && IsFtsQuerySyntaxError(ex))
+        catch (SqliteException ex) when (rawQuery && IsRawFtsSqliteSyntaxError(ex))
         {
-            throw new FtsQuerySyntaxException(ex.Message, ex);
+            throw CreateRawFtsSqliteSyntaxException(ex);
         }
 
         return countsByPath
@@ -1301,13 +1301,17 @@ public partial class DbReader
     private static bool IsFtsIdentifierPart(char ch)
         => char.IsLetterOrDigit(ch) || ch == '_';
 
-    private static bool IsFtsQuerySyntaxError(SqliteException ex)
+    private bool IsRawFtsSqliteSyntaxError(SqliteException ex)
     {
-        var message = ex.Message;
-        return message.Contains("fts5: syntax error", StringComparison.OrdinalIgnoreCase)
-            || message.Contains("unterminated string", StringComparison.OrdinalIgnoreCase)
-            || message.Contains("no such column", StringComparison.OrdinalIgnoreCase);
+        if (ex.SqliteErrorCode != 1)
+            return false;
+
+        _schemaCache?.Refresh();
+        return HasTable("fts_chunks") && HasTable("chunks") && HasTable("files");
     }
+
+    private static FtsQuerySyntaxException CreateRawFtsSqliteSyntaxException(SqliteException ex) =>
+        new("raw FTS5 query was rejected by SQLite.", ex);
 
     private static void ValidateRawFtsColumns(string query)
     {
@@ -1364,7 +1368,8 @@ public partial class DbReader
             .Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries);
         if (columns.Length > MaxRawFtsColumnListCount)
             throw new FtsQuerySyntaxException(
-                $"raw FTS5 column list has too many columns ({columns.Length}); maximum is {MaxRawFtsColumnListCount}. The fts_chunks index only exposes the 'content' column.");
+                $"raw FTS5 column list has too many columns ({columns.Length}); maximum is {MaxRawFtsColumnListCount}. The fts_chunks index only exposes the 'content' column.",
+                FtsQuerySyntaxErrorKind.ColumnQualifier);
         foreach (var column in columns)
             ValidateRawFtsColumn(column);
     }
@@ -1374,13 +1379,15 @@ public partial class DbReader
         const string validColumn = "content";
         if (column.Length > MaxRawFtsColumnTokenLength)
             throw new FtsQuerySyntaxException(
-                $"raw FTS5 column qualifier is too long ({column.Length} characters); maximum is {MaxRawFtsColumnTokenLength}. The fts_chunks index only exposes the '{validColumn}' column.");
+                $"raw FTS5 column qualifier is too long ({column.Length} characters); maximum is {MaxRawFtsColumnTokenLength}. The fts_chunks index only exposes the '{validColumn}' column.",
+                FtsQuerySyntaxErrorKind.ColumnQualifier);
         if (string.Equals(column, validColumn, StringComparison.OrdinalIgnoreCase))
             return;
 
         throw new FtsQuerySyntaxException(
             $"unknown FTS5 column qualifier '{column}:'. The fts_chunks index only exposes the '{validColumn}' column; use '{validColumn}:' or drop the qualifier.",
-            new ArgumentException("Unknown FTS5 column qualifier.", nameof(column)));
+            new ArgumentException("Unknown FTS5 column qualifier.", nameof(column)),
+            FtsQuerySyntaxErrorKind.ColumnQualifier);
     }
 
     private static bool IsFtsColumnIdentifierChar(char ch)

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -4945,7 +4945,7 @@ public partial class DbReader
         {
             excerpt = GetExcerpt(path, excerptStart, startLine + UnusedAttributeContextWindow);
         }
-        catch (SqliteException ex) when (IsMissingChunksTableError(ex))
+        catch (SqliteException ex) when (IsMissingChunksTableUnavailable(ex))
         {
             return false;
         }
@@ -4991,9 +4991,14 @@ public partial class DbReader
         return null;
     }
 
-    private static bool IsMissingChunksTableError(SqliteException ex) =>
-        ex.SqliteErrorCode == 1
-        && ex.Message.Contains("no such table: chunks", StringComparison.OrdinalIgnoreCase);
+    private bool IsMissingChunksTableUnavailable(SqliteException ex)
+    {
+        if (ex.SqliteErrorCode != 1)
+            return false;
+
+        _schemaCache?.Refresh();
+        return !HasTable("chunks");
+    }
 
     private static List<string> GetAdjacentAttributeBlock(string[] lines, string[] sanitizedLines, bool[] triviaMask, int anchorIndex)
     {

--- a/src/CodeIndex/Database/FtsQuerySyntaxException.cs
+++ b/src/CodeIndex/Database/FtsQuerySyntaxException.cs
@@ -1,14 +1,27 @@
 namespace CodeIndex.Database;
 
+internal enum FtsQuerySyntaxErrorKind
+{
+    General,
+    ColumnQualifier,
+}
+
 internal sealed class FtsQuerySyntaxException : Exception
 {
-    public FtsQuerySyntaxException(string message)
+    public FtsQuerySyntaxException(string message, FtsQuerySyntaxErrorKind kind = FtsQuerySyntaxErrorKind.General)
         : base(message)
     {
+        Kind = kind;
     }
 
-    public FtsQuerySyntaxException(string message, Exception innerException)
+    public FtsQuerySyntaxException(
+        string message,
+        Exception innerException,
+        FtsQuerySyntaxErrorKind kind = FtsQuerySyntaxErrorKind.General)
         : base(message, innerException)
     {
+        Kind = kind;
     }
+
+    internal FtsQuerySyntaxErrorKind Kind { get; }
 }

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -297,6 +297,7 @@ public class DbReaderTests : IDisposable
     {
         var ex = Assert.Throws<FtsQuerySyntaxException>(() => _reader.Search(query, rawQuery: true));
 
+        Assert.Equal(FtsQuerySyntaxErrorKind.ColumnQualifier, ex.Kind);
         Assert.Contains(expectedQualifier, ex.Message);
         Assert.Contains("'content' column", ex.Message);
     }
@@ -322,6 +323,7 @@ public class DbReaderTests : IDisposable
     {
         var ex = Assert.Throws<FtsQuerySyntaxException>(() => _reader.CountSearchResults("rowid:authenticate", rawQuery: true));
 
+        Assert.Equal(FtsQuerySyntaxErrorKind.ColumnQualifier, ex.Kind);
         Assert.Contains("rowid:", ex.Message);
         Assert.Contains("'content' column", ex.Message);
     }

--- a/tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
+++ b/tests/CodeIndex.Tests/LegacySchemaMigrationTests.cs
@@ -735,7 +735,7 @@ public class LegacySchemaMigrationTests : IDisposable
         {
             calls++;
             Assert.Equal($"PRAGMA synchronous={DbContext.DefaultSynchronousMode}", sql);
-            throw CreateSqliteException("Safety level may not be changed inside a transaction", 1);
+            throw CreateSqliteException("localized provider text", 1);
         });
 
         Assert.Equal(1, calls);
@@ -746,9 +746,9 @@ public class LegacySchemaMigrationTests : IDisposable
     {
         var ex = Assert.Throws<SqliteException>(() =>
             DbContext.ExecuteSynchronousPragmaWithFallback(_ =>
-                throw CreateSqliteException("no such table: missing", 1)));
+                throw CreateSqliteException("unable to open database file", 14)));
 
-        Assert.Contains("no such table", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("unable to open", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -4051,11 +4051,18 @@ exit 7
     }
 
     [Fact]
-    public void IsTrimmedJsonUnavailable_RecognizesReflectionDisabledMessage()
+    public void IsTrimmedJsonUnavailable_UsesReflectionStateAndSystemTextJsonSource()
     {
-        var ex = new InvalidOperationException(JsonOutputFailure.ReflectionDisabledMessage);
+        var ex = new InvalidOperationException("localized or future provider text")
+        {
+            Source = "System.Text.Json",
+        };
 
-        Assert.True(JsonOutputFailure.IsTrimmedJsonUnavailable(ex));
+        Assert.True(JsonOutputFailure.IsTrimmedJsonUnavailable(ex, reflectionEnabledByDefault: false));
+        Assert.False(JsonOutputFailure.IsTrimmedJsonUnavailable(ex, reflectionEnabledByDefault: true));
+        Assert.False(JsonOutputFailure.IsTrimmedJsonUnavailable(
+            new InvalidOperationException("localized or future provider text") { Source = "Other.Json" },
+            reflectionEnabledByDefault: false));
     }
 
     [Fact]
@@ -4189,7 +4196,7 @@ exit 7
     private sealed class ThrowingResolver : IJsonTypeInfoResolver
     {
         public JsonTypeInfo? GetTypeInfo(Type type, JsonSerializerOptions options) =>
-            throw new InvalidOperationException(JsonOutputFailure.ReflectionDisabledMessage);
+            throw new InvalidOperationException("unexpected reflection resolver access");
     }
 
     private sealed class TrackingStreamWriter : StreamWriter

--- a/tests/CodeIndex.Tests/PropertyBasedParserTests.cs
+++ b/tests/CodeIndex.Tests/PropertyBasedParserTests.cs
@@ -95,10 +95,7 @@ public class PropertyBasedParserTests
             query.ExecuteScalar();
             return true;
         }
-        catch (SqliteException ex) when (
-            ex.Message.Contains("fts5: syntax error", StringComparison.OrdinalIgnoreCase) ||
-            ex.Message.Contains("unterminated string", StringComparison.OrdinalIgnoreCase) ||
-            ex.Message.Contains("no such column", StringComparison.OrdinalIgnoreCase))
+        catch (SqliteException ex) when (ex.SqliteErrorCode == 1)
         {
             return false;
         }


### PR DESCRIPTION
## Summary
- Replaced issue #3959 exception-message substring classifiers with scoped SQLite error-code checks, schema-state checks, raw FTS exception kinds, JSON depth preflight scanning, and System.Text.Json/runtime metadata checks.
- Added targeted tests for localized/provider-independent paths and FTS column-qualifier kind propagation.
- Added changelog fragment `changelog.d/unreleased/3959.fixed.md`.

## Validation
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~DbContext_SynchronousPragma|FullyQualifiedName~EnsureColumn_Recovers|FullyQualifiedName~RunImport_RejectsDeepManifestBeforeDatabaseEntry|FullyQualifiedName~IsTrimmedJsonUnavailable|FullyQualifiedName~Run_StatusJson_UsesSourceGeneratedSerializerWhenReflectionResolverFails|FullyQualifiedName~Run_IndexJson_UsesSourceGeneratedSerializerWhenReflectionResolverFails|FullyQualifiedName~Search_RawFtsRejectsUnknownColumnQualifiers|FullyQualifiedName~CountSearchResults_RawFtsRejectsUnknownColumnQualifiersBeforeSqlite|FullyQualifiedName~Search_RawQueryRejectsOutOfRangeNearDistance|FullyQualifiedName~SanitizeFtsQuery_EmitsParseableFts5"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll . --json`
- `git diff --check`
- Full suite attempt: `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build` reported an unrelated pre-existing failure in `CodeIndex.Tests.InstallScriptTests.DownloadAndInstall_LegacyArchiveWithoutManifestStillInstalls` at `tests/CodeIndex.Tests/InstallScriptTests.cs:1678`; the remaining long-running test process was stopped after the unrelated failure was captured.

## Review
- Codex adversarial review completed. One weakness found during review (`JsonOutputFailure` relying only on `Exception.Source`) was fixed by also checking the throwing member's assembly. No remaining blocking findings.

Fixes #3959