### PR TITLE
[codex] Stabilize flaky test diagnostics for issues 4015, 4024, and 4027

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -66,7 +66,7 @@ The test project mirrors the production areas closely.
 - `HttpMcpTransportTests.cs`
   HTTP MCP transport behavior, including authentication responses, warm server reuse, concurrent requests, and request logging. Request-log assertions must validate recorded contents without assuming callback order between independently handled HTTP requests.
 - `GitHelperTests.cs`
-  Git-specific behavior, including worktrees, commit-based updates, and cancellation of git subprocesses. Cancellation wall-clock assertions should stay below the fake git scripts' natural 5-second completion while leaving room for macOS CI scheduling and process-cleanup overhead.
+  Git-specific behavior, including worktrees, commit-based updates, and cancellation of git subprocesses. Timeout and cancellation wall-clock assertions should stay below the fake git scripts' natural completion while leaving room for macOS CI scheduling and process-cleanup overhead.
 - `WorkspaceMetadataEnricherTests.cs`
   Workspace freshness and git metadata enrichment behavior.
 - `SuggestionStoreTests.cs`
@@ -281,7 +281,7 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
 - `HttpMcpTransportTests.cs`
   HTTP MCP transport の挙動。認証レスポンス、warm server reuse、並行リクエスト、リクエストログを含みます。リクエストログの assertion は、独立に処理される HTTP リクエスト間の callback 順序を仮定せず、記録内容を検証してください。
 - `GitHelperTests.cs`
-  worktree や commit ベース更新、git subprocess の cancellation を含む Git まわりのテスト。Cancellation の wall-clock assertion は fake git script が自然完了する 5 秒未満に保ちつつ、macOS CI の scheduling や process cleanup の遅れを許容する余裕を持たせます。
+  worktree や commit ベース更新、git subprocess の cancellation を含む Git まわりのテスト。Timeout と cancellation の wall-clock assertion は fake git script の自然完了より短く保ちつつ、macOS CI の scheduling や process cleanup の遅れを許容する余裕を持たせます。
 - `WorkspaceMetadataEnricherTests.cs`
   ワークスペース鮮度と git メタデータ付与のテスト。
 - `SuggestionStoreTests.cs`

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -44,6 +44,7 @@ The test project mirrors the production areas closely.
   End-to-end upgrade path: seeds a pre-column legacy DB, opens it through `TryMigrateForRead`, and exercises the read paths that touch nullable symbol ordinals (outline, symbol search, nearby, unused, analyze bundle) to lock in the real-world failure mode behind #58 / #49.
 - `IndexCommandRunnerTests.cs`, `QueryCommandRunner*Tests.cs`, `ProgramCliTests.cs`, `InstallScriptTests.cs`
   CLI parsing, command execution, and installer behavior. Query command coverage is split by command family with partial `QueryCommandRunnerTests` classes so shared console and fixture helpers stay centralized. `ProgramCliTests.cs` covers top-level entrypoint behavior that must be exercised through a subprocess, while `InstallScriptTests.cs` runs focused bash snippets against `install.sh` in library mode to lock in release-installer regressions without performing real network installs.
+  `InstallScriptTests.RunInstallerSnippet` enforces a bounded timeout and kills the snippet process tree on timeout, so installer regressions fail with captured output instead of hanging the suite.
 - `IndexCommandRunnerTests.Run_CancelDuringFreshIndex_ReturnsInterruptedJson`, `Run_CancelDuringDryRunScan_ReturnsInterruptedJson`, and `Run_CancelBeforeFreshScan_ReturnsInterruptedJson`
   exercise the same in-process cancellation paths used after Ctrl-C/SIGINT wiring, including scan-time cancellation, so interrupted index runs keep returning the canonical JSON error contract.
 - `IndexCommandRunnerTests.SymbolExtractionWorker_LegacyEnvironmentHooksAreIgnored_Issue3398`
@@ -258,6 +259,7 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
   エンドツーエンドのアップグレード経路: カラム追加前のレガシー DB を用意し、`TryMigrateForRead` 経由で開いてから NULL になりうるシンボル列を触る read path（outline、シンボル検索、近傍、unused、analyze バンドル）を一通り叩き、#58 / #49 の実機失敗モードを固定する。
 - `IndexCommandRunnerTests.cs`、`QueryCommandRunner*Tests.cs`、`ProgramCliTests.cs`、`InstallScriptTests.cs`
   CLI の引数解析、コマンド実行、installer 挙動のテスト。Query command coverage は command family ごとの partial `QueryCommandRunnerTests` class に分割し、共有 console / fixture helper は一箇所に保ちます。`ProgramCliTests.cs` はグローバル引数の解釈や完全な CLI 起動フローのように subprocess 経由で確認すべき Program エントリポイント挙動を扱い、`InstallScriptTests.cs` は `install.sh` を library mode で source した bash snippet を実行して、実ネットワーク install を行わずに release installer の回帰を固定する。
+  `InstallScriptTests.RunInstallerSnippet` は bounded timeout を強制し、timeout 時は snippet の process tree を kill するため、installer 回帰は suite を hang させずに captured output 付きで失敗します。
 - `IndexCommandRunnerTests.Run_CancelDuringFreshIndex_ReturnsInterruptedJson`、`Run_CancelDuringDryRunScan_ReturnsInterruptedJson`、`Run_CancelBeforeFreshScan_ReturnsInterruptedJson`
   Ctrl-C/SIGINT 配線後に使われる in-process cancellation 経路を、scan 中のキャンセルも含めて検証し、interrupted index run が標準の JSON error contract を返し続けることを固定する。
 - `IndexCommandRunnerTests.SymbolExtractionWorker_LegacyEnvironmentHooksAreIgnored_Issue3398`

--- a/changelog.d/unreleased/4015.internal.md
+++ b/changelog.d/unreleased/4015.internal.md
@@ -9,8 +9,8 @@ affected:
 
 ## English
 
-- **Installer snippet tests now fail fast on hangs (#4015)** — `InstallScriptTests.RunInstallerSnippet` now applies a bounded timeout, kills the snippet process tree when the timeout expires, and returns captured diagnostics instead of allowing the full suite to hang silently.
+- **Installer snippet tests now fail fast on hangs (#4015)** — `InstallScriptTests.RunInstallerSnippet` now applies a bounded timeout, kills the snippet process tree when the timeout expires, and surfaces captured diagnostics from selected success assertions instead of allowing the full suite to hang silently.
 
 ## 日本語
 
-- **installer snippet テストが hang 時に bounded failure するようになりました (#4015)** — `InstallScriptTests.RunInstallerSnippet` は bounded timeout を適用し、timeout 時に snippet の process tree を kill して captured diagnostics を返すため、full suite が無音で hang し続けなくなりました。
+- **installer snippet テストが hang 時に bounded failure するようになりました (#4015)** — `InstallScriptTests.RunInstallerSnippet` は bounded timeout を適用し、timeout 時に snippet の process tree を kill し、一部の成功系 assertion から captured diagnostics を表示するため、full suite が無音で hang し続けなくなりました。

--- a/changelog.d/unreleased/4015.internal.md
+++ b/changelog.d/unreleased/4015.internal.md
@@ -1,0 +1,16 @@
+---
+category: internal
+issues:
+  - 4015
+affected:
+  - tests/CodeIndex.Tests/InstallScriptTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **Installer snippet tests now fail fast on hangs (#4015)** — `InstallScriptTests.RunInstallerSnippet` now applies a bounded timeout, kills the snippet process tree when the timeout expires, and returns captured diagnostics instead of allowing the full suite to hang silently.
+
+## 日本語
+
+- **installer snippet テストが hang 時に bounded failure するようになりました (#4015)** — `InstallScriptTests.RunInstallerSnippet` は bounded timeout を適用し、timeout 時に snippet の process tree を kill して captured diagnostics を返すため、full suite が無音で hang し続けなくなりました。

--- a/changelog.d/unreleased/4024.internal.md
+++ b/changelog.d/unreleased/4024.internal.md
@@ -1,0 +1,15 @@
+---
+category: internal
+issues:
+  - 4024
+affected:
+  - tests/CodeIndex.Tests/InstallScriptTests.cs
+---
+
+## English
+
+- **Reinstall test failures now include installer output (#4024)** — installer snippets now keep a wider bounded timeout for net9 test load, and `DownloadAndInstall_ReinstallReplacesExistingOptionalDirectories` reports captured stdout/stderr when the snippet exits non-zero so reinstall failures are diagnosable from the assertion message.
+
+## 日本語
+
+- **reinstall テスト失敗時に installer 出力が表示されるようになりました (#4024)** — installer snippet は net9 のテスト負荷に耐える広めの bounded timeout を使い、`DownloadAndInstall_ReinstallReplacesExistingOptionalDirectories` は snippet が非 0 で終了した場合に captured stdout/stderr を assertion message に含めるため、reinstall 失敗を診断しやすくなりました。

--- a/changelog.d/unreleased/4027.internal.md
+++ b/changelog.d/unreleased/4027.internal.md
@@ -1,0 +1,16 @@
+---
+category: internal
+issues:
+  - 4027
+affected:
+  - tests/CodeIndex.Tests/GitHelperTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **GitHelper timeout tests now tolerate full-suite load (#4027)** — git subprocess timeout assertions now use a wider wall-clock budget while keeping the fake git command's natural completion beyond that budget, so missed timeout handling still fails deterministically.
+
+## 日本語
+
+- **GitHelper の timeout テストが full-suite load に耐えるようになりました (#4027)** — git subprocess timeout assertion は広めの wall-clock budget を使い、fake git command の自然完了はその budget より後に保つため、timeout 処理漏れは引き続き決定的に失敗します。

--- a/tests/CodeIndex.Tests/GitHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitHelperTests.cs
@@ -11,8 +11,11 @@ namespace CodeIndex.Tests;
 [Collection("SQLite pool sensitive")]
 public class GitHelperTests : IDisposable
 {
-    // Keep below the fake git scripts' 5-second sleep so missed cancellation still fails.
-    private static readonly TimeSpan GitCancellationWallClockLimit = TimeSpan.FromSeconds(4);
+    private const int FakeGitHangSeconds = 15;
+
+    // Keep below the fake git scripts' sleep so missed timeout/cancellation still fails,
+    // while leaving room for process cleanup under full-suite load.
+    private static readonly TimeSpan GitCancellationWallClockLimit = TimeSpan.FromSeconds(10);
 
     private readonly string _tempDir;
 
@@ -658,7 +661,9 @@ public class GitHelperTests : IDisposable
             Assert.Equal(-1, result.ExitCode);
             Assert.Equal(GitCommandFailureKind.TimedOut, result.FailureKind);
             Assert.Contains("timed out", result.Diagnostic);
-            Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2), $"Timeout took {stopwatch.Elapsed}.");
+            Assert.True(
+                stopwatch.Elapsed < GitCancellationWallClockLimit,
+                $"Timeout took {stopwatch.Elapsed}, expected less than {GitCancellationWallClockLimit}.");
         }
         finally
         {
@@ -1611,9 +1616,9 @@ exit 23
     private static void WriteFakeGitThatHangsForAnyCommand(string directory)
     {
         var script = Path.Combine(directory, "git");
-        File.WriteAllText(script, """
+        File.WriteAllText(script, $$"""
 #!/bin/sh
-sleep 5
+sleep {{FakeGitHangSeconds}}
 exit 0
 """);
         if (!OperatingSystem.IsWindows())

--- a/tests/CodeIndex.Tests/InstallScriptTests.cs
+++ b/tests/CodeIndex.Tests/InstallScriptTests.cs
@@ -702,7 +702,7 @@ public sealed class InstallScriptTests : IDisposable
 
             mkdir -p "{{installDir}}"
             cat > "{{Path.Combine(installDir, "cdidx")}}" <<'EOF'
-            #!/usr/bin/env bash
+            #!/bin/sh
             echo "cdidx v1.2.3"
             EOF
             chmod +x "{{Path.Combine(installDir, "cdidx")}}"
@@ -1457,7 +1457,7 @@ public sealed class InstallScriptTests : IDisposable
             mkdir -p "{{payloadDir}}"
             mkdir -p "{{Path.Combine(payloadDir, "LICENSES")}}"
             cat > "{{Path.Combine(payloadDir, "cdidx")}}" <<'EOF'
-            #!/usr/bin/env bash
+            #!/bin/sh
             echo "cdidx v1.2.3"
             EOF
             chmod +x "{{Path.Combine(payloadDir, "cdidx")}}"
@@ -1559,7 +1559,7 @@ public sealed class InstallScriptTests : IDisposable
             $$"""
             mkdir -p "{{Path.Combine(installDir, "LICENSES")}}"
             cat > "{{Path.Combine(installDir, "cdidx")}}" <<'EOF'
-            #!/usr/bin/env bash
+            #!/bin/sh
             echo "cdidx v1.24.6"
             EOF
             chmod +x "{{Path.Combine(installDir, "cdidx")}}"
@@ -1570,7 +1570,7 @@ public sealed class InstallScriptTests : IDisposable
             mkdir -p "{{payloadDir}}"
             mkdir -p "{{Path.Combine(payloadDir, "LICENSES")}}"
             cat > "{{Path.Combine(payloadDir, "cdidx")}}" <<'EOF'
-            #!/usr/bin/env bash
+            #!/bin/sh
             echo "cdidx v1.24.6"
             EOF
             chmod +x "{{Path.Combine(payloadDir, "cdidx")}}"

--- a/tests/CodeIndex.Tests/InstallScriptTests.cs
+++ b/tests/CodeIndex.Tests/InstallScriptTests.cs
@@ -12,7 +12,7 @@ namespace CodeIndex.Tests;
 /// </summary>
 public sealed class InstallScriptTests : IDisposable
 {
-    private static readonly TimeSpan InstallerSnippetTimeout = TimeSpan.FromSeconds(120);
+    private static readonly TimeSpan InstallerSnippetTimeout = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan InstallerSnippetKillWaitTimeout = TimeSpan.FromSeconds(5);
 
     private readonly string _tempRoot = TestProjectHelper.CreateTempProject("cdidx_install_script");
@@ -43,7 +43,7 @@ public sealed class InstallScriptTests : IDisposable
                 ["CDIDX_INSTALL_DIR"] = installDir,
             });
 
-        Assert.Equal(0, exitCode);
+        AssertInstallerCommandSucceeded(exitCode, stdout, stderr);
         Assert.Equal(string.Empty, stderr);
         Assert.Contains("Uninstall complete", stdout);
         Assert.False(File.Exists(Path.Combine(installDir, "cdidx")));
@@ -79,7 +79,7 @@ public sealed class InstallScriptTests : IDisposable
                 ["XDG_CACHE_HOME"] = cacheRoot + "/",
             });
 
-        Assert.Equal(0, exitCode);
+        AssertInstallerCommandSucceeded(exitCode, stdout, stderr);
         Assert.Equal(string.Empty, stderr);
         Assert.Contains("Removed", stdout);
         Assert.False(Directory.Exists(cdidxCache));
@@ -1527,7 +1527,7 @@ public sealed class InstallScriptTests : IDisposable
                 ["CDIDX_INSTALL_DIR"] = installDir,
             });
 
-        Assert.Equal(0, exitCode);
+        AssertInstallerCommandSucceeded(exitCode, stdout, stderr);
         Assert.Contains("INSTALL_OK", stdout);
         Assert.Contains("LICENSE:license text", stdout);
         Assert.Contains("COMMERCIAL:commercial license text", stdout);
@@ -1613,7 +1613,7 @@ public sealed class InstallScriptTests : IDisposable
                 ["CDIDX_INSTALL_DIR"] = installDir,
             });
 
-        AssertInstallerSnippetSucceeded(exitCode, stdout, stderr);
+        AssertInstallerCommandSucceeded(exitCode, stdout, stderr);
         Assert.Contains("REINSTALL_OK", stdout);
         Assert.Equal(string.Empty, stderr);
         Assert.Equal("new-license", File.ReadAllText(Path.Combine(installDir, "LICENSES", "new.txt")));
@@ -5977,12 +5977,12 @@ public sealed class InstallScriptTests : IDisposable
     private static string AppendInstallerSnippetDiagnostic(string output, string diagnostic)
         => string.IsNullOrEmpty(output) ? diagnostic : output + Environment.NewLine + diagnostic;
 
-    private static void AssertInstallerSnippetSucceeded(int exitCode, string stdout, string stderr)
+    private static void AssertInstallerCommandSucceeded(int exitCode, string stdout, string stderr)
         => Assert.True(
             exitCode == 0,
             string.Join(
                 Environment.NewLine,
-                $"Expected installer snippet exit code 0, actual {exitCode}.",
+                $"Expected installer command exit code 0, actual {exitCode}.",
                 "stdout:",
                 stdout,
                 "stderr:",

--- a/tests/CodeIndex.Tests/InstallScriptTests.cs
+++ b/tests/CodeIndex.Tests/InstallScriptTests.cs
@@ -12,7 +12,7 @@ namespace CodeIndex.Tests;
 /// </summary>
 public sealed class InstallScriptTests : IDisposable
 {
-    private static readonly TimeSpan InstallerSnippetTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan InstallerSnippetTimeout = TimeSpan.FromSeconds(120);
     private static readonly TimeSpan InstallerSnippetKillWaitTimeout = TimeSpan.FromSeconds(5);
 
     private readonly string _tempRoot = TestProjectHelper.CreateTempProject("cdidx_install_script");
@@ -1613,7 +1613,7 @@ public sealed class InstallScriptTests : IDisposable
                 ["CDIDX_INSTALL_DIR"] = installDir,
             });
 
-        Assert.Equal(0, exitCode);
+        AssertInstallerSnippetSucceeded(exitCode, stdout, stderr);
         Assert.Contains("REINSTALL_OK", stdout);
         Assert.Equal(string.Empty, stderr);
         Assert.Equal("new-license", File.ReadAllText(Path.Combine(installDir, "LICENSES", "new.txt")));
@@ -5976,6 +5976,17 @@ public sealed class InstallScriptTests : IDisposable
 
     private static string AppendInstallerSnippetDiagnostic(string output, string diagnostic)
         => string.IsNullOrEmpty(output) ? diagnostic : output + Environment.NewLine + diagnostic;
+
+    private static void AssertInstallerSnippetSucceeded(int exitCode, string stdout, string stderr)
+        => Assert.True(
+            exitCode == 0,
+            string.Join(
+                Environment.NewLine,
+                $"Expected installer snippet exit code 0, actual {exitCode}.",
+                "stdout:",
+                stdout,
+                "stderr:",
+                stderr));
 
     private static string GetInstallScriptPath() => Path.Combine(GetRepositoryRoot(), "install.sh");
 

--- a/tests/CodeIndex.Tests/InstallScriptTests.cs
+++ b/tests/CodeIndex.Tests/InstallScriptTests.cs
@@ -12,6 +12,9 @@ namespace CodeIndex.Tests;
 /// </summary>
 public sealed class InstallScriptTests : IDisposable
 {
+    private static readonly TimeSpan InstallerSnippetTimeout = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan InstallerSnippetKillWaitTimeout = TimeSpan.FromSeconds(5);
+
     private readonly string _tempRoot = TestProjectHelper.CreateTempProject("cdidx_install_script");
 
     public void Dispose()
@@ -5916,9 +5919,25 @@ public sealed class InstallScriptTests : IDisposable
 
             using var process = Process.Start(psi)
                 ?? throw new InvalidOperationException("Failed to start bash install snippet / bash install snippet の起動に失敗");
-            var stdOut = process.StandardOutput.ReadToEnd();
-            var stdErr = process.StandardError.ReadToEnd();
-            process.WaitForExit();
+            var stdOutTask = process.StandardOutput.ReadToEndAsync();
+            var stdErrTask = process.StandardError.ReadToEndAsync();
+            var timedOut = !process.WaitForExit((int)InstallerSnippetTimeout.TotalMilliseconds);
+            if (timedOut)
+            {
+                var killDiagnostic = TryKillInstallerSnippet(process);
+                process.WaitForExit((int)InstallerSnippetKillWaitTimeout.TotalMilliseconds);
+
+                var timeoutDiagnostic = $"Installer snippet timed out after {InstallerSnippetTimeout}.";
+                if (!string.IsNullOrEmpty(killDiagnostic))
+                    timeoutDiagnostic += $" {killDiagnostic}";
+                return (
+                    -1,
+                    ReadInstallerSnippetOutput(stdOutTask),
+                    AppendInstallerSnippetDiagnostic(ReadInstallerSnippetOutput(stdErrTask), timeoutDiagnostic));
+            }
+
+            var stdOut = ReadInstallerSnippetOutput(stdOutTask);
+            var stdErr = ReadInstallerSnippetOutput(stdErrTask);
             return (process.ExitCode, stdOut, stdErr);
         }
         finally
@@ -5926,6 +5945,37 @@ public sealed class InstallScriptTests : IDisposable
             TestProjectHelper.DeleteFile(scriptPath);
         }
     }
+
+    private static string TryKillInstallerSnippet(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+            return string.Empty;
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or NotSupportedException or System.ComponentModel.Win32Exception)
+        {
+            return $"Process cleanup failed: {ex.GetType().Name}: {ex.Message}";
+        }
+    }
+
+    private static string ReadInstallerSnippetOutput(Task<string> outputTask)
+    {
+        try
+        {
+            return outputTask.Wait((int)InstallerSnippetKillWaitTimeout.TotalMilliseconds)
+                ? outputTask.GetAwaiter().GetResult()
+                : "<output capture incomplete>";
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or InvalidOperationException or AggregateException)
+        {
+            return $"<output capture failed: {ex.GetType().Name}: {ex.Message}>";
+        }
+    }
+
+    private static string AppendInstallerSnippetDiagnostic(string output, string diagnostic)
+        => string.IsNullOrEmpty(output) ? diagnostic : output + Environment.NewLine + diagnostic;
 
     private static string GetInstallScriptPath() => Path.Combine(GetRepositoryRoot(), "install.sh");
 


### PR DESCRIPTION
## Summary

- Add bounded timeout handling and captured diagnostics for installer snippet tests so hangs fail as actionable test failures.
- Stabilize reinstall installer fixtures with portable fake `cdidx` scripts and diagnostic assertions.
- Widen GitHelper timeout/cancellation wall-clock assertions while keeping fake git completion beyond the expected timeout budget.
- Update bilingual testing guidance and add changelog fragments for each fixed issue.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter "FullyQualifiedName~InstallScriptTests.DownloadAndInstall_OptionalLicenseAssetsAreInstalledWhenPresent|FullyQualifiedName~InstallScriptTests.DownloadAndInstall_ReinstallReplacesExistingOptionalDirectories"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -p:UseSharedCompilation=false --filter "FullyQualifiedName~GitHelperTests.RunGitCapturingResult_TimeoutReportsStructuredFailure_Issue3434|FullyQualifiedName~GitHelperTests.GetRepositoryRootAsync_CancelBeforeGitReturns_PropagatesCancellation|FullyQualifiedName~GitHelperTests.GetCurrentCommitAsync_CancelBeforeGitReturns_PropagatesCancellation|FullyQualifiedName~GitHelperTests.GetTrackedFilesAsync_CancelBeforeGitReturns_PropagatesCancellation"`
- `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false --no-restore`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- Adversarial review: No blocking/actionable issues found.

## Changelog

- `changelog.d/unreleased/4015.internal.md`
- `changelog.d/unreleased/4024.internal.md`
- `changelog.d/unreleased/4027.internal.md`

No changes were made to `AGENT.md`, `CLAUDE.md`, or `AGENT_GUIDE.md`.

Fixes #4015
Fixes #4024
Fixes #4027
