### PR TITLE
Fix deps filtering and limits

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1470,8 +1470,8 @@ same source location.
 | `--source-only` | `search` | Shorthand for `--audit-scope source` on ad hoc and named searches. Use it for implementation-code searches without selecting a recipe. |
 | `--show-excluded` | `search --recipe <name>` | Include `scope.excluded_diagnostics` in recipe output so broad audits can see which default include patterns, default exclusions, user exclusions, and test filtering were applied. |
 | `--list-recipes` | `search` | List available search audit recipes with query text, recommended labels, exact-match mode, false-positive guidance, query-specific audit taxonomy metadata, supported formats, filter support, and limit semantics. Add `--query <filter>` to filter by recipe/query names, query text, labels, severity, path metadata, or descriptions. |
-| `--exclude-path <glob>` | `search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `validate` | Exclude glob-style path patterns. `*` and `?` are wildcards (repeatable) |
-| `--exclude-tests` | `search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `validate` | Exclude likely test files and prefer production code |
+| `--exclude-path <glob>` | `search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `validate`, `deps` | Exclude glob-style path patterns. `*` and `?` are wildcards (repeatable) |
+| `--exclude-tests` | `search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `validate`, `deps` | Exclude likely test files and prefer production code. For `deps`, source and target files are both filtered. |
 | `--exclude-comments` | `search` | Exclude matches whose only retained origin is a comment |
 | `--exclude-strings` | `search` | Exclude matches whose only retained origin is a string literal, regex literal, or CLI help text |
 | `--exclude-fixtures` | `search` | Exclude matches whose only retained facet is a test fixture string |
@@ -4111,8 +4111,8 @@ raw match density を正確に測る、といった理由で全 raw chunk hit �
 | `--source-only` | `search` | ad hoc / named search で `--audit-scope source` を指定する shorthand。recipe を選ばずに実装コードだけを検索したい場合に使う。 |
 | `--show-excluded` | `search --recipe <name>` | recipe output に `scope.excluded_diagnostics` を含め、広い audit で default include pattern、default exclusion、user exclusion、test filter の適用状況を確認できるようにする。 |
 | `--list-recipes` | `search` | 利用可能な search audit recipe を query text、推奨 label、exact-match mode、false-positive guidance、query 固有の audit taxonomy metadata、対応 format、filter support、limit semantics 付きで一覧表示する。`--query <filter>` を追加すると recipe/query 名、query text、label、severity、path metadata、説明で絞り込める。 |
-| `--exclude-path <glob>` | `search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `validate` | glob 形式のパスパターンを除外する。`*` と `?` がワイルドカード。繰り返し指定可 |
-| `--exclude-tests` | `search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `validate` | テストらしいパスを除外し、本番コードを優先 |
+| `--exclude-path <glob>` | `search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `validate`, `deps` | glob 形式のパスパターンを除外する。`*` と `?` がワイルドカード。繰り返し指定可 |
+| `--exclude-tests` | `search`, `definition`, `references`, `callers`, `callees`, `symbols`, `files`, `find`, `map`, `inspect`, `validate`, `deps` | テストらしいパスを除外し、本番コードを優先。`deps` では source file と target file の両方をフィルタする。 |
 | `--exclude-comments` | `search` | 保持される一致 origin がコメントだけの検索結果を除外する |
 | `--exclude-strings` | `search` | 保持される一致 origin が文字列リテラル、正規表現リテラル、CLI ヘルプ文言だけの検索結果を除外する |
 | `--exclude-fixtures` | `search` | 保持される facet がテスト fixture 文字列だけの検索結果を除外する |

--- a/changelog.d/unreleased/3895.fixed.md
+++ b/changelog.d/unreleased/3895.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 3895
+affected:
+  - src/CodeIndex/Database/DbReader.Dependencies.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **`deps --exclude-tests` now filters both sides of dependency edges (#3895)** — file-dependency queries now remove likely test-like source and target paths, and `deps` limits symbol sampling to displayed edges so limited queries stay responsive.
+
+## 日本語
+
+- **`deps --exclude-tests` が依存エッジの両端をフィルタするようになりました (#3895)** — ファイル依存クエリは source path と target path の両方からテストらしいパスを除外し、`deps` は表示対象のエッジだけを symbol sampling することで limit 付きクエリの応答性を保ちます。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -25,7 +25,7 @@ public static partial class QueryCommandRunner
     internal const int DefaultCompactSectionLimit = 5;
     private const int MaxNamedSearchQueryNameLength = 128;
     internal const int DefaultImpactLimit = 50;
-    internal const int DefaultDependencyCycleGraphLimit = 1_000;
+    internal const int DefaultDependencyCycleGraphLimit = 50;
     internal const int MaxWorkspaceDependencyDatabaseCount = 8;
     internal const int MaxWorkspaceDependencyDatabasePairCount = MaxWorkspaceDependencyDatabaseCount * (MaxWorkspaceDependencyDatabaseCount - 1);
     internal const int FindAllCandidateFileLimit = 4096;

--- a/src/CodeIndex/Database/DbReader.Dependencies.cs
+++ b/src/CodeIndex/Database/DbReader.Dependencies.cs
@@ -261,8 +261,8 @@ public partial class DbReader
             for (int i = 0; i < excludePathPatterns.Count; i++)
                 sql += $" AND {sourceFilterAlias}.path NOT LIKE @excludePath{i} ESCAPE '\\'";
         }
-        if (!reverse && excludeTests)
-            sql += $" AND NOT {TestPathCondition.Replace("f.path", $"{sourceFilterAlias}.path")}";
+        if (excludeTests)
+            sql += $" AND NOT {DependencyTestPathCondition($"{sourceFilterAlias}.path")}";
         sql += @"
                 GROUP BY src.id, src.path, src.lang, r.symbol_name, " + contextSql + @", r.container_name, r.line, r.column_number, logical_reference_kind
             ),
@@ -372,8 +372,8 @@ public partial class DbReader
             for (int i = 0; i < excludePathPatterns.Count; i++)
                 sql += $" AND {targetFilterAlias}.path NOT LIKE @excludePath{i} ESCAPE '\\'";
         }
-        if (reverse && excludeTests)
-            sql += $" AND NOT {TestPathCondition.Replace("f.path", $"{targetFilterAlias}.path")}";
+        if (excludeTests)
+            sql += $" AND NOT {DependencyTestPathCondition($"{targetFilterAlias}.path")}";
         sql += @"
                 GROUP BY dst.path, dst.lang, " + targetLogicalSymbolNameExpr + @", " + targetLogicalSymbolSegmentCountExpr + @"
             ),
@@ -494,9 +494,22 @@ public partial class DbReader
                 FROM edges
                 GROUP BY source_path, target_path
             ),
+            limited_edge_totals AS (
+                SELECT source_path,
+                       target_path,
+                       reference_count
+                FROM edge_totals
+                ORDER BY reference_count DESC, source_path, target_path
+                LIMIT @limit
+            ),
             distinct_edge_symbols AS (
-                SELECT DISTINCT source_path, target_path, symbol_name
+                SELECT DISTINCT edges.source_path,
+                                edges.target_path,
+                                edges.symbol_name
                 FROM edges
+                JOIN limited_edge_totals
+                  ON limited_edge_totals.source_path = edges.source_path
+                 AND limited_edge_totals.target_path = edges.target_path
             ),
             ranked_edge_symbols AS (
                 SELECT source_path,
@@ -505,17 +518,16 @@ public partial class DbReader
                        ROW_NUMBER() OVER (PARTITION BY source_path, target_path ORDER BY symbol_name) AS symbol_rank
                 FROM distinct_edge_symbols
             )
-            SELECT edge_totals.source_path,
-                   edge_totals.target_path,
-                   edge_totals.reference_count,
+            SELECT limited_edge_totals.source_path,
+                   limited_edge_totals.target_path,
+                   limited_edge_totals.reference_count,
                    COALESCE(GROUP_CONCAT(CASE WHEN ranked_edge_symbols.symbol_rank <= @symbolSampleLimit THEN ranked_edge_symbols.symbol_name END), '') AS symbols
-            FROM edge_totals
+            FROM limited_edge_totals
             LEFT JOIN ranked_edge_symbols
-              ON ranked_edge_symbols.source_path = edge_totals.source_path
-             AND ranked_edge_symbols.target_path = edge_totals.target_path
-            GROUP BY edge_totals.source_path, edge_totals.target_path, edge_totals.reference_count
-            ORDER BY edge_totals.reference_count DESC, edge_totals.source_path, edge_totals.target_path
-            LIMIT @limit";
+              ON ranked_edge_symbols.source_path = limited_edge_totals.source_path
+             AND ranked_edge_symbols.target_path = limited_edge_totals.target_path
+            GROUP BY limited_edge_totals.source_path, limited_edge_totals.target_path, limited_edge_totals.reference_count
+            ORDER BY limited_edge_totals.reference_count DESC, limited_edge_totals.source_path, limited_edge_totals.target_path";
 
         cmd.CommandText = sql;
         if (lang != null)
@@ -547,6 +559,9 @@ public partial class DbReader
         }
         return results;
     }
+
+    private static string DependencyTestPathCondition(string pathSql)
+        => "(" + TestPathCondition.Replace("f.path", pathSql) + $" OR lower({pathSql}) LIKE '%.test%/%')";
 
     private void AppendDependencyGeneratedFilter(ref string sql, string fileAlias)
     {

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -4233,6 +4233,42 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunDeps_ExcludeTestsFiltersSourceAndTargetEdges_Issue3895()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_deps_exclude_tests_targets");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            InsertFileWithReferences(dbPath, "src/Caller.cs", ["ProductionTarget", "TestTarget", "ToolTestTarget"]);
+            InsertFileWithReference(dbPath, "tests/TestCaller.cs", "ProductionTarget");
+            InsertFileWithReference(dbPath, "tools/CodeIndex.TestTelemetry/ToolCaller.cs", "ProductionTarget");
+            InsertFileWithSymbol(dbPath, "src/ProductionTarget.cs", "ProductionTarget");
+            InsertFileWithSymbol(dbPath, "tests/TestTarget.cs", "TestTarget");
+            InsertFileWithSymbol(dbPath, "tools/CodeIndex.TestTelemetry/Program.cs", "ToolTestTarget");
+            MarkDependencyGraphReady(dbPath);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunDeps(
+                ["--db", dbPath, "--json", "--exclude-tests", "--limit", "10", "--lang", "csharp"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var edge = Assert.Single(document.RootElement.GetProperty("edges").EnumerateArray());
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(1, document.RootElement.GetProperty("count").GetInt32());
+            Assert.Equal("src/Caller.cs", edge.GetProperty("source_path").GetString());
+            Assert.Equal("src/ProductionTarget.cs", edge.GetProperty("target_path").GetString());
+            Assert.DoesNotContain("tests/", stdout);
+            Assert.DoesNotContain("CodeIndex.TestTelemetry", stdout);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunDeps_ZeroJson_StaleSqlGraphContractIncludesDegradedStateWhenSqlScopeIsEmpty()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_deps_zero_sql_graph_contract");


### PR DESCRIPTION
## Summary

- Filter `deps --exclude-tests` on both source and target paths, including `.Test` tool paths.
- Limit dependency symbol sampling to displayed edges and reduce the default cycle graph budget so limited queries remain responsive.

## Validation

- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunDeps" -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll deps --json --limit 30 --exclude-tests`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll deps --cycles --json --limit 100 --path src/ --exclude-tests`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Full `dotnet test CodeIndex.sln -p:UseSharedCompilation=false` was attempted but interrupted after roughly 10 minutes with no failure output.

## Documentation and Changelog

- Updated `USER_GUIDE.md`.
- Added `changelog.d/unreleased/3895.fixed.md`.

## Review

- Adversarial review found and fixed a source-candidate limiting risk; the corrected diff has no blocking or actionable findings.
- Separate `codex exec` review attempts were blocked because the nested execution environment exited before command output.

Fixes #3895