### PR TITLE
[codex] Fix MaxValue limits and MCP cleanup

### DIFF
--- a/changelog.d/unreleased/3964.fixed.md
+++ b/changelog.d/unreleased/3964.fixed.md
@@ -1,0 +1,24 @@
+---
+category: fixed
+issues:
+  - 3964
+affected:
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Cli/BoundedHttpContentReader.cs
+  - src/CodeIndex/Database/MaintenanceGuidanceBuilder.cs
+  - src/CodeIndex/Mcp/RateLimiter.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+  - tests/CodeIndex.Tests/BoundedHttpContentReaderTests.cs
+  - tests/CodeIndex.Tests/DatabaseTests.cs
+  - tests/CodeIndex.Tests/RateLimiterTests.cs
+---
+
+## English
+
+- **MaxValue sentinels no longer expand fetches or diagnostics into unbounded work (#3964)** — MCP and CLI over-fetch helpers now clamp to documented result limits, bounded HTTP reads avoid huge declared-length preallocation, overflowed maintenance byte estimates report unknown, and rate-limit diagnostics cap huge intervals.
+
+## 日本語
+
+- **MaxValue sentinel が fetch や diagnostics を無制限相当に広げないようにしました (#3964)** — MCP / CLI の over-fetch helper は documented result limit に clamp し、bounded HTTP read は巨大 declared length で事前確保せず、maintenance byte estimate の overflow は unknown として扱い、rate-limit diagnostics は巨大 interval を上限値で丸めます。

--- a/changelog.d/unreleased/3985.fixed.md
+++ b/changelog.d/unreleased/3985.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 3985
+affected:
+  - src/CodeIndex/Mcp/HttpMcpTransport.cs
+  - tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+---
+
+## English
+
+- **HTTP MCP transport now disposes owned semaphore gates (#3985)** — clean shutdown now releases the long-lived queue and handler SemaphoreSlim instances once the accept loop has stopped and the gates are idle.
+
+## 日本語
+
+- **HTTP MCP transport が所有 semaphore gate を dispose するようになりました (#3985)** — 正常 shutdown 時に accept loop 停止後、queue / handler の長寿命 SemaphoreSlim が idle になってから解放されます。

--- a/changelog.d/unreleased/3988.fixed.md
+++ b/changelog.d/unreleased/3988.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 3988
+affected:
+  - src/CodeIndex/Diagnostics/ProcessMemorySnapshot.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Models/QueryResults.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/ProcessMemorySnapshotTests.cs
+---
+
+## English
+
+- **Process and memory metric capture is now centralized (#3988)** — CLI memory traces, status process metrics, and MCP index memory traces now share one snapshot helper that disposes the current-process handle after reading metrics.
+
+## 日本語
+
+- **process / memory metric の取得を一元化しました (#3988)** — CLI memory trace、status process metrics、MCP index memory trace が共通 snapshot helper を使い、metrics 読み取り後に current-process handle を dispose するようになりました。

--- a/src/CodeIndex/Cli/BoundedHttpContentReader.cs
+++ b/src/CodeIndex/Cli/BoundedHttpContentReader.cs
@@ -6,6 +6,7 @@ namespace CodeIndex.Cli;
 internal static class BoundedHttpContentReader
 {
     internal const int PooledCopyBufferSize = 81920;
+    internal const int MaxInitialMemoryStreamCapacity = 1 * 1024 * 1024;
 
     internal static async Task<byte[]> ReadAsByteArrayAsync(
         HttpContent content,
@@ -39,7 +40,7 @@ internal static class BoundedHttpContentReader
     {
         if (content.Headers.ContentLength is long contentLength
             && contentLength > 0
-            && contentLength <= int.MaxValue)
+            && contentLength <= MaxInitialMemoryStreamCapacity)
         {
             return new MemoryStream((int)contentLength);
         }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -4,6 +4,7 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Text.Json;
 using CodeIndex.Database;
+using CodeIndex.Diagnostics;
 using CodeIndex.Indexer;
 using CodeIndex.Indexer.Hooks;
 using CodeIndex.Models;
@@ -412,19 +413,19 @@ public static partial class IndexCommandRunner
 
     private static IndexMemorySampleJsonResult CaptureMemorySample(string phase, Stopwatch stopwatch)
     {
-        var gcInfo = GC.GetGCMemoryInfo();
+        var snapshot = ProcessMemorySnapshot.Capture();
         return new IndexMemorySampleJsonResult
         {
             Phase = phase,
             ElapsedMs = stopwatch.ElapsedMilliseconds,
-            HeapBytes = GC.GetTotalMemory(forceFullCollection: false),
-            TotalAllocatedBytes = GC.GetTotalAllocatedBytes(),
-            GcHeapSizeBytes = gcInfo.HeapSizeBytes,
-            FragmentedBytes = gcInfo.FragmentedBytes,
-            WorkingSetBytes = Process.GetCurrentProcess().WorkingSet64,
-            Gen0Collections = GC.CollectionCount(0),
-            Gen1Collections = GC.CollectionCount(1),
-            Gen2Collections = GC.CollectionCount(2),
+            HeapBytes = snapshot.HeapBytes,
+            TotalAllocatedBytes = snapshot.TotalAllocatedBytes,
+            GcHeapSizeBytes = snapshot.GcHeapSizeBytes,
+            FragmentedBytes = snapshot.FragmentedBytes,
+            WorkingSetBytes = snapshot.WorkingSetBytes,
+            Gen0Collections = snapshot.Gen0Collections,
+            Gen1Collections = snapshot.Gen1Collections,
+            Gen2Collections = snapshot.Gen2Collections,
         };
     }
 

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -127,11 +127,15 @@ public static partial class QueryCommandRunner
     internal const int ExactZeroHintSampleLimit = 5;
     private const int SearchOriginFilterMinCandidates = 200;
     private const int SearchOriginFilterOverFetchFactor = 50;
-    private const int SearchOriginFilterMaxCandidates = 10_000;
+    internal const int MaxQueryResultLimit = 10_000;
+    private const int SearchOriginFilterMaxCandidates = MaxQueryResultLimit;
     private const int SearchOriginFilterMaxPages = 50;
     private const int SearchEnvelopeMinCandidates = 200;
     private const int SearchEnvelopeOverFetchFactor = 50;
-    private const int SearchEnvelopeMaxCandidates = 10_000;
+    private const int SearchEnvelopeMaxCandidates = MaxQueryResultLimit;
+    private const int MaxUnusedPaginationPages = 10;
+    internal const int MaxUnusedPaginationFetchLimit = MaxQueryResultLimit * MaxUnusedPaginationPages + 1;
+    internal const int MaxUnusedPaginationOffset = MaxUnusedPaginationFetchLimit - MaxQueryResultLimit - 1;
     private const string SearchFilterNoMatchSentinel = "\0__cdidx_no_match__";
     private const string HotspotsGroupedByNameKind = "name_kind";
     private const string HotspotsGroupedBySymbol = "symbol";
@@ -2816,16 +2820,16 @@ public static partial class QueryCommandRunner
 
     private static int FetchLimitForSearchEnvelope(int limit)
     {
-        if (limit >= int.MaxValue)
-            return int.MaxValue;
         if (limit <= 0)
             return 1;
 
         var requested = (long)limit + 1;
         var overFetched = requested * SearchEnvelopeOverFetchFactor;
         var candidateLimit = Math.Max(SearchEnvelopeMinCandidates, Math.Max(requested, overFetched));
-        return (int)Math.Min(SearchEnvelopeMaxCandidates, Math.Min(int.MaxValue, candidateLimit));
+        return (int)Math.Min(SearchEnvelopeMaxCandidates, candidateLimit);
     }
+
+    internal static int FetchLimitForSearchEnvelopeForTests(int limit) => FetchLimitForSearchEnvelope(limit);
 
     private static bool TrimSearchRowsToRequestedLimit(List<SearchDisplayRow> rows, int limit)
     {
@@ -9914,6 +9918,15 @@ public static partial class QueryCommandRunner
             }
 
             var pageOffset = options.UnusedCursorOffset ?? 0;
+            if (!IsUnusedCursorOffsetWithinFetchCap(options.Limit, pageOffset))
+            {
+                WriteUsageError(
+                    $"unused --cursor offset must be less than or equal to {MaxUnusedPaginationOffset.ToString(CultureInfo.InvariantCulture)}, got {pageOffset.ToString(CultureInfo.InvariantCulture)}.",
+                    GetUsageLineOrThrow("unused"),
+                    "Restart unused pagination without --cursor, or narrow the query filters before paginating again.");
+                return CommandExitCodes.UsageError;
+            }
+
             var fetchLimit = GetUnusedFetchLimit(options.Limit, pageOffset);
             var fetchedResults = reader.GetUnusedSymbols(
                 fetchLimit,
@@ -9930,8 +9943,9 @@ public static partial class QueryCommandRunner
                 .Skip(pageOffset)
                 .Take(options.Limit)
                 .ToList();
-            var nextCursor = fetchedResults.Count > pageOffset + options.Limit
-                ? FormatUnusedCursor(pageOffset + options.Limit)
+            var nextOffset = pageOffset + options.Limit;
+            var nextCursor = fetchedResults.Count > nextOffset && IsUnusedCursorOffsetWithinFetchCap(options.Limit, nextOffset)
+                ? FormatUnusedCursor(nextOffset)
                 : null;
             var sqlGraphSignal = results.Count == 0
                 ? zeroResultSqlGraphSignal
@@ -10113,8 +10127,22 @@ public static partial class QueryCommandRunner
     private static int GetUnusedFetchLimit(int pageLimit, int pageOffset)
     {
         var requested = (long)Math.Max(pageLimit, 1) + Math.Max(pageOffset, 0) + 1;
-        return requested > int.MaxValue ? int.MaxValue : (int)requested;
+        return (int)Math.Min(MaxUnusedPaginationFetchLimit, requested);
     }
+
+    internal static int GetUnusedFetchLimitForTests(int pageLimit, int pageOffset) => GetUnusedFetchLimit(pageLimit, pageOffset);
+
+    private static bool IsUnusedCursorOffsetWithinFetchCap(int pageLimit, int pageOffset)
+    {
+        if (pageOffset < 0)
+            return false;
+
+        var requested = (long)Math.Max(pageLimit, 1) + pageOffset + 1;
+        return requested <= MaxUnusedPaginationFetchLimit;
+    }
+
+    internal static bool IsUnusedCursorOffsetWithinFetchCapForTests(int pageLimit, int pageOffset) =>
+        IsUnusedCursorOffsetWithinFetchCap(pageLimit, pageOffset);
 
     internal static JsonObject BuildUnusedRepresentativeSymbolsJson(IEnumerable<UnusedSymbolResult> results)
     {
@@ -15712,8 +15740,8 @@ public static partial class QueryCommandRunner
     internal static readonly IReadOnlyDictionary<string, int> NumericFlagUpperBounds =
         new Dictionary<string, int>(StringComparer.Ordinal)
         {
-            ["--limit"] = 10_000,
-            ["--max-results"] = 10_000,
+            ["--limit"] = MaxQueryResultLimit,
+            ["--max-results"] = MaxQueryResultLimit,
             ["--snippet-lines"] = SearchSnippetFormatter.MaxSnippetLines,
             ["--max-line-width"] = LineWidthFormatter.MaxAllowedLineWidth,
             ["--slow-query-ms"] = 3_600_000,

--- a/src/CodeIndex/Database/MaintenanceGuidanceBuilder.cs
+++ b/src/CodeIndex/Database/MaintenanceGuidanceBuilder.cs
@@ -112,7 +112,7 @@ internal static class MaintenanceGuidanceBuilder
         if (!pages.HasValue || !pageSize.HasValue || pages.Value < 0 || pageSize.Value <= 0)
             return null;
         if (pages.Value > long.MaxValue / pageSize.Value)
-            return long.MaxValue;
+            return null;
         return pages.Value * pageSize.Value;
     }
 

--- a/src/CodeIndex/Diagnostics/ProcessMemorySnapshot.cs
+++ b/src/CodeIndex/Diagnostics/ProcessMemorySnapshot.cs
@@ -1,0 +1,54 @@
+using System.Diagnostics;
+
+namespace CodeIndex.Diagnostics;
+
+internal readonly struct ProcessMemorySnapshot
+{
+    private ProcessMemorySnapshot(
+        long heapBytes,
+        long totalAllocatedBytes,
+        long gcHeapSizeBytes,
+        long fragmentedBytes,
+        long workingSetBytes,
+        long privateBytes,
+        int gen0Collections,
+        int gen1Collections,
+        int gen2Collections)
+    {
+        HeapBytes = heapBytes;
+        TotalAllocatedBytes = totalAllocatedBytes;
+        GcHeapSizeBytes = gcHeapSizeBytes;
+        FragmentedBytes = fragmentedBytes;
+        WorkingSetBytes = workingSetBytes;
+        PrivateBytes = privateBytes;
+        Gen0Collections = gen0Collections;
+        Gen1Collections = gen1Collections;
+        Gen2Collections = gen2Collections;
+    }
+
+    public long HeapBytes { get; }
+    public long TotalAllocatedBytes { get; }
+    public long GcHeapSizeBytes { get; }
+    public long FragmentedBytes { get; }
+    public long WorkingSetBytes { get; }
+    public long PrivateBytes { get; }
+    public int Gen0Collections { get; }
+    public int Gen1Collections { get; }
+    public int Gen2Collections { get; }
+
+    public static ProcessMemorySnapshot Capture()
+    {
+        var gcInfo = GC.GetGCMemoryInfo();
+        using var process = Process.GetCurrentProcess();
+        return new ProcessMemorySnapshot(
+            GC.GetTotalMemory(forceFullCollection: false),
+            GC.GetTotalAllocatedBytes(),
+            gcInfo.HeapSizeBytes,
+            gcInfo.FragmentedBytes,
+            process.WorkingSet64,
+            process.PrivateMemorySize64,
+            GC.CollectionCount(0),
+            GC.CollectionCount(1),
+            GC.CollectionCount(2));
+    }
+}

--- a/src/CodeIndex/Mcp/HttpMcpTransport.cs
+++ b/src/CodeIndex/Mcp/HttpMcpTransport.cs
@@ -121,6 +121,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     private string? _lastAuthDenialReason;
     private string? _lastRequestLogDropReason;
     private bool _disposed;
+    private bool _ownedSemaphoreGatesDisposed;
 
     /// <summary>
     /// Build an HTTP transport bound to the supplied loopback prefix. If <paramref name="bearerToken"/>
@@ -246,6 +247,8 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     internal bool AuthDisabled => !RequiresBearerToken;
 
     internal string? AuthDisabledWarning => AuthDisabled ? LoopbackAuthDisabledWarning : null;
+
+    internal bool OwnedSemaphoreGatesDisposedForTests => Volatile.Read(ref _ownedSemaphoreGatesDisposed);
 
     internal Func<string, CancellationToken, Task<string?>>? OutOfBandFrameHandler { get; set; }
 
@@ -1540,6 +1543,26 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
                 // request log は best-effort。shutdown を無期限に待たせない。
             }
         }
+        if (acceptLoopCompleted && await WaitForOwnedSemaphoreGatesIdleAsync().ConfigureAwait(false))
+        {
+            _queueSlots.Dispose();
+            _handlerSemaphore.Dispose();
+            Volatile.Write(ref _ownedSemaphoreGatesDisposed, true);
+        }
+    }
+
+    private async Task<bool> WaitForOwnedSemaphoreGatesIdleAsync()
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(DisposeAcceptLoopTimeout);
+        while (_queueSlots.CurrentCount != _maxQueuedRequests
+            || _handlerSemaphore.CurrentCount != _maxConcurrentHandlers)
+        {
+            if (DateTimeOffset.UtcNow >= deadline)
+                return false;
+            await Task.Delay(10).ConfigureAwait(false);
+        }
+
+        return true;
     }
 
     private void MarkRejected(PendingRequest request, string reason)

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -5572,14 +5572,14 @@ public partial class McpServer
 
     private static JsonObject CaptureMcpIndexMemorySample(string stage, Stopwatch stopwatch)
     {
-        using var process = Process.GetCurrentProcess();
+        var snapshot = ProcessMemorySnapshot.Capture();
         return new JsonObject
         {
             ["stage"] = stage,
             ["elapsed_ms"] = stopwatch.ElapsedMilliseconds,
-            ["managed_bytes"] = GC.GetTotalMemory(forceFullCollection: false),
-            ["working_set_bytes"] = process.WorkingSet64,
-            ["private_bytes"] = process.PrivateMemorySize64,
+            ["managed_bytes"] = snapshot.HeapBytes,
+            ["working_set_bytes"] = snapshot.WorkingSetBytes,
+            ["private_bytes"] = snapshot.PrivateBytes,
         };
     }
 

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -1131,20 +1131,28 @@ public partial class McpServer
     private const int SearchEnvelopeMinCandidates = 200;
     private const int SearchEnvelopeOverFetchFactor = 50;
     private const int SearchEnvelopeMaxCandidates = 10_000;
+    internal const int MaxMcpEnvelopeFetchLimit = MaxLimit + 1;
 
-    private static int FetchLimitForEnvelope(int limit) => limit >= int.MaxValue ? int.MaxValue : limit + 1;
+    private static int FetchLimitForEnvelope(int limit)
+    {
+        if (limit <= 0)
+            return 1;
+
+        var requested = (long)limit + 1;
+        return (int)Math.Min(MaxMcpEnvelopeFetchLimit, requested);
+    }
+
+    internal static int FetchLimitForEnvelopeForTests(int limit) => FetchLimitForEnvelope(limit);
 
     private static int FetchLimitForSearchRecipeEnvelope(int limit)
     {
-        if (limit >= int.MaxValue)
-            return int.MaxValue;
         if (limit <= 0)
             return 1;
 
         var requested = (long)limit + 1;
         var overFetched = requested * SearchEnvelopeOverFetchFactor;
         var candidateLimit = Math.Max(SearchEnvelopeMinCandidates, Math.Max(requested, overFetched));
-        return (int)Math.Min(SearchEnvelopeMaxCandidates, Math.Min(int.MaxValue, candidateLimit));
+        return (int)Math.Min(SearchEnvelopeMaxCandidates, candidateLimit);
     }
 
     private static bool TrimToRequestedLimit<T>(List<T> results, int limit)
@@ -4628,7 +4636,7 @@ public partial class McpServer
             MaxBatchQueryResponseByteLimit,
             "MCP batch_query response byte limit");
 
-    private int EstimateJsonUtf8Bytes(JsonNode node, int maxBytes = int.MaxValue)
+    private int EstimateJsonUtf8Bytes(JsonNode node, int maxBytes = MaxBatchQueryResponseByteLimit)
     {
         _ = TryMeasureJsonUtf8BytesWithinLimit(node, _jsonOptions, maxBytes, out var bytesWritten);
         return bytesWritten;

--- a/src/CodeIndex/Mcp/RateLimiter.cs
+++ b/src/CodeIndex/Mcp/RateLimiter.cs
@@ -12,6 +12,7 @@ namespace CodeIndex.Mcp;
 /// </summary>
 internal sealed class RateLimiter
 {
+    internal const long MaxDiagnosticIntervalMilliseconds = int.MaxValue;
     private readonly object _gate = new();
     private readonly Dictionary<RateLimiterBucketKey, TokenBucket> _buckets = new();
     private readonly RateLimiterOptions _options;
@@ -156,13 +157,16 @@ internal sealed class RateLimiter
             return 0;
         try
         {
-            return (long)Math.Ceiling((nextPruneAt - now).TotalMilliseconds);
+            return CapDiagnosticMilliseconds((nextPruneAt - now).TotalMilliseconds);
         }
         catch (ArgumentOutOfRangeException)
         {
-            return long.MaxValue;
+            return MaxDiagnosticIntervalMilliseconds;
         }
     }
+
+    internal static long ComputeNextPruneInMillisecondsForTests(DateTimeOffset now, DateTimeOffset nextPruneAt) =>
+        ComputeNextPruneInMilliseconds(now, nextPruneAt);
 
     private static long ComputeElapsedMilliseconds(DateTimeOffset now, DateTimeOffset since)
     {
@@ -170,12 +174,24 @@ internal sealed class RateLimiter
             return 0;
         try
         {
-            return (long)Math.Ceiling((now - since).TotalMilliseconds);
+            return CapDiagnosticMilliseconds((now - since).TotalMilliseconds);
         }
         catch (ArgumentOutOfRangeException)
         {
-            return long.MaxValue;
+            return MaxDiagnosticIntervalMilliseconds;
         }
+    }
+
+    internal static long ComputeElapsedMillisecondsForTests(DateTimeOffset now, DateTimeOffset since) =>
+        ComputeElapsedMilliseconds(now, since);
+
+    private static long CapDiagnosticMilliseconds(double milliseconds)
+    {
+        if (milliseconds <= 0)
+            return 0;
+        if (milliseconds >= MaxDiagnosticIntervalMilliseconds)
+            return MaxDiagnosticIntervalMilliseconds;
+        return (long)Math.Ceiling(milliseconds);
     }
 
     private sealed class TokenBucket

--- a/src/CodeIndex/Models/QueryResults.cs
+++ b/src/CodeIndex/Models/QueryResults.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using CodeIndex.Diagnostics;
 using CodeIndex.Indexer.Extensibility;
 using CodeIndex.Indexer.Hooks;
 using CodeIndex.Models;
@@ -1265,15 +1266,15 @@ public sealed class StatusProcessMetrics
 
     public static StatusProcessMetrics Capture()
     {
-        var gcInfo = GC.GetGCMemoryInfo();
+        var snapshot = ProcessMemorySnapshot.Capture();
         return new StatusProcessMetrics
         {
-            HeapBytes = GC.GetTotalMemory(forceFullCollection: false),
-            GcHeapSizeBytes = gcInfo.HeapSizeBytes,
-            GcGen0Count = GC.CollectionCount(0),
-            GcGen1Count = GC.CollectionCount(1),
-            GcGen2Count = GC.CollectionCount(2),
-            WorkingSetBytes = System.Diagnostics.Process.GetCurrentProcess().WorkingSet64,
+            HeapBytes = snapshot.HeapBytes,
+            GcHeapSizeBytes = snapshot.GcHeapSizeBytes,
+            GcGen0Count = snapshot.Gen0Collections,
+            GcGen1Count = snapshot.Gen1Collections,
+            GcGen2Count = snapshot.Gen2Collections,
+            WorkingSetBytes = snapshot.WorkingSetBytes,
         };
     }
 }

--- a/tests/CodeIndex.Tests/BoundedHttpContentReaderTests.cs
+++ b/tests/CodeIndex.Tests/BoundedHttpContentReaderTests.cs
@@ -80,6 +80,19 @@ public class BoundedHttpContentReaderTests
     }
 
     [Fact]
+    public async Task ReadAsByteArrayAsync_DoesNotPreallocateHugeDeclaredLength_Issue3964()
+    {
+        using var content = new DeclaredLengthContent([], int.MaxValue);
+
+        var bytes = await BoundedHttpContentReader.ReadAsByteArrayAsync(
+            content,
+            maxBytes: int.MaxValue,
+            CancellationToken.None);
+
+        Assert.Empty(bytes);
+    }
+
+    [Fact]
     public void ClearSensitiveCopyBufferForTests_ClearsWholePooledBuffer_Issue3799()
     {
         var buffer = Enumerable.Range(1, BoundedHttpContentReader.PooledCopyBufferSize)
@@ -121,6 +134,31 @@ public class BoundedHttpContentReaderTests
         {
             length = 0;
             return false;
+        }
+    }
+
+    private sealed class DeclaredLengthContent : HttpContent
+    {
+        private readonly byte[] _payload;
+        private readonly long _declaredLength;
+
+        internal DeclaredLengthContent(byte[] payload, long declaredLength)
+        {
+            _payload = payload;
+            _declaredLength = declaredLength;
+            Headers.ContentLength = declaredLength;
+        }
+
+        protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+            => stream.WriteAsync(_payload, 0, _payload.Length);
+
+        protected override Task<Stream> CreateContentReadStreamAsync()
+            => Task.FromResult<Stream>(new MemoryStream(_payload, writable: false));
+
+        protected override bool TryComputeLength(out long length)
+        {
+            length = _declaredLength;
+            return true;
         }
     }
 }

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -979,6 +979,21 @@ public class DatabaseTests : IDisposable
         Assert.Equal("incremental", guidance.AutoVacuumModeName);
     }
 
+    [Fact]
+    public void MaintenanceGuidance_OverflowEstimateReportsUnknown_Issue3964()
+    {
+        var guidance = MaintenanceGuidanceBuilder.Build(new MaintenanceMetrics(
+            PageCount: long.MaxValue,
+            FreelistCount: long.MaxValue,
+            PageSize: 4096,
+            WalSizeBytes: 0,
+            DbSizeBytes: null,
+            AutoVacuumMode: 2));
+
+        Assert.Equal("vacuum_recommended", guidance.FreelistState);
+        Assert.Null(guidance.EstimatedBytesReclaimable);
+    }
+
     private static int GetTransactionDepth(DbWriter writer)
     {
         var field = typeof(DbWriter).GetField("_transactionDepth", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)

--- a/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+++ b/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
@@ -45,6 +45,19 @@ public class HttpMcpTransportTests : IDisposable
     }
 
     [Fact]
+    public async Task HttpTransport_DisposeAsync_DisposesOwnedSemaphoreGates_Issue3985()
+    {
+        var harness = await McpHttpHarness.StartAsync(_dbPath);
+
+        using var response = await harness.PostJsonAsync("""{"jsonrpc":"2.0","id":1,"method":"ping"}""");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        await harness.DisposeAsync();
+
+        Assert.True(harness.OwnedSemaphoreGatesDisposed);
+    }
+
+    [Fact]
     public void HttpTransport_TimeoutDiagnosticsUseStableCategories_Issue3990()
     {
         Assert.Equal(
@@ -1719,6 +1732,8 @@ public class HttpMcpTransportTests : IDisposable
         public string Endpoint { get; }
 
         public bool HasEventStreams => _transport.HasEventStreams;
+
+        public bool OwnedSemaphoreGatesDisposed => _transport.OwnedSemaphoreGatesDisposedForTests;
 
         public int EventStreamCount => _transport.EventStreamCount;
 

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -26,6 +26,13 @@ namespace CodeIndex.Tests;
 [Collection("SQLite pool sensitive")]
 public class McpServerTests : IDisposable
 {
+    [Fact]
+    public void FetchLimitForEnvelope_ClampsHugeInternalLimit_Issue3964()
+    {
+        Assert.Equal(1, McpServer.FetchLimitForEnvelopeForTests(0));
+        Assert.Equal(McpServer.MaxMcpEnvelopeFetchLimit, McpServer.FetchLimitForEnvelopeForTests(int.MaxValue));
+    }
+
     private static readonly Dictionary<short, OpCode> SingleByteOpCodes = typeof(OpCodes)
         .GetFields(BindingFlags.Public | BindingFlags.Static)
         .Where(field => field.GetValue(null) is OpCode opCode && opCode.Size == 1)

--- a/tests/CodeIndex.Tests/ProcessMemorySnapshotTests.cs
+++ b/tests/CodeIndex.Tests/ProcessMemorySnapshotTests.cs
@@ -1,0 +1,22 @@
+using CodeIndex.Diagnostics;
+
+namespace CodeIndex.Tests;
+
+public class ProcessMemorySnapshotTests
+{
+    [Fact]
+    public void Capture_ReturnsNonNegativeMetrics_Issue3988()
+    {
+        var snapshot = ProcessMemorySnapshot.Capture();
+
+        Assert.True(snapshot.HeapBytes >= 0);
+        Assert.True(snapshot.TotalAllocatedBytes >= 0);
+        Assert.True(snapshot.GcHeapSizeBytes >= 0);
+        Assert.True(snapshot.FragmentedBytes >= 0);
+        Assert.True(snapshot.WorkingSetBytes > 0);
+        Assert.True(snapshot.PrivateBytes >= 0);
+        Assert.True(snapshot.Gen0Collections >= 0);
+        Assert.True(snapshot.Gen1Collections >= 0);
+        Assert.True(snapshot.Gen2Collections >= 0);
+    }
+}

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -11,6 +11,29 @@ namespace CodeIndex.Tests;
 public partial class QueryCommandRunnerTests
 {
     [Fact]
+    public void FetchLimitForSearchEnvelope_ClampsHugeInternalLimit_Issue3964()
+    {
+        Assert.Equal(1, QueryCommandRunner.FetchLimitForSearchEnvelopeForTests(0));
+        Assert.Equal(200, QueryCommandRunner.FetchLimitForSearchEnvelopeForTests(1));
+        Assert.Equal(QueryCommandRunner.MaxQueryResultLimit, QueryCommandRunner.FetchLimitForSearchEnvelopeForTests(int.MaxValue));
+    }
+
+    [Fact]
+    public void GetUnusedFetchLimit_ClampsDeepCursorFetch_Issue3964()
+    {
+        Assert.Equal(21, QueryCommandRunner.GetUnusedFetchLimitForTests(20, 0));
+        Assert.Equal(
+            QueryCommandRunner.MaxUnusedPaginationFetchLimit,
+            QueryCommandRunner.GetUnusedFetchLimitForTests(QueryCommandRunner.MaxQueryResultLimit, int.MaxValue));
+        Assert.True(QueryCommandRunner.IsUnusedCursorOffsetWithinFetchCapForTests(
+            QueryCommandRunner.MaxQueryResultLimit,
+            QueryCommandRunner.MaxUnusedPaginationOffset));
+        Assert.False(QueryCommandRunner.IsUnusedCursorOffsetWithinFetchCapForTests(
+            QueryCommandRunner.MaxQueryResultLimit,
+            QueryCommandRunner.MaxUnusedPaginationOffset + 1));
+    }
+
+    [Fact]
     public void RunSearch_GroupByFileCountStreamsFileCounts_Issue3741()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_search_group_by_file_count");

--- a/tests/CodeIndex.Tests/RateLimiterTests.cs
+++ b/tests/CodeIndex.Tests/RateLimiterTests.cs
@@ -265,6 +265,17 @@ public class RateLimiterTests
     }
 
     [Fact]
+    public void DiagnosticMilliseconds_ClampHugeIntervals_Issue3964()
+    {
+        Assert.Equal(
+            RateLimiter.MaxDiagnosticIntervalMilliseconds,
+            RateLimiter.ComputeNextPruneInMillisecondsForTests(DateTimeOffset.MinValue, DateTimeOffset.MaxValue));
+        Assert.Equal(
+            RateLimiter.MaxDiagnosticIntervalMilliseconds,
+            RateLimiter.ComputeElapsedMillisecondsForTests(DateTimeOffset.MaxValue, DateTimeOffset.MinValue));
+    }
+
+    [Fact]
     public void FromEnvironment_NoVars_ReturnsDisabled()
     {
         var opts = RateLimiterOptions.FromEnvironment(_ => null, _ => { });


### PR DESCRIPTION
## Summary
- Bound MaxValue-style sentinel fetch paths and oversized diagnostic calculations to explicit caps.
- Dispose HTTP MCP transport semaphore gates after shutdown once owned gates are idle.
- Centralize process memory snapshots behind a shared disposable helper.

## Root Cause
Several paths used unbounded sentinel values for internal fetch or diagnostic sizing, the HTTP MCP transport left owned semaphores undisposed, and memory metric collection duplicated process snapshot logic across call sites.

## Validation
- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~ProcessMemorySnapshotTests|FullyQualifiedName~HttpMcpTransportTests.HttpTransport_DisposeAsync_DisposesOwnedSemaphoreGates_Issue3985|FullyQualifiedName~QueryCommandRunnerTests.FetchLimitForSearchEnvelope_ClampsHugeInternalLimit_Issue3964|FullyQualifiedName~QueryCommandRunnerTests.GetUnusedFetchLimit_ClampsDeepCursorFetch_Issue3964|FullyQualifiedName~McpServerTests.FetchLimitForEnvelope_ClampsHugeInternalLimit_Issue3964|FullyQualifiedName~BoundedHttpContentReaderTests.ReadAsByteArrayAsync_DoesNotPreallocateHugeDeclaredLength_Issue3964|FullyQualifiedName~DatabaseTests.MaintenanceGuidance_OverflowEstimateReportsUnknown_Issue3964|FullyQualifiedName~RateLimiterTests.DiagnosticMilliseconds_ClampHugeIntervals_Issue3964"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `codex exec review --base origin/main --dangerously-bypass-approvals-and-sandbox`

Fixes #3964
Fixes #3985
Fixes #3988
