### PR TITLE
Audit static regex usage in recipes

### DIFF
--- a/changelog.d/unreleased/3960.fixed.md
+++ b/changelog.d/unreleased/3960.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 3960
+affected:
+  - src/CodeIndex/Cli/SearchAuditRecipes.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+---
+
+## English
+
+- **Static regex audits now cover direct `Regex.Match` and `Regex.Replace` calls (#3960)** - built-in audit recipes can flag static regex APIs separately from `new Regex(...)`, while additional raw call sites now use the shared bounded regex wrapper.
+
+## 日本語
+
+- **static regex 監査が直接の `Regex.Match` / `Regex.Replace` 呼び出しを検出するようになりました (#3960)** - built-in audit recipe が `new Regex(...)` とは別に static regex API を検出できるようになり、追加の raw 呼び出し箇所も共有の bounded regex wrapper を使うようになりました。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -11,6 +11,7 @@ using CodeIndex.Indexer.Extensibility;
 using CodeIndex.Indexer.Hooks;
 using CodeIndex.Models;
 using Microsoft.Data.Sqlite;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Cli;
 

--- a/src/CodeIndex/Cli/SearchAuditRecipes.cs
+++ b/src/CodeIndex/Cli/SearchAuditRecipes.cs
@@ -294,6 +294,42 @@ internal static class SearchAuditRecipes
                     ],
                 },
                 new(
+                    "static-regex-match",
+                    " Regex.Match(",
+                    "Find static Regex.Match calls that may need BoundedRegex or an explicit timeout overload.",
+                    ["audit", "performance"],
+                    "False positives include bounded wrapper aliases, prevalidated small inputs, and tests that intentionally exercise raw Regex behavior.")
+                {
+                    RejectFileQueries =
+                    [
+                        "using Regex = CodeIndex.Indexer.BoundedRegex"
+                    ],
+                    RiskEvidence =
+                    [
+                        "risk: static System.Text.RegularExpressions.Regex.Match can run without the shared timeout policy.",
+                        "positive: BoundedRegex aliases, explicit timeout overloads, or tightly bounded trusted inputs can make a hit intentional."
+                    ],
+                    MatchOrigins = ["code"],
+                },
+                new(
+                    "static-regex-replace",
+                    " Regex.Replace(",
+                    "Find static Regex.Replace calls that may need BoundedRegex or an explicit timeout overload.",
+                    ["audit", "performance"],
+                    "False positives include bounded wrapper aliases, prevalidated small inputs, and tests that intentionally exercise raw Regex behavior.")
+                {
+                    RejectFileQueries =
+                    [
+                        "using Regex = CodeIndex.Indexer.BoundedRegex"
+                    ],
+                    RiskEvidence =
+                    [
+                        "risk: static System.Text.RegularExpressions.Regex.Replace can run without the shared timeout policy.",
+                        "positive: BoundedRegex aliases, explicit timeout overloads, or tightly bounded trusted inputs can make a hit intentional."
+                    ],
+                    MatchOrigins = ["code"],
+                },
+                new(
                     "regex-timeout-handling",
                     "RegexMatchTimeoutException",
                     "Find regex timeout handling boundaries that may need consistent diagnostics and recovery behavior.",
@@ -766,6 +802,42 @@ internal static class SearchAuditRecipes
                         "risk: fully qualified BCL Regex construction bypasses local aliases and should carry timeout/non-backtracking evidence.",
                         "positive: explicit timeout arguments or RegexOptions.NonBacktracking can make the construction bounded."
                     ],
+                },
+                new(
+                    "static-regex-match",
+                    " Regex.Match(",
+                    "Find static Regex.Match calls that may need BoundedRegex or an explicit timeout overload.",
+                    ["audit", "performance"],
+                    "False positives include bounded wrapper aliases, prevalidated small inputs, and tests that intentionally exercise raw Regex behavior.")
+                {
+                    RejectFileQueries =
+                    [
+                        "using Regex = CodeIndex.Indexer.BoundedRegex"
+                    ],
+                    RiskEvidence =
+                    [
+                        "risk: static System.Text.RegularExpressions.Regex.Match can run without the shared timeout policy.",
+                        "positive: BoundedRegex aliases, explicit timeout overloads, or tightly bounded trusted inputs can make a hit intentional."
+                    ],
+                    MatchOrigins = ["code"],
+                },
+                new(
+                    "static-regex-replace",
+                    " Regex.Replace(",
+                    "Find static Regex.Replace calls that may need BoundedRegex or an explicit timeout overload.",
+                    ["audit", "performance"],
+                    "False positives include bounded wrapper aliases, prevalidated small inputs, and tests that intentionally exercise raw Regex behavior.")
+                {
+                    RejectFileQueries =
+                    [
+                        "using Regex = CodeIndex.Indexer.BoundedRegex"
+                    ],
+                    RiskEvidence =
+                    [
+                        "risk: static System.Text.RegularExpressions.Regex.Replace can run without the shared timeout policy.",
+                        "positive: BoundedRegex aliases, explicit timeout overloads, or tightly bounded trusted inputs can make a hit intentional."
+                    ],
+                    MatchOrigins = ["code"],
                 },
                 new(
                     "cancellation-token-none",

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using CodeIndex.Indexer;
 using Microsoft.Data.Sqlite;
+using Regex = CodeIndex.Indexer.BoundedRegex;
 
 namespace CodeIndex.Database;
 

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -1245,6 +1245,14 @@ public partial class QueryCommandRunnerTests
             .GetProperty("queries")
             .EnumerateArray()
             .Single(item => item.GetProperty("name").GetString() == "regex-construction");
+        var staticRegexMatchQuery = recipe
+            .GetProperty("queries")
+            .EnumerateArray()
+            .Single(item => item.GetProperty("name").GetString() == "static-regex-match");
+        var staticRegexReplaceQuery = recipe
+            .GetProperty("queries")
+            .EnumerateArray()
+            .Single(item => item.GetProperty("name").GetString() == "static-regex-replace");
         var boundedRegexAliasQuery = recipe
             .GetProperty("queries")
             .EnumerateArray()
@@ -1287,6 +1295,10 @@ public partial class QueryCommandRunnerTests
         Assert.Equal(0, emptyCatchQuery.GetProperty("result_kinds").GetArrayLength());
         Assert.Equal("new Regex(", regexQuery.GetProperty("query").GetString());
         Assert.Contains(regexQuery.GetProperty("risk_evidence").EnumerateArray(), evidence => evidence.GetString()!.Contains("bounded-regex-alias", StringComparison.Ordinal));
+        Assert.Equal(" Regex.Match(", staticRegexMatchQuery.GetProperty("query").GetString());
+        Assert.Contains(staticRegexMatchQuery.GetProperty("risk_evidence").EnumerateArray(), evidence => evidence.GetString()!.Contains("shared timeout policy", StringComparison.Ordinal));
+        Assert.Equal(" Regex.Replace(", staticRegexReplaceQuery.GetProperty("query").GetString());
+        Assert.Contains(staticRegexReplaceQuery.GetProperty("risk_evidence").EnumerateArray(), evidence => evidence.GetString()!.Contains("shared timeout policy", StringComparison.Ordinal));
         Assert.Equal("info", boundedRegexAliasQuery.GetProperty("severity").GetString());
         Assert.Contains(boundedRegexAliasQuery.GetProperty("risk_evidence").EnumerateArray(), evidence => evidence.GetString()!.Contains("aliases CodeIndex.Indexer.BoundedRegex", StringComparison.Ordinal));
         var broadCatchTaxonomy = broadCatchQuery.GetProperty("broad_catch_taxonomy");
@@ -1317,6 +1329,8 @@ public partial class QueryCommandRunnerTests
         Assert.Contains(dotnetRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "sqlite-quoted-identifier");
         Assert.Contains(dotnetRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "sqlite-typed-parameter");
         Assert.Contains(dotnetRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "fully-qualified-regex-construction");
+        Assert.Contains(dotnetRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "static-regex-match");
+        Assert.Contains(dotnetRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "static-regex-replace");
         Assert.Contains(dotnetRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "sync-over-async");
         Assert.Contains(xmlRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "dtd-processing");
         Assert.Contains(traversalRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "enumerate-files");
@@ -1443,6 +1457,8 @@ public partial class QueryCommandRunnerTests
                 "regex-construction",
                 "bounded-regex-alias",
                 "fully-qualified-regex-construction",
+                "static-regex-match",
+                "static-regex-replace",
                 "regex-timeout-handling",
                 "environment-secret-source",
                 "authorization-handling",
@@ -1491,7 +1507,7 @@ public partial class QueryCommandRunnerTests
             SearchAuditRecipes.DefaultAuditScope,
             ["src/**"],
             expectedSourceExcludes,
-            ["sqlite-addwithvalue", "sqlite-quoted-identifier", "sqlite-typed-parameter", "regex-construction", "bounded-regex-alias", "fully-qualified-regex-construction", "cancellation-token-none", "sync-over-async"]);
+            ["sqlite-addwithvalue", "sqlite-quoted-identifier", "sqlite-typed-parameter", "regex-construction", "bounded-regex-alias", "fully-qualified-regex-construction", "static-regex-match", "static-regex-replace", "cancellation-token-none", "sync-over-async"]);
         AssertRecipe(
             "xml-parser-security",
             SearchAuditRecipes.DefaultAuditScope,
@@ -1762,6 +1778,21 @@ public partial class QueryCommandRunnerTests
                 public sealed class BoundedRegexUse
                 {
                     public object Build() => new Regex("token");
+                    public bool HasToken(string input) => Regex.Match(input, "token").Success;
+                    public string Clean(string input) => Regex.Replace(input, "token", "value");
+                }
+                """);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/static-raw.cs",
+                "csharp",
+                """
+                using System.Text.RegularExpressions;
+
+                public sealed class StaticRawRegexUse
+                {
+                    public bool HasToken(string input) => Regex.Match(input, "token").Success;
+                    public string Clean(string input) => Regex.Replace(input, "token", "value");
                 }
                 """);
             TestProjectHelper.InsertIndexedFile(
@@ -1788,7 +1819,7 @@ public partial class QueryCommandRunnerTests
             var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
                 [
                     "--recipe", "risky-code",
-                    "--include-query", "regex-construction,bounded-regex-alias,fully-qualified-regex-construction",
+                    "--include-query", "regex-construction,bounded-regex-alias,fully-qualified-regex-construction,static-regex-match,static-regex-replace",
                     "--db", dbPath,
                     "--json",
                     "--limit", "10",
@@ -1808,6 +1839,18 @@ public partial class QueryCommandRunnerTests
                 .ToList();
             var boundedAlias = queries.Single(item => item.GetProperty("name").GetString() == "bounded-regex-alias");
             var fullyQualified = queries.Single(item => item.GetProperty("name").GetString() == "fully-qualified-regex-construction");
+            var staticMatchPaths = queries
+                .Single(item => item.GetProperty("name").GetString() == "static-regex-match")
+                .GetProperty("results")
+                .EnumerateArray()
+                .Select(item => item.GetProperty("path").GetString())
+                .ToList();
+            var staticReplacePaths = queries
+                .Single(item => item.GetProperty("name").GetString() == "static-regex-replace")
+                .GetProperty("results")
+                .EnumerateArray()
+                .Select(item => item.GetProperty("path").GetString())
+                .ToList();
 
             Assert.Contains("src/raw.cs", constructionPaths);
             Assert.DoesNotContain("src/bounded.cs", constructionPaths);
@@ -1815,11 +1858,15 @@ public partial class QueryCommandRunnerTests
             Assert.Equal("src/bounded.cs", Assert.Single(boundedAlias.GetProperty("results").EnumerateArray()).GetProperty("path").GetString());
             Assert.Contains(boundedAlias.GetProperty("risk_evidence").EnumerateArray(), evidence => evidence.GetString()!.Contains("aliases CodeIndex.Indexer.BoundedRegex", StringComparison.Ordinal));
             Assert.Equal("src/full.cs", Assert.Single(fullyQualified.GetProperty("results").EnumerateArray()).GetProperty("path").GetString());
+            Assert.Contains("src/static-raw.cs", staticMatchPaths);
+            Assert.DoesNotContain("src/bounded.cs", staticMatchPaths);
+            Assert.Contains("src/static-raw.cs", staticReplacePaths);
+            Assert.DoesNotContain("src/bounded.cs", staticReplacePaths);
 
             var (dotnetExitCode, dotnetStdout, dotnetStderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
                 [
                     "--recipe", "dotnet-risk-patterns",
-                    "--include-query", "regex-construction,bounded-regex-alias,fully-qualified-regex-construction",
+                    "--include-query", "regex-construction,bounded-regex-alias,fully-qualified-regex-construction,static-regex-match,static-regex-replace",
                     "--db", dbPath,
                     "--json",
                     "--limit", "10",
@@ -1839,11 +1886,27 @@ public partial class QueryCommandRunnerTests
                 .ToList();
             var dotnetBoundedAlias = dotnetQueries.Single(item => item.GetProperty("name").GetString() == "bounded-regex-alias");
             var dotnetFullyQualified = dotnetQueries.Single(item => item.GetProperty("name").GetString() == "fully-qualified-regex-construction");
+            var dotnetStaticMatchPaths = dotnetQueries
+                .Single(item => item.GetProperty("name").GetString() == "static-regex-match")
+                .GetProperty("results")
+                .EnumerateArray()
+                .Select(item => item.GetProperty("path").GetString())
+                .ToList();
+            var dotnetStaticReplacePaths = dotnetQueries
+                .Single(item => item.GetProperty("name").GetString() == "static-regex-replace")
+                .GetProperty("results")
+                .EnumerateArray()
+                .Select(item => item.GetProperty("path").GetString())
+                .ToList();
 
             Assert.Contains("src/raw.cs", dotnetConstructionPaths);
             Assert.DoesNotContain("src/bounded.cs", dotnetConstructionPaths);
             Assert.Equal("src/bounded.cs", Assert.Single(dotnetBoundedAlias.GetProperty("results").EnumerateArray()).GetProperty("path").GetString());
             Assert.Equal("src/full.cs", Assert.Single(dotnetFullyQualified.GetProperty("results").EnumerateArray()).GetProperty("path").GetString());
+            Assert.Contains("src/static-raw.cs", dotnetStaticMatchPaths);
+            Assert.DoesNotContain("src/bounded.cs", dotnetStaticMatchPaths);
+            Assert.Contains("src/static-raw.cs", dotnetStaticReplacePaths);
+            Assert.DoesNotContain("src/bounded.cs", dotnetStaticReplacePaths);
         }
         finally
         {
@@ -2281,7 +2344,7 @@ public partial class QueryCommandRunnerTests
                 .Single(item => item.GetProperty("name").GetString() == "unbounded-json-parse");
 
             Assert.Equal("risky-code", root.GetProperty("recipe").GetProperty("name").GetString());
-            Assert.Equal(26, root.GetProperty("query_count").GetInt32());
+            Assert.Equal(28, root.GetProperty("query_count").GetInt32());
             Assert.Equal("source", root.GetProperty("scope").GetProperty("name").GetString());
             Assert.Contains(root.GetProperty("scope").GetProperty("path_patterns").EnumerateArray(), path => path.GetString() == "src/**");
             Assert.Contains(root.GetProperty("scope").GetProperty("exclude_paths").EnumerateArray(), path => path.GetString() == "src/CodeIndex/Cli/SearchAuditRecipes.cs");


### PR DESCRIPTION
## Summary

- Add `static-regex-match` and `static-regex-replace` audit queries to `risky-code` and `dotnet-risk-patterns`.
- Route the remaining raw-looking `Regex.Match` / `Regex.Replace` call sites touched by this audit through the shared bounded regex wrapper alias.
- Cover recipe metadata, snapshot output, and raw-vs-bounded behavior in search tests.

## Validation

- `dotnet build`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~RunSearch_RecipeJsonRunsBuiltInQueries_Issue3144"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~RunSearch_RegexRecipeSeparatesBoundedAliasAndRawConstruction_Issue3919"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~RunSearch_ListRecipesJsonIncludesBuiltInAuditMetadata_Issue3144"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~RunSearch_BuiltInRecipeSnapshotCoversNamesScopesAndQueries_Issue3692"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search --recipe risky-code --include-query static-regex-match,static-regex-replace --json --limit 100`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search --recipe dotnet-risk-patterns --include-query static-regex-match,static-regex-replace --json --limit 100`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Note: `dotnet test --no-build` was also run before the final query-count expectation update. It failed only on `RunSearch_RecipeJsonRunsBuiltInQueries_Issue3144` expecting `26` instead of the new `28`; that expectation was fixed and the test was rerun successfully on net8.0 and net9.0.

## Documentation / Changelog

- Added `changelog.d/unreleased/3960.fixed.md`.
- No standalone docs update was needed because user-facing docs list recipe names, while child query names are exposed dynamically through `cdidx search --list-recipes`.

## Review

- Adversarial review: No blocking/actionable issues found.

## Follow-up Candidates

- None.

Fixes #3960
