### PR TITLE
[codex] Improve huge codebase indexing performance

### DIFF
--- a/changelog.d/unreleased/+chunk-line-capacity.changed.md
+++ b/changelog.d/unreleased/+chunk-line-capacity.changed.md
@@ -1,0 +1,16 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Indexer/Scanning/ChunkSplitter.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+---
+
+## English
+
+- **Chunking reuses known line counts during indexing** — CLI and MCP indexing now pass the loader's normalized line count into chunk splitting so large files avoid repeated line-offset list growth while preserving the same chunk output.
+
+## 日本語
+
+- **chunking が indexing 済みの行数情報を再利用するようになりました** — CLI と MCP の indexing は loader が持つ正規化後 line count を chunk 分割に渡し、大きなファイルで line offset list の再確保を避けつつ従来と同じ chunk 出力を保ちます。

--- a/changelog.d/unreleased/+empty-csharp-prepass-skip.changed.md
+++ b/changelog.d/unreleased/+empty-csharp-prepass-skip.changed.md
@@ -1,0 +1,17 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **Full index runs skip the C# static-interface prepass when the scan has no C# files** - CLI and MCP index paths now avoid the empty-candidate prepass query and use an empty C# workspace directly.
+
+## 日本語
+
+- **scan に C# file がない full index では C# static-interface prepass を省略します** - CLI / MCP index は候補 0 件の prepass query を避け、空の C# workspace を直接使うようになりました。

--- a/changelog.d/unreleased/+finalizer-language-existence-cache.changed.md
+++ b/changelog.d/unreleased/+finalizer-language-existence-cache.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+---
+
+## English
+
+- **Index finalizers reuse language-existence checks** — CLI full-scan, CLI scoped update, and MCP index finalizers now query indexed C# / SQL language presence once per run instead of repeating the same SQLite existence checks while stamping readiness.
+
+## 日本語
+
+- **index finalizer が言語存在チェックを再利用します** — CLI full-scan、CLI scoped update、MCP index の finalizer は、readiness stamp 中に同じ SQLite 言語存在チェックを繰り返さず、C# / SQL の indexed file 有無を run ごとに一度だけ読むようになりました。

--- a/changelog.d/unreleased/+fullscan-csharp-metadata-noop.changed.md
+++ b/changelog.d/unreleased/+fullscan-csharp-metadata-noop.changed.md
@@ -1,0 +1,13 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+---
+
+## English
+
+- **No-op full scans reuse current C# metadata-target trust** — full-repository `cdidx index` runs now skip the C# metadata-target resolver when no C# rows changed and the existing metadata-target contract is already current.
+
+## 日本語
+
+- **変更なし full scan が最新の C# metadata-target trust を再利用するようになりました** — full-repository の `cdidx index` は、C# 行に変更がなく既存の metadata-target 契約が最新の場合、C# metadata-target resolver をスキップします。

--- a/changelog.d/unreleased/+fullscan-noop-extraction-short-circuit.changed.md
+++ b/changelog.d/unreleased/+fullscan-noop-extraction-short-circuit.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **No-op full scans skip extraction setup** — full-repository `cdidx index` runs now avoid starting extraction workers and post-extraction hook discovery when every file can be reused from stat metadata.
+
+## 日本語
+
+- **変更なし full scan で抽出基盤の起動を省くようになりました** — full-repository の `cdidx index` は、全ファイルを stat metadata から再利用できる場合に extraction worker と post-extraction hook discovery を起動しないようになりました。

--- a/changelog.d/unreleased/+fullscan-noop-finalize.changed.md
+++ b/changelog.d/unreleased/+fullscan-noop-finalize.changed.md
@@ -1,0 +1,13 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+---
+
+## English
+
+- **No-op full scans skip unnecessary FTS optimization** — full-repository `cdidx index` runs now avoid the expensive FTS5 optimize step when no indexed chunks were inserted, deleted, or purged.
+
+## 日本語
+
+- **変更なし full scan で不要な FTS optimize を省くようになりました** — full-repository の `cdidx index` は、indexed chunk の追加・削除・purge がない場合に高コストな FTS5 optimize を実行しないようになりました。

--- a/changelog.d/unreleased/+fullscan-stat-skip.changed.md
+++ b/changelog.d/unreleased/+fullscan-stat-skip.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Indexer/CSharpStaticInterfacePrepass.cs
+---
+
+## English
+
+- **Full scans skip unchanged files before content loading** — `cdidx index <path>` now reuses stat-matched existing rows before queueing extraction work, and the C# static-interface prepass reuses existing workspace symbols for unchanged C# files instead of reading them again.
+
+## 日本語
+
+- **full scan が content load 前に未変更ファイルを skip するようになりました** — `cdidx index <path>` は抽出キュー投入前に stat が一致する既存行を再利用し、C# static-interface prepass も未変更の C# ファイルを再読込せず既存 workspace symbols を使うようになりました。

--- a/changelog.d/unreleased/+fullscan-typescript-augmentation-noop.changed.md
+++ b/changelog.d/unreleased/+fullscan-typescript-augmentation-noop.changed.md
@@ -1,0 +1,16 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Database/DbReader.cs
+  - src/CodeIndex/Database/DbWriter.cs
+---
+
+## English
+
+- **No-op full scans skip TypeScript augmentation rebuilds** — `cdidx index <path>` now avoids the all-TypeScript augmentation reference rebuild when the scan reused every TypeScript row, no stale rows were purged, and the existing hotspot-family trust is current.
+
+## 日本語
+
+- **no-op full scan が TypeScript augmentation rebuild を skip します** — `cdidx index <path>` は、すべての TypeScript row を再利用し、stale row purge がなく、既存の hotspot-family trust が現行の場合に、全 TypeScript augmentation reference の再構築を避けるようになりました。

--- a/changelog.d/unreleased/+fullscan-validation-read-ahead-memory.changed.md
+++ b/changelog.d/unreleased/+fullscan-validation-read-ahead-memory.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Full scans retain less read-ahead memory during sequential extraction** — non-precomputed full-scan workers now validate file content before handing work to the writer, and their read-ahead queue is bounded to one item, so queued work no longer keeps raw bytes alongside decoded content while preserving file issue reporting.
+
+## 日本語
+
+- **逐次抽出の full scan で先読みメモリ保持を削減しました** — precompute しない full scan worker は writer へ処理を渡す前にファイル内容を検証し、先読み queue を 1 item に制限するようになりました。これにより、file issue の記録を維持しながら queued work が decoded content と raw bytes を同時に保持しないようになりました。

--- a/changelog.d/unreleased/+generated-reuse-suppression-check.changed.md
+++ b/changelog.d/unreleased/+generated-reuse-suppression-check.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+---
+
+## English
+
+- **Unchanged generated-code reuse checks avoid constructing issue payloads** - CLI and MCP no-op reuse paths now compare generated-code suppression state as a boolean and only build the `generated_code_extraction_skipped` issue when a file is actually reindexed.
+
+## 日本語
+
+- **unchanged generated code の再利用判定で issue payload を構築しないようになりました** - CLI / MCP の no-op reuse path は generated-code suppression 状態を boolean として比較し、`generated_code_extraction_skipped` issue は実際に再 index する file でのみ構築します。

--- a/changelog.d/unreleased/+index-run-byte-size-cache.changed.md
+++ b/changelog.d/unreleased/+index-run-byte-size-cache.changed.md
@@ -1,0 +1,17 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Index-run byte accounting reuses sizes already observed while indexing** - CLI and MCP index runs now feed stat-skip and loaded-record sizes into `last_index_run.bytes_read`, avoiding a second file-size probe for unchanged files during final metadata stamping.
+
+## 日本語
+
+- **index run の byte 集計が index 中に観測済みの size を再利用するようになりました** - CLI / MCP index は stat skip や読み込み済み record の size を `last_index_run.bytes_read` に渡し、最終 metadata stamp 時に unchanged file を再度 size probe しないようになりました。

--- a/changelog.d/unreleased/+mcp-csharp-metadata-noop.changed.md
+++ b/changelog.d/unreleased/+mcp-csharp-metadata-noop.changed.md
@@ -1,0 +1,13 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+---
+
+## English
+
+- **MCP no-op indexing skips unchanged C# metadata resolution** — the MCP `index` tool now avoids the all-workspace C# metadata-target resolver when no C# rows were rewritten or purged and the existing metadata-target contract stamp is current.
+
+## 日本語
+
+- **MCP の no-op index が未変更 C# metadata 解決を skip します** — MCP `index` ツールは、C# row の書き換えや purge がなく、既存の metadata-target contract stamp が現行の場合に、全ワークスペースの C# metadata-target resolver を避けるようになりました。

--- a/changelog.d/unreleased/+mcp-noop-fts.changed.md
+++ b/changelog.d/unreleased/+mcp-noop-fts.changed.md
@@ -1,0 +1,13 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+---
+
+## English
+
+- **MCP no-op indexing skips FTS optimization** — the MCP `index` tool now avoids `OptimizeFts()` when an index pass reuses existing rows and performs no FTS-affecting purge, delete, or upsert.
+
+## 日本語
+
+- **MCP の no-op index が FTS optimize を skip します** — MCP `index` ツールは、既存 row を再利用し、FTS に影響する purge / delete / upsert がない場合に `OptimizeFts()` を避けるようになりました。

--- a/changelog.d/unreleased/+mcp-noop-hook-discovery-lazy.changed.md
+++ b/changelog.d/unreleased/+mcp-noop-hook-discovery-lazy.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+---
+
+## English
+
+- **No-op MCP indexes skip hook discovery** — MCP `index_project` now delays post-extraction hook discovery until a file actually needs symbol/reference extraction, reducing overhead for unchanged large workspaces.
+
+## 日本語
+
+- **変更なし MCP index で hook discovery を省くようになりました** — MCP `index_project` は、実際に symbol/reference extraction が必要なファイルが出るまで post-extraction hook discovery を遅らせ、変更なしの巨大 workspace での余分な overhead を減らします。

--- a/changelog.d/unreleased/+mcp-stat-skip.changed.md
+++ b/changelog.d/unreleased/+mcp-stat-skip.changed.md
@@ -1,0 +1,13 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+---
+
+## English
+
+- **MCP indexing skips unchanged files before content loading** — the MCP `index` tool now reuses stat-matched rows before reading file contents, and its C# static-interface prepass can reuse unchanged C# symbols directly from the existing index.
+
+## 日本語
+
+- **MCP index が content load 前に未変更ファイルを skip します** — MCP `index` ツールは、ファイル内容を読む前に stat が一致する row を再利用し、C# static-interface prepass も未変更 C# symbols を既存 index から直接再利用できるようになりました。

--- a/changelog.d/unreleased/+mcp-typescript-augmentation-noop.changed.md
+++ b/changelog.d/unreleased/+mcp-typescript-augmentation-noop.changed.md
@@ -1,0 +1,13 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+---
+
+## English
+
+- **MCP no-op indexing skips TypeScript augmentation rebuilds** — the MCP `index` tool now avoids rebuilding all TypeScript augmentation references when an index run reuses existing rows, keeps the same project root, and already has a current augmentation contract stamp.
+
+## 日本語
+
+- **MCP の no-op index が TypeScript augmentation rebuild を skip します** — MCP `index` ツールは、既存 row を再利用し、project root が同じで、augmentation contract stamp が現行の場合に、全 TypeScript augmentation reference の再構築を避けるようになりました。

--- a/changelog.d/unreleased/+refresh-js-ts-config-fallback.changed.md
+++ b/changelog.d/unreleased/+refresh-js-ts-config-fallback.changed.md
@@ -4,12 +4,13 @@ affected:
   - src/CodeIndex/Cli/IndexCommandRunner.cs
   - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
   - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - src/CodeIndex/Database/DbWriter.cs
 ---
 
 ## English
 
-- **JavaScript/TypeScript config fallback scans refresh JS/TS references** — scoped updates that fall back to a full scan after `jsconfig*.json` or `tsconfig*.json` changes now force JavaScript and TypeScript files through extraction instead of reusing unchanged rows, so path-alias reference targets are recalculated while ordinary no-op full scans still keep the new stat-skip fast path.
+- **JavaScript/TypeScript config refreshes re-extract JS/TS references** — scoped updates that fall back to a full scan after `jsconfig*.json` or `tsconfig*.json` changes, and ordinary full scans that observe changed or removed JS/TS config files, now force JavaScript and TypeScript files through extraction instead of reusing unchanged rows, so path-alias reference targets are recalculated while unrelated no-op full scans still keep the new stat-skip fast path.
 
 ## 日本語
 
-- **JavaScript/TypeScript 設定変更の fallback full scan が JS/TS 参照を再抽出するようになりました** — `jsconfig*.json` または `tsconfig*.json` の変更で scoped update が full scan にフォールバックした場合、JavaScript/TypeScript ファイルは未変更行の再利用ではなく抽出を通すようにし、通常の no-op full scan では新しい stat skip 高速化を維持したまま path alias の参照先を再計算します。
+- **JavaScript/TypeScript 設定変更時に JS/TS 参照を再抽出するようになりました** — `jsconfig*.json` または `tsconfig*.json` の変更で scoped update が full scan にフォールバックした場合に加え、通常の full scan が JS/TS 設定ファイルの変更または削除を検出した場合も、JavaScript/TypeScript ファイルは未変更行の再利用ではなく抽出を通すようにし、無関係な no-op full scan では新しい stat skip 高速化を維持したまま path alias の参照先を再計算します。

--- a/changelog.d/unreleased/+refresh-js-ts-config-fallback.changed.md
+++ b/changelog.d/unreleased/+refresh-js-ts-config-fallback.changed.md
@@ -9,8 +9,8 @@ affected:
 
 ## English
 
-- **JavaScript/TypeScript config refreshes re-extract JS/TS references** — scoped updates that fall back to a full scan after `jsconfig*.json` or `tsconfig*.json` changes, and ordinary full scans that observe changed or removed JS/TS config files, now force JavaScript and TypeScript files through extraction instead of reusing unchanged rows, so path-alias reference targets are recalculated while unrelated no-op full scans still keep the new stat-skip fast path.
+- **JavaScript/TypeScript config refreshes re-extract JS/TS references** — scoped updates that fall back to a full scan after `jsconfig*.json` or `tsconfig*.json` changes, and ordinary full scans that observe changed or removed JS/TS config files including derived names such as `tsconfig.base.json`, now force JavaScript and TypeScript files through extraction instead of reusing unchanged rows, so path-alias reference targets are recalculated while unrelated no-op full scans still keep the new stat-skip fast path.
 
 ## 日本語
 
-- **JavaScript/TypeScript 設定変更時に JS/TS 参照を再抽出するようになりました** — `jsconfig*.json` または `tsconfig*.json` の変更で scoped update が full scan にフォールバックした場合に加え、通常の full scan が JS/TS 設定ファイルの変更または削除を検出した場合も、JavaScript/TypeScript ファイルは未変更行の再利用ではなく抽出を通すようにし、無関係な no-op full scan では新しい stat skip 高速化を維持したまま path alias の参照先を再計算します。
+- **JavaScript/TypeScript 設定変更時に JS/TS 参照を再抽出するようになりました** — `jsconfig*.json` または `tsconfig*.json` の変更で scoped update が full scan にフォールバックした場合に加え、通常の full scan が `tsconfig.base.json` のような派生名を含む JS/TS 設定ファイルの変更または削除を検出した場合も、JavaScript/TypeScript ファイルは未変更行の再利用ではなく抽出を通すようにし、無関係な no-op full scan では新しい stat skip 高速化を維持したまま path alias の参照先を再計算します。

--- a/changelog.d/unreleased/+refresh-js-ts-config-fallback.changed.md
+++ b/changelog.d/unreleased/+refresh-js-ts-config-fallback.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+---
+
+## English
+
+- **JavaScript/TypeScript config fallback scans refresh JS/TS references** — scoped updates that fall back to a full scan after `jsconfig*.json` or `tsconfig*.json` changes now force JavaScript and TypeScript files through extraction instead of reusing unchanged rows, so path-alias reference targets are recalculated while ordinary no-op full scans still keep the new stat-skip fast path.
+
+## 日本語
+
+- **JavaScript/TypeScript 設定変更の fallback full scan が JS/TS 参照を再抽出するようになりました** — `jsconfig*.json` または `tsconfig*.json` の変更で scoped update が full scan にフォールバックした場合、JavaScript/TypeScript ファイルは未変更行の再利用ではなく抽出を通すようにし、通常の no-op full scan では新しい stat skip 高速化を維持したまま path alias の参照先を再計算します。

--- a/changelog.d/unreleased/+reuse-blocking-query.changed.md
+++ b/changelog.d/unreleased/+reuse-blocking-query.changed.md
@@ -1,0 +1,16 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+---
+
+## English
+
+- **Reusable-row validation combines cap and generated-code checks** — CLI and MCP indexing now validate extraction caps and generated-code suppression state for unchanged rows with one SQLite query.
+
+## 日本語
+
+- **再利用 row の cap / generated-code 判定をまとめました** — CLI と MCP の indexing は、未変更 row の extraction cap と generated-code 抑止状態を単一の SQLite クエリで検証するようになりました。

--- a/changelog.d/unreleased/+reuse-cap-check-query.changed.md
+++ b/changelog.d/unreleased/+reuse-cap-check-query.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Database/DbWriter.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+---
+
+## English
+
+- **Unchanged-file reuse checks use fewer SQLite round trips** — indexing now checks symbol/reference cap violations for reusable existing rows with one query instead of separate count and issue lookups.
+
+## 日本語
+
+- **未変更ファイル再利用時の SQLite 往復を削減しました** — indexing は再利用可能な既存行の symbol/reference cap 違反を、個別の count / issue lookup ではなく単一クエリで確認するようになりました。

--- a/changelog.d/unreleased/+stat-reuse-path.changed.md
+++ b/changelog.d/unreleased/+stat-reuse-path.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+---
+
+## English
+
+- **Stat-based unchanged checks reuse normalized paths** — full-scan, update, and C# prepass skip checks now pass the already-normalized index path into the reuse helper instead of recomputing a relative path per file.
+
+## 日本語
+
+- **stat ベースの未変更判定が正規化済み path を再利用するようになりました** — full scan、update、C# prepass の skip 判定は、ファイルごとに relative path を再計算せず、既に正規化済みの index path を reuse helper に渡します。

--- a/changelog.d/unreleased/+typescript-augmentation-stamp-clear.changed.md
+++ b/changelog.d/unreleased/+typescript-augmentation-stamp-clear.changed.md
@@ -1,0 +1,16 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - src/CodeIndex/Database/DbWriter.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+---
+
+## English
+
+- **TypeScript augmentation freshness is cleared with the mutation that needs a rebuild** — CLI and MCP indexing now clear the `typescript_augmentation_version` stamp when a committed file or purge invalidates augmentation references, so interrupted or partial runs force the next successful index to rebuild them instead of trusting an older success stamp.
+
+## 日本語
+
+- **TypeScript augmentation の freshness stamp を再構築が必要な mutation と同時に clear するようにしました** — CLI と MCP の index は、commit 済みファイル更新や purge が augmentation 参照を無効化した時点で `typescript_augmentation_version` を clear し、中断・部分失敗後の次回成功 index が古い成功 stamp を信頼せず必ず再構築するようにしました。

--- a/changelog.d/unreleased/+typescript-unchanged-reuse.changed.md
+++ b/changelog.d/unreleased/+typescript-unchanged-reuse.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+---
+
+## English
+
+- **Unchanged JavaScript and TypeScript files reuse existing index rows** — CLI and MCP indexing now let unchanged JS/TS files take the same row-reuse path as other languages while final TypeScript augmentation rebuilding still runs when an index pass actually mutates the graph.
+
+## 日本語
+
+- **未変更の JavaScript / TypeScript ファイルが既存 index 行を再利用するようになりました** — CLI と MCP の indexing で、未変更の JS/TS ファイルも他言語と同じ row reuse 経路を使えるようにしつつ、index 実行が graph を変更した場合の TypeScript augmentation 再構築は維持します。

--- a/changelog.d/unreleased/+update-csharp-metadata-noop.changed.md
+++ b/changelog.d/unreleased/+update-csharp-metadata-noop.changed.md
@@ -1,0 +1,13 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+---
+
+## English
+
+- **Scoped updates skip unnecessary C# metadata resolution** — `cdidx index --files ...` no longer runs the all-workspace C# metadata-target resolver when only non-C# files were rewritten and the existing C# metadata contract is already current.
+
+## 日本語
+
+- **scoped update が不要な C# metadata 解決を skip します** — `cdidx index --files ...` は、C# 以外のファイルだけを書き換え、既存の C# metadata contract が現行の場合に、全ワークスペースの C# metadata-target resolver を走らせないようになりました。

--- a/changelog.d/unreleased/+update-csharp-prepass-skip.changed.md
+++ b/changelog.d/unreleased/+update-csharp-prepass-skip.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Scoped updates skip the C# static-interface prepass when no target can be C#** - `cdidx index --files` now filters prepass candidates up front, avoiding duplicate language probes for large non-C# update sets.
+
+## 日本語
+
+- **C# になり得る target がない scoped update では C# static-interface prepass を省略します** - `cdidx index --files` は prepass 候補を先に絞り込み、大規模な非 C# update set で重複する言語 probe を避けます。

--- a/changelog.d/unreleased/+update-noop-extraction-lazy.changed.md
+++ b/changelog.d/unreleased/+update-noop-extraction-lazy.changed.md
@@ -1,0 +1,15 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **No-op scoped updates skip extraction setup** — `cdidx index --files` / commit-scoped update runs now avoid creating symbol extraction workers and discovering post-extraction hooks until a file actually needs re-indexing.
+
+## 日本語
+
+- **変更なし scoped update で抽出基盤の起動を省くようになりました** — `cdidx index --files` や commit scoped update は、実際に再インデックスが必要なファイルが出るまで symbol extraction worker と post-extraction hook discovery を作らないようになりました。

--- a/changelog.d/unreleased/+update-typescript-augmentation-noop.changed.md
+++ b/changelog.d/unreleased/+update-typescript-augmentation-noop.changed.md
@@ -1,0 +1,13 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+---
+
+## English
+
+- **Scoped updates skip unchanged TypeScript augmentation rebuilds** — `cdidx index --files ...` now avoids rebuilding all TypeScript augmentation references when the update only rewrote non-TypeScript files, no stale rows were purged, the project root stayed the same, and the augmentation contract stamp is current.
+
+## 日本語
+
+- **scoped update が未変更 TypeScript augmentation rebuild を skip します** — `cdidx index --files ...` は、TypeScript 以外のファイルだけを書き換え、stale row purge がなく、project root が同じで、augmentation contract stamp が現行の場合に、全 TypeScript augmentation reference の再構築を避けるようになりました。

--- a/changelog.d/unreleased/+update-typescript-delete-augmentation.changed.md
+++ b/changelog.d/unreleased/+update-typescript-delete-augmentation.changed.md
@@ -1,0 +1,14 @@
+---
+category: changed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **Scoped updates refresh TypeScript augmentation after deletes** — `cdidx index --files` now clears and rebuilds TypeScript augmentation metadata when an update deletes or purges indexed rows, preventing stale augmentation readiness after TypeScript files disappear.
+
+## 日本語
+
+- **scoped update の削除時に TypeScript augmentation を更新するようになりました** — `cdidx index --files` は update 中に indexed row を delete/purge した場合、TypeScript augmentation metadata を clear/rebuild し、TypeScript ファイル削除後に古い augmentation readiness が残らないようにします。

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -1206,7 +1206,6 @@ public static partial class IndexCommandRunner
             var language = target.Language;
             var allowReuse = symbolKindFilterMatchesPrior
                 && !priorSymbolsOnlyGraphOmitted
-                && language is not ("javascript" or "typescript")
                 && (language != "csharp" || csharpSymbolNameContractMatchesCurrent)
                 && (language != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
                 && (language != "sql" || sqlGraphContractMatchesCurrent)
@@ -1563,7 +1562,6 @@ public static partial class IndexCommandRunner
                             generated: record.Generated,
                             allowReuse: symbolKindFilterMatchesPrior
                                 && !priorSymbolsOnlyGraphOmitted
-                                && record.Lang is not ("javascript" or "typescript")
                                 && (record.Lang != "csharp" || csharpSymbolNameContractMatchesCurrent)
                                 && (record.Lang != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
                                 && (record.Lang != "sql" || sqlGraphContractMatchesCurrent)

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -1893,10 +1893,11 @@ public static partial class IndexCommandRunner
         // degraded rather than authoritative. Interrupted runs also stay unstamped because
         // ClearReadyFlags() ran at the start.
         // errors==0 の成功 run のみマーカーを打つ。途中失敗は未 stamp のままで縮退扱い。
+        var hasCSharpFilesAfter = writer.HasAnyFilesWithLanguage("csharp");
         var graphTableAvailableAfter = false;
         var issuesTableAvailableAfter = false;
-        var csharpSymbolNameReadyAfter = !writer.HasAnyFilesWithLanguage("csharp");
-        var csharpMetadataTargetReadyAfter = !writer.HasAnyFilesWithLanguage("csharp");
+        var csharpSymbolNameReadyAfter = !hasCSharpFilesAfter;
+        var csharpMetadataTargetReadyAfter = !hasCSharpFilesAfter;
         var foldReadyAfter = false;
         string? foldReadyReasonAfter = null;
         if (errors == 0)
@@ -1918,7 +1919,7 @@ public static partial class IndexCommandRunner
                 writer.SetMeta(DbContext.SymbolsOnlyGraphOmittedMetaKey, "true");
             }
             writer.MarkCSharpSymbolNameContractReady();
-            if (writer.HasAnyFilesWithLanguage("csharp"))
+            if (hasCSharpFilesAfter)
             {
                 if (csharpMetadataTargetsNeedRefresh)
                 {

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -780,7 +780,6 @@ public static partial class IndexCommandRunner
         var jsonContext = CliJsonSerializerContextFactory.Create(jsonOptions);
         var memorySamples = options.MemoryTrace ? new List<IndexMemorySampleJsonResult> { CaptureMemorySample("start", stopwatch) } : [];
         var actualMode = options.Rebuild ? "rebuild" : "incremental";
-        _ = priorMetadataTargetCsharp; // full-scan resolver runs unconditionally on success / 成功時に常に再解決するため不要
         var unresolvedMergeExitCode = RejectUnresolvedMergeState(projectRoot, options.Json, jsonOptions, cancellationToken);
         if (unresolvedMergeExitCode != null)
             return unresolvedMergeExitCode.Value;
@@ -792,6 +791,8 @@ public static partial class IndexCommandRunner
         var projectRootWritten = PathsEqual(normalizedPriorIndexedProjectRoot, normalizedProjectRoot);
         var currentCSharpSymbolNameContractVersion = DbContext.CSharpSymbolNameContractVersion.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var csharpSymbolNameContractMatchesCurrent = priorCSharpSymbolNameContractVersion == currentCSharpSymbolNameContractVersion;
+        var currentMetadataTargetVersion = DbContext.MetadataTargetVersion.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var priorMetadataTargetCsharpMatchesCurrent = priorMetadataTargetCsharp == currentMetadataTargetVersion;
         var currentSqlGraphContractVersion = DbContext.SqlGraphContractVersion.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var sqlGraphContractMatchesCurrent = priorSqlGraphContractVersion == currentSqlGraphContractVersion;
         var hotspotFamilyTrustMatchesCurrent = GetHotspotFamilyTrustMatchesCurrent(
@@ -987,6 +988,10 @@ public static partial class IndexCommandRunner
         var hasPostExtractionHooks = postExtractionHooks.Hooks.Count > 0;
         var existingFileCount = writer.GetCounts().files;
         var startedWithNoIndexedFiles = existingFileCount == 0;
+        var csharpMetadataTargetsNeedRefresh = options.Rebuild
+            || startedWithNoIndexedFiles
+            || purged > 0
+            || !priorMetadataTargetCsharpMatchesCurrent;
         var parallelizeExtraction = (options.Rebuild || startedWithNoIndexedFiles)
             && !options.SymbolKindFilter.IsActive
             && !hasPostExtractionHooks;
@@ -1512,6 +1517,7 @@ public static partial class IndexCommandRunner
                             if (writer.DeleteFileByPath(currentJsonIndexFile))
                             {
                                 ftsMutated = true;
+                                csharpMetadataTargetsNeedRefresh = true;
                                 WriteProjectRootOnce();
                                 deleteTxn.Commit();
                             }
@@ -1575,8 +1581,12 @@ public static partial class IndexCommandRunner
                     }
                     if (existingId != null)
                     {
-                        if (writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum) > 0)
+                        var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
+                        if (stalePurged > 0)
+                        {
                             ftsMutated = true;
+                            csharpMetadataTargetsNeedRefresh = true;
+                        }
                         skipped++;
                         processed++;
                         if (!string.IsNullOrWhiteSpace(record.Lang))
@@ -1601,11 +1611,18 @@ public static partial class IndexCommandRunner
                         continue;
                     }
 
+                    if (record.Lang == "csharp")
+                        csharpMetadataTargetsNeedRefresh = true;
+
                     using var txn = writer.BeginTransaction(cancellationToken, "full scan file");
                     if (!startedWithNoIndexedFiles)
                     {
-                        if (writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum) > 0)
+                        var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
+                        if (stalePurged > 0)
+                        {
                             ftsMutated = true;
+                            csharpMetadataTargetsNeedRefresh = true;
+                        }
                     }
                     var fileId = writer.UpsertFile(record, cleanExistingData: !startedWithNoIndexedFiles);
                     ftsMutated = true;
@@ -1885,14 +1902,13 @@ public static partial class IndexCommandRunner
                 writer.SetMeta(DbContext.SymbolsOnlyGraphOmittedMetaKey, "true");
             }
             writer.MarkCSharpSymbolNameContractReady();
-            // Issue #435: resolve every C# class-like row and stamp readiness. Full-scan
-            // touches the entire repo, so the resolver output is authoritative regardless
-            // of which individual files were reparsed.
-            // Issue #435: full-scan は全リポジトリを touch するため resolver の出力は
-            // 全行 authoritative。必ず再解決して stamp する。
             if (writer.HasAnyFilesWithLanguage("csharp"))
             {
-                writer.ResolveCSharpMetadataTargets();
+                if (csharpMetadataTargetsNeedRefresh)
+                {
+                    FullScanCSharpMetadataResolveForTesting?.Invoke();
+                    writer.ResolveCSharpMetadataTargets();
+                }
                 writer.MarkMetadataTargetReady("csharp");
                 csharpMetadataTargetReadyAfter = true;
             }

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -1486,8 +1486,6 @@ public static partial class IndexCommandRunner
                                             displayRelativePath,
                                             record,
                                             content,
-                                            null,
-                                            null,
                                             hasOversizeLine,
                                             warning,
                                             chunks,
@@ -1727,7 +1725,7 @@ public static partial class IndexCommandRunner
                             writer.InsertSymbols([], cancellationToken);
                             writer.InsertReferences([], cancellationToken);
                             var generatedIssues = AppendIssueIfMissing(
-                                item.Issues ?? ValidateWorkItemContent(item, record),
+                                RequireWorkItemIssues(item),
                                 generatedSuppressionIssue);
                             writer.InsertIssues(fileId, generatedIssues);
                             if (options.Verbose)
@@ -1822,7 +1820,7 @@ public static partial class IndexCommandRunner
                         writer.InsertSymbols(symbols, cancellationToken);
                         if (symbolRegexTimeoutIssue != null)
                         {
-                            var baseIssues = item.Issues ?? ValidateWorkItemContent(item, record);
+                            var baseIssues = RequireWorkItemIssues(item);
                             item = item with { Issues = AppendIssue(baseIssues, symbolRegexTimeoutIssue) };
                         }
                         currentJsonIndexFile = FormatIndexPhasePath(record.Path, "references");
@@ -1858,12 +1856,12 @@ public static partial class IndexCommandRunner
                             postExtractionHooks.OnReferencesExtracted(fileContext, AsMutableList(references));
                             if (regexTimeoutIssue != null)
                             {
-                                var baseIssues = item.Issues ?? ValidateWorkItemContent(item, record);
+                                var baseIssues = RequireWorkItemIssues(item);
                                 item = item with { Issues = AppendIssue(baseIssues, regexTimeoutIssue) };
                             }
                             if (referenceExtraction != null)
                             {
-                                var baseIssues = item.Issues ?? ValidateWorkItemContent(item, record);
+                                var baseIssues = RequireWorkItemIssues(item);
                                 item = item with
                                 {
                                     Issues = AppendReferenceExtractionDiagnosticIssues(baseIssues, record.Path, referenceExtraction.Diagnostics),
@@ -1873,7 +1871,7 @@ public static partial class IndexCommandRunner
                             {
                                 var issue = BuildReferenceCountExceededIssue(record.Path, references.Count, options.MaxReferencesPerFile);
                                 references = [];
-                                var baseIssues = item.Issues ?? ValidateWorkItemContent(item, record);
+                                var baseIssues = RequireWorkItemIssues(item);
                                 item = item with { Issues = AppendIssue(baseIssues, issue) };
                             }
                         }
@@ -1881,7 +1879,7 @@ public static partial class IndexCommandRunner
                         if (references.Count > 0)
                             mutualRecursionRefreshNeeded = true;
                         currentJsonIndexFile = FormatIndexPhasePath(record.Path, "validating");
-                        var issues = item.Issues ?? ValidateWorkItemContent(item, record);
+                        var issues = RequireWorkItemIssues(item);
                         writer.InsertIssues(fileId, issues);
                         currentJsonIndexFile = FormatIndexPhasePath(record.Path, "committing");
                         WriteProjectRootOnce();
@@ -2327,14 +2325,9 @@ public static partial class IndexCommandRunner
         throw new InvalidOperationException("Post-extraction hooks require mutable extraction result lists.");
     }
 
-    private static List<FileIssue> ValidateWorkItemContent(FullScanFileWorkItem item, FileRecord record)
+    private static IReadOnlyList<FileIssue> RequireWorkItemIssues(FullScanFileWorkItem item)
     {
-        if (item.RawBytes is not { } rawBytes || item.Content is not { } content)
-            throw new InvalidOperationException("Full-scan work item does not carry deferred content for validation.");
-
-        return item.Inspection is { } inspection
-            ? FileIndexer.ValidateContent(record.Path, rawBytes, content, record.Lang, inspection, item.HasOversizeLine)
-            : FileIndexer.ValidateContent(record.Path, rawBytes, content, record.Lang);
+        return item.Issues ?? throw new InvalidOperationException("Full-scan work item does not carry precomputed validation issues.");
     }
 
     private static int AddPostExtractionHookWarnings(PostExtractionHookRunner? runner, List<CliJsonMessage> warningList)

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -1200,15 +1200,24 @@ public static partial class IndexCommandRunner
                         target.RelativePath,
                         target.DisplayRelativePath,
                         target.IndexPath,
-                        target.Language));
-                csharpWorkspace = CSharpStaticInterfacePrepass.BuildWorkspaceSymbols(
-                    writer,
-                    indexer,
-                    csharpPrepassTargets,
-                    includeExistingSymbols: !options.Rebuild && !startedWithNoIndexedFiles,
-                    canReuseExistingSymbolsWithoutRead: CanReuseCSharpPrepassTargetWithoutRead,
-                    reportCurrentFile: path => currentCSharpWorkspaceFile = path,
-                    cancellationToken: cancellationToken);
+                        target.Language))
+                    .ToArray();
+                if (csharpPrepassTargets.Length == 0)
+                {
+                    csharpWorkspace = new CSharpStaticInterfaceWorkspaceSymbols([], false);
+                }
+                else
+                {
+                    FullScanCSharpPrepassForTesting?.Invoke();
+                    csharpWorkspace = CSharpStaticInterfacePrepass.BuildWorkspaceSymbols(
+                        writer,
+                        indexer,
+                        csharpPrepassTargets,
+                        includeExistingSymbols: !options.Rebuild && !startedWithNoIndexedFiles,
+                        canReuseExistingSymbolsWithoutRead: CanReuseCSharpPrepassTargetWithoutRead,
+                        reportCurrentFile: path => currentCSharpWorkspaceFile = path,
+                        cancellationToken: cancellationToken);
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -120,11 +120,17 @@ public static partial class IndexCommandRunner
         };
     }
 
-    private static bool ExistingFileViolatesExtractionCaps(DbWriter writer, long fileId, int maxSymbolsPerFile, int maxReferencesPerFile) =>
-        writer.HasExtractionCapViolationForFile(fileId, maxSymbolsPerFile, maxReferencesPerFile);
-
-    internal static bool ExistingFileGeneratedSuppressionMismatch(DbWriter writer, long fileId, FileIssue? generatedSuppressionIssue)
-        => writer.HasIssueForFile(fileId, FileIndexer.GeneratedCodeExtractionSkippedIssueKind) != (generatedSuppressionIssue != null);
+    private static bool ExistingFileBlocksReuse(
+        DbWriter writer,
+        long fileId,
+        int maxSymbolsPerFile,
+        int maxReferencesPerFile,
+        FileIssue? generatedSuppressionIssue) =>
+        writer.HasReusableFileBlockingIssueForFile(
+            fileId,
+            maxSymbolsPerFile,
+            maxReferencesPerFile,
+            generatedSuppressionIssue != null);
 
     internal static IReadOnlyList<FileIssue> AppendIssue(IReadOnlyList<FileIssue> issues, FileIssue issue)
     {
@@ -1143,11 +1149,11 @@ public static partial class IndexCommandRunner
                 allowReuse: true);
             if (existingId == null)
                 return false;
-            if (ExistingFileViolatesExtractionCaps(writer, existingId.Value, options.MaxSymbolsPerFile, options.MaxReferencesPerFile))
-                return false;
-            return !ExistingFileGeneratedSuppressionMismatch(
+            return !ExistingFileBlocksReuse(
                 writer,
                 existingId.Value,
+                options.MaxSymbolsPerFile,
+                options.MaxReferencesPerFile,
                 indexer.BuildGeneratedCodeExtractionSkippedIssue(target.IndexPath));
         }
 
@@ -1215,10 +1221,15 @@ public static partial class IndexCommandRunner
                 allowReuse);
             if (existingId == null)
                 return false;
-            if (ExistingFileViolatesExtractionCaps(writer, existingId.Value, options.MaxSymbolsPerFile, options.MaxReferencesPerFile))
+            if (ExistingFileBlocksReuse(
+                writer,
+                existingId.Value,
+                options.MaxSymbolsPerFile,
+                options.MaxReferencesPerFile,
+                indexer.BuildGeneratedCodeExtractionSkippedIssue(target.IndexPath)))
+            {
                 return false;
-            if (ExistingFileGeneratedSuppressionMismatch(writer, existingId.Value, indexer.BuildGeneratedCodeExtractionSkippedIssue(target.IndexPath)))
-                return false;
+            }
 
             skipped++;
             processed++;
@@ -1565,12 +1576,12 @@ public static partial class IndexCommandRunner
                                 && AllowReuseWithCurrentHotspotFamilyTrust(record.Lang, hotspotFamilyTrustMatchesCurrent));
                     }
                     if (existingId != null
-                        && ExistingFileViolatesExtractionCaps(writer, existingId.Value, options.MaxSymbolsPerFile, options.MaxReferencesPerFile))
-                    {
-                        existingId = null;
-                    }
-                    if (existingId != null
-                        && ExistingFileGeneratedSuppressionMismatch(writer, existingId.Value, generatedSuppressionIssue))
+                        && ExistingFileBlocksReuse(
+                            writer,
+                            existingId.Value,
+                            options.MaxSymbolsPerFile,
+                            options.MaxReferencesPerFile,
+                            generatedSuppressionIssue))
                     {
                         existingId = null;
                     }

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -1294,7 +1294,7 @@ public static partial class IndexCommandRunner
                             if (parallelizeExtraction)
                             {
                                 activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(record.Path, "chunking");
-                                chunks = ChunkSplitter.SplitNormalized(0, content, hasOversizeLine);
+                                chunks = ChunkSplitter.SplitNormalized(0, content, hasOversizeLine, record.Lines);
                                 if (generatedSuppressionIssue != null)
                                 {
                                     symbols = [];
@@ -1614,7 +1614,8 @@ public static partial class IndexCommandRunner
                         ? ChunkSplitter.SplitNormalized(
                             fileId,
                             item.Content!,
-                            item.HasOversizeLine ?? ChunkSplitter.HasOversizeLine(item.Content!))
+                            item.HasOversizeLine ?? ChunkSplitter.HasOversizeLine(item.Content!),
+                            record.Lines)
                         : ReassignChunkFileIds(item.Chunks, fileId);
                     if (generatedSuppressionIssue != null)
                     {

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -1125,6 +1125,29 @@ public static partial class IndexCommandRunner
             jsonHeartbeatTask = null;
         }
 
+        bool CanReuseCSharpPrepassTargetWithoutRead(CSharpStaticInterfacePrepass.FileTarget target)
+        {
+            if (options.Rebuild || startedWithNoIndexedFiles || !symbolKindFilterMatchesPrior || !csharpSymbolNameContractMatchesCurrent)
+                return false;
+            if (target.Language != "csharp")
+                return false;
+
+            var existingId = TryGetUnchangedFileIdFromStat(
+                writer,
+                projectRoot,
+                target.FilePath,
+                target.Language,
+                allowReuse: true);
+            if (existingId == null)
+                return false;
+            if (ExistingFileViolatesExtractionCaps(writer, existingId.Value, options.MaxSymbolsPerFile, options.MaxReferencesPerFile))
+                return false;
+            return !ExistingFileGeneratedSuppressionMismatch(
+                writer,
+                existingId.Value,
+                indexer.BuildGeneratedCodeExtractionSkippedIssue(target.IndexPath));
+        }
+
         CSharpStaticInterfaceWorkspaceSymbols csharpWorkspace;
         if (options.SymbolsOnly)
         {
@@ -1153,8 +1176,9 @@ public static partial class IndexCommandRunner
                     indexer,
                     csharpPrepassTargets,
                     includeExistingSymbols: !options.Rebuild && !startedWithNoIndexedFiles,
-                    path => currentCSharpWorkspaceFile = path,
-                    cancellationToken);
+                    canReuseExistingSymbolsWithoutRead: CanReuseCSharpPrepassTargetWithoutRead,
+                    reportCurrentFile: path => currentCSharpWorkspaceFile = path,
+                    cancellationToken: cancellationToken);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
@@ -1165,6 +1189,52 @@ public static partial class IndexCommandRunner
                 currentCSharpWorkspaceFile = null;
                 StopFullScanJsonPhaseHeartbeat(csharpWorkspaceHeartbeat);
             }
+        }
+
+        bool TrySkipFullScanTargetBeforeContentLoad(int fileIndex)
+        {
+            if (options.Rebuild || startedWithNoIndexedFiles || options.SymbolsOnly)
+                return false;
+
+            var target = fileTargets[fileIndex];
+            var language = target.Language;
+            var allowReuse = symbolKindFilterMatchesPrior
+                && !priorSymbolsOnlyGraphOmitted
+                && language is not ("javascript" or "typescript")
+                && (language != "csharp" || csharpSymbolNameContractMatchesCurrent)
+                && (language != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
+                && (language != "sql" || sqlGraphContractMatchesCurrent)
+                && AllowReuseWithCurrentHotspotFamilyTrust(language, hotspotFamilyTrustMatchesCurrent);
+            var existingId = TryGetUnchangedFileIdFromStat(
+                writer,
+                projectRoot,
+                target.FilePath,
+                language,
+                allowReuse);
+            if (existingId == null)
+                return false;
+            if (ExistingFileViolatesExtractionCaps(writer, existingId.Value, options.MaxSymbolsPerFile, options.MaxReferencesPerFile))
+                return false;
+            if (ExistingFileGeneratedSuppressionMismatch(writer, existingId.Value, indexer.BuildGeneratedCodeExtractionSkippedIssue(target.IndexPath)))
+                return false;
+
+            skipped++;
+            processed++;
+            if (!string.IsNullOrWhiteSpace(language))
+                skippedSymbolExtractorLanguages.Add(language);
+            if (FileIndexer.SupportsHotspotFamilyMarkerLanguage(language) && language != null)
+                reusedHotspotFamilyLanguages.Add(language);
+            if (options.Verbose && !options.Json && !options.Quiet)
+                Console.WriteLine($"  [SKIP] {target.IndexPath} (unchanged)");
+            return true;
+        }
+
+        var extractionFileIndexes = new List<int>(fileTargets.Length);
+        for (var fileIndex = 0; fileIndex < fileTargets.Length; fileIndex++)
+        {
+            ThrowIfFullScanCancelled(processed, files.Count);
+            if (!TrySkipFullScanTargetBeforeContentLoad(fileIndex))
+                extractionFileIndexes.Add(fileIndex);
         }
 
         EnsureIndexingActivityVisible();
@@ -1184,7 +1254,7 @@ public static partial class IndexCommandRunner
             using var extractionStallCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             using var mainSymbolExtractionWorker = new SymbolExtractionWorkerClient(options.MaxFileSizeBytes);
             var extractionCancellationToken = extractionStallCts.Token;
-            var nextFileIndex = -1;
+            var nextExtractionIndex = -1;
             var workers = Enumerable.Range(0, extractionParallelism)
                 .Select(workerIndex => Task.Factory.StartNew(() =>
                 {
@@ -1192,10 +1262,11 @@ public static partial class IndexCommandRunner
                     while (true)
                     {
                         extractionCancellationToken.ThrowIfCancellationRequested();
-                        var fileIndex = Interlocked.Increment(ref nextFileIndex);
-                        if (fileIndex >= files.Count)
+                        var extractionIndex = Interlocked.Increment(ref nextExtractionIndex);
+                        if (extractionIndex >= extractionFileIndexes.Count)
                             break;
 
+                        var fileIndex = extractionFileIndexes[extractionIndex];
                         var target = fileTargets[fileIndex];
                         var filePath = target.FilePath;
                         var relativeFilePath = target.RelativePath;
@@ -1203,6 +1274,7 @@ public static partial class IndexCommandRunner
                         try
                         {
                             activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(displayRelativePath, "reading");
+                            FullScanFileContentLoadForTesting?.Invoke(displayRelativePath);
                             var loaded = indexer.BuildLoadedRecordWithRawBytes(
                                 filePath,
                                 relativeFilePath,

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -998,12 +998,7 @@ public static partial class IndexCommandRunner
         var activeJsonExtractionPhases = new ConcurrentDictionary<int, string>();
         CancellationTokenSource? jsonHeartbeatCts = null;
         Task? jsonHeartbeatTask = null;
-        using var postExtractionHooks = PostExtractionHookRunner.DiscoverDefault(
-            options.MaxFileSizeBytes,
-            maxSymbolCount: options.MaxSymbolsPerFile + 1,
-            maxReferenceCount: options.MaxReferencesPerFile + 1);
         var extractionParallelism = Math.Max(1, options.Parallelism);
-        var hasPostExtractionHooks = postExtractionHooks.Hooks.Count > 0;
         var existingFileCount = writer.GetCounts().files;
         var startedWithNoIndexedFiles = existingFileCount == 0;
         var typeScriptAugmentationVersionMatchesCurrent = writer.TypeScriptAugmentationVersionMatchesCurrent();
@@ -1018,15 +1013,6 @@ public static partial class IndexCommandRunner
             || startedWithNoIndexedFiles
             || purged > 0
             || !priorMetadataTargetCsharpMatchesCurrent;
-        var parallelizeExtraction = (options.Rebuild || startedWithNoIndexedFiles)
-            && !options.SymbolKindFilter.IsActive
-            && !hasPostExtractionHooks;
-        var parallelizeExtractionReason = parallelizeExtraction
-            ? options.Rebuild ? "rebuild" : "empty_index"
-            : null;
-        FullScanExtractionSchedulingForTesting?.Invoke(
-            parallelizeExtraction,
-            parallelizeExtractionReason);
 
         void RequireTypeScriptAugmentationRefresh()
         {
@@ -1304,76 +1290,196 @@ public static partial class IndexCommandRunner
                 extractionFileIndexes.Add(fileIndex);
         }
 
-        EnsureIndexingActivityVisible();
         ReportJsonIndexProgressIfNeeded();
-        StartJsonHeartbeatIfNeeded();
 
-        try
+        PostExtractionHookRunner? postExtractionHooks = null;
+        if (extractionFileIndexes.Count == 0)
         {
-            if (!options.Json && !options.Quiet)
+            FullScanExtractionSchedulingForTesting?.Invoke(false, null);
+        }
+        else
+        {
+            postExtractionHooks = PostExtractionHookRunner.DiscoverDefault(
+                options.MaxFileSizeBytes,
+                maxSymbolCount: options.MaxSymbolsPerFile + 1,
+                maxReferenceCount: options.MaxReferencesPerFile + 1);
+            var hasPostExtractionHooks = postExtractionHooks.Hooks.Count > 0;
+            var parallelizeExtraction = (options.Rebuild || startedWithNoIndexedFiles)
+                && !options.SymbolKindFilter.IsActive
+                && !hasPostExtractionHooks;
+            var parallelizeExtractionReason = parallelizeExtraction
+                ? options.Rebuild ? "rebuild" : "empty_index"
+                : null;
+            FullScanExtractionSchedulingForTesting?.Invoke(
+                parallelizeExtraction,
+                parallelizeExtractionReason);
+
+            EnsureIndexingActivityVisible();
+            StartJsonHeartbeatIfNeeded();
+
+            try
             {
-                PauseIndexSpinnerForConsoleWrite();
-                indexProgressVisible = true;
-                ConsoleUi.PrintProgress(0, files.Count);
-            }
-
-            using var extractionResults = new BlockingCollection<FullScanFileWorkItem>(Math.Max(1, extractionParallelism * 4));
-            using var extractionStallCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            using var mainSymbolExtractionWorker = new SymbolExtractionWorkerClient(options.MaxFileSizeBytes);
-            var extractionCancellationToken = extractionStallCts.Token;
-            var nextExtractionIndex = -1;
-            var workers = Enumerable.Range(0, extractionParallelism)
-                .Select(workerIndex => Task.Factory.StartNew(() =>
+                if (!options.Json && !options.Quiet)
                 {
-                    using var workerSymbolExtractionWorker = new SymbolExtractionWorkerClient(options.MaxFileSizeBytes);
-                    while (true)
-                    {
-                        extractionCancellationToken.ThrowIfCancellationRequested();
-                        var extractionIndex = Interlocked.Increment(ref nextExtractionIndex);
-                        if (extractionIndex >= extractionFileIndexes.Count)
-                            break;
+                    PauseIndexSpinnerForConsoleWrite();
+                    indexProgressVisible = true;
+                    ConsoleUi.PrintProgress(0, files.Count);
+                }
 
-                        var fileIndex = extractionFileIndexes[extractionIndex];
-                        var target = fileTargets[fileIndex];
-                        var filePath = target.FilePath;
-                        var relativeFilePath = target.RelativePath;
-                        var displayRelativePath = target.DisplayRelativePath;
-                        try
+                FullScanExtractionWorkStartedForTesting?.Invoke();
+                using var extractionResults = new BlockingCollection<FullScanFileWorkItem>(Math.Max(1, extractionParallelism * 4));
+                using var extractionStallCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                using var mainSymbolExtractionWorker = new SymbolExtractionWorkerClient(options.MaxFileSizeBytes);
+                var extractionCancellationToken = extractionStallCts.Token;
+                var nextExtractionIndex = -1;
+                var workers = Enumerable.Range(0, extractionParallelism)
+                    .Select(workerIndex => Task.Factory.StartNew(() =>
+                    {
+                        using var workerSymbolExtractionWorker = new SymbolExtractionWorkerClient(options.MaxFileSizeBytes);
+                        while (true)
                         {
-                            activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(displayRelativePath, "reading");
-                            FullScanFileContentLoadForTesting?.Invoke(displayRelativePath);
-                            var loaded = indexer.BuildLoadedRecordWithRawBytes(
-                                filePath,
-                                relativeFilePath,
-                                target.Language,
-                                extractionCancellationToken);
-                            var record = loaded.Record;
-                            var content = loaded.Content;
-                            var rawBytes = loaded.RawBytes;
-                            var warning = loaded.Warning;
-                            var hasOversizeLine = loaded.HasOversizeLine;
-                            IReadOnlyList<ChunkRecord>? chunks = null;
-                            IReadOnlyList<SymbolRecord>? symbols = null;
-                            IReadOnlyList<ReferenceRecord>? references = null;
-                            IReadOnlyList<FileIssue>? issues = null;
-                            var generatedSuppressionIssue = indexer.BuildGeneratedCodeExtractionSkippedIssue(record.Path);
-                            if (parallelizeExtraction)
+                            extractionCancellationToken.ThrowIfCancellationRequested();
+                            var extractionIndex = Interlocked.Increment(ref nextExtractionIndex);
+                            if (extractionIndex >= extractionFileIndexes.Count)
+                                break;
+
+                            var fileIndex = extractionFileIndexes[extractionIndex];
+                            var target = fileTargets[fileIndex];
+                            var filePath = target.FilePath;
+                            var relativeFilePath = target.RelativePath;
+                            var displayRelativePath = target.DisplayRelativePath;
+                            try
                             {
-                                activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(record.Path, "chunking");
-                                chunks = ChunkSplitter.SplitNormalized(0, content, hasOversizeLine, record.Lines);
-                                if (generatedSuppressionIssue != null)
+                                activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(displayRelativePath, "reading");
+                                FullScanFileContentLoadForTesting?.Invoke(displayRelativePath);
+                                var loaded = indexer.BuildLoadedRecordWithRawBytes(
+                                    filePath,
+                                    relativeFilePath,
+                                    target.Language,
+                                    extractionCancellationToken);
+                                var record = loaded.Record;
+                                var content = loaded.Content;
+                                var rawBytes = loaded.RawBytes;
+                                var warning = loaded.Warning;
+                                var hasOversizeLine = loaded.HasOversizeLine;
+                                IReadOnlyList<ChunkRecord>? chunks = null;
+                                IReadOnlyList<SymbolRecord>? symbols = null;
+                                IReadOnlyList<ReferenceRecord>? references = null;
+                                IReadOnlyList<FileIssue>? issues = null;
+                                var generatedSuppressionIssue = indexer.BuildGeneratedCodeExtractionSkippedIssue(record.Path);
+                                if (parallelizeExtraction)
                                 {
-                                    symbols = [];
-                                    references = [];
+                                    activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(record.Path, "chunking");
+                                    chunks = ChunkSplitter.SplitNormalized(0, content, hasOversizeLine, record.Lines);
+                                    if (generatedSuppressionIssue != null)
+                                    {
+                                        symbols = [];
+                                        references = [];
+                                        activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(record.Path, "validating");
+                                        issues = AppendIssueIfMissing(
+                                            FileIndexer.ValidateContent(record.Path, rawBytes, content, record.Lang, loaded.Inspection, hasOversizeLine),
+                                            generatedSuppressionIssue);
+                                        extractionResults.Add(
+                                            FullScanFileWorkItem.Precomputed(
+                                                filePath,
+                                                displayRelativePath,
+                                                record,
+                                                warning,
+                                                chunks,
+                                                symbols,
+                                                references,
+                                                issues,
+                                                generatedSuppressionIssue,
+                                                generatedSuppressionChecked: true),
+                                            extractionCancellationToken);
+                                        continue;
+                                    }
+                                    activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(record.Path, "symbols");
+                                    var symbolExtraction = ExtractSymbolsWithStallTimeout(
+                                        0,
+                                        record.Lang,
+                                        content,
+                                        filePath,
+                                        Path.GetFullPath(options.ProjectPath!),
+                                        record.Path,
+                                        activeJsonExtractionPhases[workerIndex],
+                                        true,
+                                        hasOversizeLine,
+                                        workerSymbolExtractionWorker,
+                                        extractionCancellationToken);
+                                    symbols = symbolExtraction.Symbols;
+                                    var symbolRegexTimeoutIssue = symbolExtraction.RegexTimeoutIssue;
+                                    if (symbols.Count > options.MaxSymbolsPerFile)
+                                    {
+                                        var issue = BuildSymbolCountExceededIssue(record.Path, symbols.Count, options.MaxSymbolsPerFile);
+                                        IReadOnlyList<FileIssue> capIssues = symbolRegexTimeoutIssue == null
+                                            ? [issue]
+                                            : AppendIssue([symbolRegexTimeoutIssue], issue);
+                                        extractionResults.Add(
+                                            FullScanFileWorkItem.Precomputed(filePath, displayRelativePath, record, issue.Message, [], [], [], capIssues),
+                                            extractionCancellationToken);
+                                        continue;
+                                    }
+                                    SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(filePath, record.Lang));
+                                    FileIssue? referenceRegexTimeoutIssue = null;
+                                    ReferenceExtractionResult? referenceExtraction = null;
+                                    if (options.SymbolsOnly)
+                                    {
+                                        references = [];
+                                    }
+                                    else
+                                    {
+                                        activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(record.Path, "references");
+                                        using var regexTimeouts = BoundedRegex.CaptureTimeouts(record.Lang, "reference_extraction");
+                                        referenceExtraction = ReferenceExtractor.ExtractDetailedNormalized(
+                                            0,
+                                            record.Lang,
+                                            content,
+                                            hasOversizeLine,
+                                            symbols,
+                                            record.Path,
+                                            record.Lang == "csharp" ? csharpWorkspace.Symbols : null,
+                                            extractionCancellationToken,
+                                            maxReferenceCount: options.MaxReferencesPerFile + 1);
+                                        references = referenceExtraction.References;
+                                        referenceRegexTimeoutIssue = BuildRegexTimeoutIssue(record.Path, regexTimeouts);
+                                    }
                                     activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(record.Path, "validating");
-                                    issues = AppendIssueIfMissing(
-                                        FileIndexer.ValidateContent(record.Path, rawBytes, content, record.Lang, loaded.Inspection, hasOversizeLine),
-                                        generatedSuppressionIssue);
-                                    extractionResults.Add(
-                                        FullScanFileWorkItem.Precomputed(
+                                    issues = FileIndexer.ValidateContent(record.Path, rawBytes, content, record.Lang, loaded.Inspection, hasOversizeLine);
+                                    if (symbolRegexTimeoutIssue != null)
+                                        issues = AppendIssue(issues, symbolRegexTimeoutIssue);
+                                    if (referenceRegexTimeoutIssue != null)
+                                        issues = AppendIssue(issues, referenceRegexTimeoutIssue);
+                                    if (referenceExtraction != null)
+                                        issues = AppendReferenceExtractionDiagnosticIssues(issues, record.Path, referenceExtraction.Diagnostics);
+                                    if (references.Count > options.MaxReferencesPerFile)
+                                    {
+                                        var issue = BuildReferenceCountExceededIssue(record.Path, references.Count, options.MaxReferencesPerFile);
+                                        references = [];
+                                        issues = AppendIssue(issues, issue);
+                                    }
+                                }
+                                extractionResults.Add(
+                                    parallelizeExtraction
+                                        ? FullScanFileWorkItem.Precomputed(
                                             filePath,
                                             displayRelativePath,
                                             record,
+                                            warning,
+                                            chunks!,
+                                            symbols!,
+                                            references!,
+                                            issues!,
+                                            generatedSuppressionIssue,
+                                            generatedSuppressionChecked: true)
+                                        : FullScanFileWorkItem.Success(
+                                            filePath,
+                                            displayRelativePath,
+                                            record,
+                                            content,
+                                            rawBytes,
+                                            loaded.Inspection,
+                                            hasOversizeLine,
                                             warning,
                                             chunks,
                                             symbols,
@@ -1381,531 +1487,437 @@ public static partial class IndexCommandRunner
                                             issues,
                                             generatedSuppressionIssue,
                                             generatedSuppressionChecked: true),
-                                        extractionCancellationToken);
-                                    continue;
-                                }
-                                activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(record.Path, "symbols");
-                                var symbolExtraction = ExtractSymbolsWithStallTimeout(
-                                    0,
-                                    record.Lang,
-                                    content,
-                                    filePath,
-                                    Path.GetFullPath(options.ProjectPath!),
-                                    record.Path,
-                                    activeJsonExtractionPhases[workerIndex],
-                                    true,
-                                    hasOversizeLine,
-                                    workerSymbolExtractionWorker,
                                     extractionCancellationToken);
-                                symbols = symbolExtraction.Symbols;
-                                var symbolRegexTimeoutIssue = symbolExtraction.RegexTimeoutIssue;
-                                if (symbols.Count > options.MaxSymbolsPerFile)
+                            }
+                            catch (OperationCanceledException) when (extractionCancellationToken.IsCancellationRequested)
+                            {
+                                throw;
+                            }
+                            catch (FileIndexer.BinaryFileSkippedException ex)
+                            {
+                                var record = indexer.BuildSkippedFileRecord(filePath, relativeFilePath, target.Language);
+                                var issue = BuildNullByteIssue(ex);
+                                extractionResults.Add(
+                                    FullScanFileWorkItem.Precomputed(filePath, displayRelativePath, record, ex.Message, [], [], [], [issue]),
+                                    extractionCancellationToken);
+                            }
+                            catch (FileIndexer.FileTooLargeSkippedException ex)
+                            {
+                                var record = indexer.BuildSkippedFileRecord(filePath, relativeFilePath, target.Language);
+                                var issue = new FileIssue
                                 {
-                                    var issue = BuildSymbolCountExceededIssue(record.Path, symbols.Count, options.MaxSymbolsPerFile);
-                                    IReadOnlyList<FileIssue> capIssues = symbolRegexTimeoutIssue == null
-                                        ? [issue]
-                                        : AppendIssue([symbolRegexTimeoutIssue], issue);
-                                    extractionResults.Add(
-                                        FullScanFileWorkItem.Precomputed(filePath, displayRelativePath, record, issue.Message, [], [], [], capIssues),
-                                        extractionCancellationToken);
-                                    continue;
-                                }
-                                SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(filePath, record.Lang));
-                                FileIssue? referenceRegexTimeoutIssue = null;
-                                ReferenceExtractionResult? referenceExtraction = null;
-                                if (options.SymbolsOnly)
+                                    Path = ex.RelativePath,
+                                    Kind = "file_too_large",
+                                    Line = 0,
+                                    Message = ex.Message,
+                                };
+                                extractionResults.Add(
+                                    FullScanFileWorkItem.Precomputed(filePath, displayRelativePath, record, ex.Message, [], [], [], [issue]),
+                                    extractionCancellationToken);
+                            }
+                            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+                            {
+                                extractionResults.Add(
+                                    FullScanFileWorkItem.Skipped(filePath, displayRelativePath, $"{displayRelativePath}: skipped because it was deleted during indexing."),
+                                    extractionCancellationToken);
+                            }
+                            catch (Exception ex)
+                            {
+                                extractionResults.Add(FullScanFileWorkItem.Failure(filePath, displayRelativePath, ex), extractionCancellationToken);
+                            }
+                            finally
+                            {
+                                activeJsonExtractionPhases.TryRemove(workerIndex, out _);
+                            }
+                        }
+                    }, cancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Default))
+                    .ToArray();
+
+                _ = Task.WhenAll(workers).ContinueWith(
+                    task =>
+                    {
+                        extractionResults.CompleteAdding();
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+
+                var extractionStallTimeout = IndexExtractionStallTimeoutForTesting?.Invoke() ?? IndexExtractionStallTimeout;
+                var lastExtractionProgressAt = Stopwatch.GetTimestamp();
+                while (!extractionResults.IsCompleted)
+                {
+                    ThrowIfFullScanCancelled(processed, files.Count);
+                    if (!extractionResults.TryTake(out var item, millisecondsTimeout: 100))
+                    {
+                        ThrowIfFullScanExtractionStalled(
+                            processed,
+                            files.Count,
+                            extractionStallTimeout,
+                            lastExtractionProgressAt,
+                            currentJsonIndexFile,
+                            activeJsonExtractionPhases,
+                            extractionStallCts.Cancel);
+                        continue;
+                    }
+
+                    lastExtractionProgressAt = Stopwatch.GetTimestamp();
+                    currentJsonIndexFile = item.RelativePath;
+                    EnsureIndexingActivityVisible();
+                    if (item.Exception is IndexExtractionStalledException stalledException)
+                        throw stalledException;
+
+                    try
+                    {
+                        if (item.Exception != null)
+                            throw item.Exception;
+
+                        if (item.Record == null)
+                        {
+                            warnings++;
+                            warningList.Add(new CliJsonMessage(currentJsonIndexFile, item.Warning ?? "File skipped"));
+                            if (!options.Json && !options.Quiet && item.Warning != null)
+                            {
+                                PauseIndexSpinnerForConsoleWrite();
+                                ConsoleUi.PrintWarning(item.Warning);
+                                ResumeIndexSpinnerAfterConsoleWrite();
+                            }
+
+                            if (writer.HasFileAtPath(currentJsonIndexFile))
+                            {
+                                using var deleteTxn = writer.BeginTransaction(cancellationToken, "full scan delete skipped file");
+                                if (writer.DeleteFileByPath(currentJsonIndexFile))
                                 {
-                                    references = [];
-                                }
-                                else
-                                {
-                                    activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(record.Path, "references");
-                                    using var regexTimeouts = BoundedRegex.CaptureTimeouts(record.Lang, "reference_extraction");
-                                    referenceExtraction = ReferenceExtractor.ExtractDetailedNormalized(
-                                        0,
-                                        record.Lang,
-                                        content,
-                                        hasOversizeLine,
-                                        symbols,
-                                        record.Path,
-                                        record.Lang == "csharp" ? csharpWorkspace.Symbols : null,
-                                        extractionCancellationToken,
-                                        maxReferenceCount: options.MaxReferencesPerFile + 1);
-                                    references = referenceExtraction.References;
-                                    referenceRegexTimeoutIssue = BuildRegexTimeoutIssue(record.Path, regexTimeouts);
-                                }
-                                activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(record.Path, "validating");
-                                issues = FileIndexer.ValidateContent(record.Path, rawBytes, content, record.Lang, loaded.Inspection, hasOversizeLine);
-                                if (symbolRegexTimeoutIssue != null)
-                                    issues = AppendIssue(issues, symbolRegexTimeoutIssue);
-                                if (referenceRegexTimeoutIssue != null)
-                                    issues = AppendIssue(issues, referenceRegexTimeoutIssue);
-                                if (referenceExtraction != null)
-                                    issues = AppendReferenceExtractionDiagnosticIssues(issues, record.Path, referenceExtraction.Diagnostics);
-                                if (references.Count > options.MaxReferencesPerFile)
-                                {
-                                    var issue = BuildReferenceCountExceededIssue(record.Path, references.Count, options.MaxReferencesPerFile);
-                                    references = [];
-                                    issues = AppendIssue(issues, issue);
+                                    ftsMutated = true;
+                                    csharpMetadataTargetsNeedRefresh = true;
+                                    RequireTypeScriptAugmentationRefresh();
+                                    WriteProjectRootOnce();
+                                    deleteTxn.Commit();
                                 }
                             }
-                            extractionResults.Add(
-                                parallelizeExtraction
-                                    ? FullScanFileWorkItem.Precomputed(
-                                        filePath,
-                                        displayRelativePath,
-                                        record,
-                                        warning,
-                                        chunks!,
-                                        symbols!,
-                                        references!,
-                                        issues!,
-                                        generatedSuppressionIssue,
-                                        generatedSuppressionChecked: true)
-                                    : FullScanFileWorkItem.Success(
-                                        filePath,
-                                        displayRelativePath,
-                                        record,
-                                        content,
-                                        rawBytes,
-                                        loaded.Inspection,
-                                        hasOversizeLine,
-                                        warning,
-                                        chunks,
-                                        symbols,
-                                        references,
-                                        issues,
-                                        generatedSuppressionIssue,
-                                        generatedSuppressionChecked: true),
-                                extractionCancellationToken);
-                        }
-                        catch (OperationCanceledException) when (extractionCancellationToken.IsCancellationRequested)
-                        {
-                            throw;
-                        }
-                        catch (FileIndexer.BinaryFileSkippedException ex)
-                        {
-                            var record = indexer.BuildSkippedFileRecord(filePath, relativeFilePath, target.Language);
-                            var issue = BuildNullByteIssue(ex);
-                            extractionResults.Add(
-                                FullScanFileWorkItem.Precomputed(filePath, displayRelativePath, record, ex.Message, [], [], [], [issue]),
-                                extractionCancellationToken);
-                        }
-                        catch (FileIndexer.FileTooLargeSkippedException ex)
-                        {
-                            var record = indexer.BuildSkippedFileRecord(filePath, relativeFilePath, target.Language);
-                            var issue = new FileIssue
+                            else
                             {
-                                Path = ex.RelativePath,
-                                Kind = "file_too_large",
-                                Line = 0,
-                                Message = ex.Message,
-                            };
-                            extractionResults.Add(
-                                FullScanFileWorkItem.Precomputed(filePath, displayRelativePath, record, ex.Message, [], [], [], [issue]),
-                                extractionCancellationToken);
+                                skipped++;
+                            }
+                            processed++;
+                            currentJsonIndexFile = null;
+                            ThrowIfFullScanCancelled(processed, files.Count);
+                            ReportJsonIndexProgressIfNeeded();
+                            if (!options.Json && !options.Quiet)
+                            {
+                                PauseIndexSpinnerForConsoleWrite();
+                                ConsoleUi.PrintProgress(processed, files.Count);
+                                ResumeIndexSpinnerAfterConsoleWrite();
+                            }
+                            continue;
                         }
-                        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
-                        {
-                            extractionResults.Add(
-                                FullScanFileWorkItem.Skipped(filePath, displayRelativePath, $"{displayRelativePath}: skipped because it was deleted during indexing."),
-                                extractionCancellationToken);
-                        }
-                        catch (Exception ex)
-                        {
-                            extractionResults.Add(FullScanFileWorkItem.Failure(filePath, displayRelativePath, ex), extractionCancellationToken);
-                        }
-                        finally
-                        {
-                            activeJsonExtractionPhases.TryRemove(workerIndex, out _);
-                        }
-                    }
-                }, cancellationToken, TaskCreationOptions.LongRunning, TaskScheduler.Default))
-                .ToArray();
 
-            _ = Task.WhenAll(workers).ContinueWith(
-                task =>
-                {
-                    extractionResults.CompleteAdding();
-                },
-                CancellationToken.None,
-                TaskContinuationOptions.ExecuteSynchronously,
-                TaskScheduler.Default);
-
-            var extractionStallTimeout = IndexExtractionStallTimeoutForTesting?.Invoke() ?? IndexExtractionStallTimeout;
-            var lastExtractionProgressAt = Stopwatch.GetTimestamp();
-            while (!extractionResults.IsCompleted)
-            {
-                ThrowIfFullScanCancelled(processed, files.Count);
-                if (!extractionResults.TryTake(out var item, millisecondsTimeout: 100))
-                {
-                    ThrowIfFullScanExtractionStalled(
-                        processed,
-                        files.Count,
-                        extractionStallTimeout,
-                        lastExtractionProgressAt,
-                        currentJsonIndexFile,
-                        activeJsonExtractionPhases,
-                        extractionStallCts.Cancel);
-                    continue;
-                }
-
-                lastExtractionProgressAt = Stopwatch.GetTimestamp();
-                currentJsonIndexFile = item.RelativePath;
-                EnsureIndexingActivityVisible();
-                if (item.Exception is IndexExtractionStalledException stalledException)
-                    throw stalledException;
-
-                try
-                {
-                    if (item.Exception != null)
-                        throw item.Exception;
-
-                    if (item.Record == null)
-                    {
-                        warnings++;
-                        warningList.Add(new CliJsonMessage(currentJsonIndexFile, item.Warning ?? "File skipped"));
-                        if (!options.Json && !options.Quiet && item.Warning != null)
+                        var record = item.Record!;
+                        knownReadableFileSizes[item.FilePath] = record.Size;
+                        if (item.Warning != null && !options.Json && !options.Quiet)
                         {
                             PauseIndexSpinnerForConsoleWrite();
                             ConsoleUi.PrintWarning(item.Warning);
                             ResumeIndexSpinnerAfterConsoleWrite();
                         }
 
-                        if (writer.HasFileAtPath(currentJsonIndexFile))
+                        var generatedSuppressionIssue = item.GeneratedSuppressionChecked
+                            ? item.GeneratedSuppressionIssue
+                            : indexer.BuildGeneratedCodeExtractionSkippedIssue(record.Path);
+                        long? existingId = null;
+                        if (!options.Rebuild && !startedWithNoIndexedFiles && !options.SymbolsOnly)
                         {
-                            using var deleteTxn = writer.BeginTransaction(cancellationToken, "full scan delete skipped file");
-                            if (writer.DeleteFileByPath(currentJsonIndexFile))
+                            var languageRequiresRefresh = forceJavaScriptTypeScriptRefresh
+                                && IsJavaScriptTypeScriptLanguage(record.Lang);
+                            existingId = writer.GetUnchangedFileId(
+                                record.Path,
+                                record.Modified,
+                                record.Checksum,
+                                size: record.Size,
+                                lines: record.Lines,
+                                language: record.Lang,
+                                generated: record.Generated,
+                                allowReuse: symbolKindFilterMatchesPrior
+                                    && !languageRequiresRefresh
+                                    && !priorSymbolsOnlyGraphOmitted
+                                    && (record.Lang != "csharp" || csharpSymbolNameContractMatchesCurrent)
+                                    && (record.Lang != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
+                                    && (record.Lang != "sql" || sqlGraphContractMatchesCurrent)
+                                    && AllowReuseWithCurrentHotspotFamilyTrust(record.Lang, hotspotFamilyTrustMatchesCurrent));
+                        }
+                        if (existingId != null
+                            && ExistingFileBlocksReuse(
+                                writer,
+                                existingId.Value,
+                                options.MaxSymbolsPerFile,
+                                options.MaxReferencesPerFile,
+                                generatedSuppressionIssue))
+                        {
+                            existingId = null;
+                        }
+                        if (existingId != null)
+                        {
+                            var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
+                            if (stalePurged > 0)
                             {
                                 ftsMutated = true;
                                 csharpMetadataTargetsNeedRefresh = true;
                                 RequireTypeScriptAugmentationRefresh();
-                                WriteProjectRootOnce();
-                                deleteTxn.Commit();
                             }
+                            skipped++;
+                            processed++;
+                            if (!string.IsNullOrWhiteSpace(record.Lang))
+                                skippedSymbolExtractorLanguages.Add(record.Lang);
+                            if (FileIndexer.SupportsHotspotFamilyMarkerLanguage(record.Lang) && record.Lang != null)
+                                reusedHotspotFamilyLanguages.Add(record.Lang);
+                            if (options.Verbose && !options.Json && !options.Quiet)
+                            {
+                                PauseIndexSpinnerForConsoleWrite();
+                                ConsoleUi.ClearProgressLine();
+                                Console.WriteLine($"  [SKIP] {record.Path}");
+                                ResumeIndexSpinnerAfterConsoleWrite();
+                            }
+                            if (!options.Json && !options.Quiet)
+                            {
+                                PauseIndexSpinnerForConsoleWrite();
+                                ConsoleUi.PrintProgress(processed, files.Count);
+                                ResumeIndexSpinnerAfterConsoleWrite();
+                            }
+                            ReportJsonIndexProgressIfNeeded();
+                            currentJsonIndexFile = null;
+                            continue;
+                        }
+
+                        if (record.Lang == "csharp")
+                            csharpMetadataTargetsNeedRefresh = true;
+                        if (record.Lang == "typescript")
+                            RequireTypeScriptAugmentationRefresh();
+
+                        using var txn = writer.BeginTransaction(cancellationToken, "full scan file");
+                        if (!startedWithNoIndexedFiles)
+                        {
+                            var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
+                            if (stalePurged > 0)
+                            {
+                                ftsMutated = true;
+                                csharpMetadataTargetsNeedRefresh = true;
+                            }
+                        }
+                        var fileId = writer.UpsertFile(record, cleanExistingData: !startedWithNoIndexedFiles);
+                        ftsMutated = true;
+                        currentJsonIndexFile = FormatIndexPhasePath(record.Path, "chunking");
+                        var chunks = item.Chunks == null
+                            ? ChunkSplitter.SplitNormalized(
+                                fileId,
+                                item.Content!,
+                                item.HasOversizeLine ?? ChunkSplitter.HasOversizeLine(item.Content!),
+                                record.Lines)
+                            : ReassignChunkFileIds(item.Chunks, fileId);
+                        if (generatedSuppressionIssue != null)
+                        {
+                            writer.InsertChunks(chunks, cancellationToken);
+                            writer.InsertSymbols([], cancellationToken);
+                            writer.InsertReferences([], cancellationToken);
+                            var generatedIssues = AppendIssueIfMissing(
+                                item.Issues ?? ValidateWorkItemContent(item, record),
+                                generatedSuppressionIssue);
+                            writer.InsertIssues(fileId, generatedIssues);
+                            if (options.Verbose)
+                                WriteIndexVerboseStatus($"  [OK  ] {record.Path} ({chunks.Count} chunks, generated-code extraction skipped)");
+                            currentJsonIndexFile = FormatIndexPhasePath(record.Path, "committing");
+                            WriteProjectRootOnce();
+                            txn.Commit();
+
+                            processed++;
+                            if (!options.Json && !options.Quiet)
+                            {
+                                PauseIndexSpinnerForConsoleWrite();
+                                ConsoleUi.PrintProgress(processed, files.Count);
+                                ResumeIndexSpinnerAfterConsoleWrite();
+                            }
+                            ReportJsonIndexProgressIfNeeded();
+                            currentJsonIndexFile = null;
+                            continue;
+                        }
+                        currentJsonIndexFile = FormatIndexPhasePath(record.Path, "symbols");
+                        SymbolExtractionResult? symbolExtraction = null;
+                        var symbols = item.Symbols == null
+                            ? (symbolExtraction = ExtractSymbolsWithStallTimeout(
+                                fileId,
+                                record.Lang,
+                                item.Content!,
+                                item.FilePath,
+                                Path.GetFullPath(options.ProjectPath!),
+                                record.Path,
+                                currentJsonIndexFile,
+                                true,
+                                item.HasOversizeLine,
+                                mainSymbolExtractionWorker,
+                                cancellationToken)).Symbols
+                            : ReassignSymbolFileIds(item.Symbols, fileId);
+                        var symbolRegexTimeoutIssue = symbolExtraction?.RegexTimeoutIssue;
+                        if (symbols.Count > options.MaxSymbolsPerFile)
+                        {
+                            var issue = BuildSymbolCountExceededIssue(record.Path, symbols.Count, options.MaxSymbolsPerFile);
+                            IReadOnlyList<FileIssue> capIssues = symbolRegexTimeoutIssue == null
+                                ? [issue]
+                                : AppendIssue([symbolRegexTimeoutIssue], issue);
+                            writer.InsertSymbols([], cancellationToken);
+                            writer.InsertReferences([], cancellationToken);
+                            writer.InsertIssues(fileId, capIssues);
+                            if (options.Verbose)
+                                WriteIndexVerboseStatus($"  [SKIP] {record.Path} ({issue.Message})");
+                            txn.Commit();
+                            processed++;
+                            if (!options.Json && !options.Quiet)
+                            {
+                                PauseIndexSpinnerForConsoleWrite();
+                                ConsoleUi.PrintProgress(processed, files.Count);
+                                ResumeIndexSpinnerAfterConsoleWrite();
+                            }
+                            ReportJsonIndexProgressIfNeeded();
+                            currentJsonIndexFile = null;
+                            continue;
+                        }
+                        if (item.Symbols == null)
+                            SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(item.FilePath, record.Lang));
+                        var fileContext = new FileContext(projectRoot, record.Path, item.FilePath, record.Lang);
+                        var mutableSymbols = symbols as IList<SymbolRecord> ?? symbols.ToList();
+                        postExtractionHooks.OnSymbolsExtracted(fileContext, mutableSymbols);
+                        symbolsDroppedByKindFilter += options.SymbolKindFilter.Apply(mutableSymbols);
+                        symbols = (IReadOnlyList<SymbolRecord>)mutableSymbols;
+                        if (symbols.Count > options.MaxSymbolsPerFile)
+                        {
+                            var issue = BuildSymbolCountExceededIssue(record.Path, symbols.Count, options.MaxSymbolsPerFile);
+                            IReadOnlyList<FileIssue> capIssues = symbolRegexTimeoutIssue == null
+                                ? [issue]
+                                : AppendIssue([symbolRegexTimeoutIssue], issue);
+                            writer.InsertSymbols([], cancellationToken);
+                            writer.InsertReferences([], cancellationToken);
+                            writer.InsertIssues(fileId, capIssues);
+                            if (options.Verbose)
+                                WriteIndexVerboseStatus($"  [SKIP] {record.Path} ({issue.Message})");
+                            txn.Commit();
+                            processed++;
+                            if (!options.Json && !options.Quiet)
+                            {
+                                PauseIndexSpinnerForConsoleWrite();
+                                ConsoleUi.PrintProgress(processed, files.Count);
+                                ResumeIndexSpinnerAfterConsoleWrite();
+                            }
+                            ReportJsonIndexProgressIfNeeded();
+                            currentJsonIndexFile = null;
+                            continue;
+                        }
+                        writer.InsertChunks(chunks, cancellationToken);
+                        FileIndexer.ValidateSymbolLineRanges(record, symbols);
+                        writer.InsertSymbols(symbols, cancellationToken);
+                        if (symbolRegexTimeoutIssue != null)
+                        {
+                            var baseIssues = item.Issues ?? ValidateWorkItemContent(item, record);
+                            item = item with { Issues = AppendIssue(baseIssues, symbolRegexTimeoutIssue) };
+                        }
+                        currentJsonIndexFile = FormatIndexPhasePath(record.Path, "references");
+                        IReadOnlyList<ReferenceRecord> references;
+                        if (options.SymbolsOnly)
+                        {
+                            references = [];
                         }
                         else
                         {
-                            skipped++;
+                            FileIssue? regexTimeoutIssue = null;
+                            ReferenceExtractionResult? referenceExtraction = null;
+                            if (item.References == null)
+                            {
+                                using var regexTimeouts = BoundedRegex.CaptureTimeouts(record.Lang, "reference_extraction");
+                                referenceExtraction = ReferenceExtractor.ExtractDetailedNormalized(
+                                    fileId,
+                                    record.Lang,
+                                    item.Content!,
+                                    item.HasOversizeLine ?? ChunkSplitter.HasOversizeLine(item.Content!),
+                                    symbols,
+                                    record.Path,
+                                    record.Lang == "csharp" ? csharpWorkspace.Symbols : null,
+                                    cancellationToken,
+                                    maxReferenceCount: options.MaxReferencesPerFile + 1);
+                                references = referenceExtraction.References;
+                                regexTimeoutIssue = BuildRegexTimeoutIssue(record.Path, regexTimeouts);
+                            }
+                            else
+                            {
+                                references = ReassignReferenceFileIds(item.References, fileId);
+                            }
+                            postExtractionHooks.OnReferencesExtracted(fileContext, AsMutableList(references));
+                            if (regexTimeoutIssue != null)
+                            {
+                                var baseIssues = item.Issues ?? ValidateWorkItemContent(item, record);
+                                item = item with { Issues = AppendIssue(baseIssues, regexTimeoutIssue) };
+                            }
+                            if (referenceExtraction != null)
+                            {
+                                var baseIssues = item.Issues ?? ValidateWorkItemContent(item, record);
+                                item = item with
+                                {
+                                    Issues = AppendReferenceExtractionDiagnosticIssues(baseIssues, record.Path, referenceExtraction.Diagnostics),
+                                };
+                            }
+                            if (references.Count > options.MaxReferencesPerFile)
+                            {
+                                var issue = BuildReferenceCountExceededIssue(record.Path, references.Count, options.MaxReferencesPerFile);
+                                references = [];
+                                var baseIssues = item.Issues ?? ValidateWorkItemContent(item, record);
+                                item = item with { Issues = AppendIssue(baseIssues, issue) };
+                            }
                         }
-                        processed++;
-                        currentJsonIndexFile = null;
-                        ThrowIfFullScanCancelled(processed, files.Count);
-                        ReportJsonIndexProgressIfNeeded();
-                        if (!options.Json && !options.Quiet)
-                        {
-                            PauseIndexSpinnerForConsoleWrite();
-                            ConsoleUi.PrintProgress(processed, files.Count);
-                            ResumeIndexSpinnerAfterConsoleWrite();
-                        }
-                        continue;
-                    }
-
-                    var record = item.Record!;
-                    knownReadableFileSizes[item.FilePath] = record.Size;
-                    if (item.Warning != null && !options.Json && !options.Quiet)
-                    {
-                        PauseIndexSpinnerForConsoleWrite();
-                        ConsoleUi.PrintWarning(item.Warning);
-                        ResumeIndexSpinnerAfterConsoleWrite();
-                    }
-
-                    var generatedSuppressionIssue = item.GeneratedSuppressionChecked
-                        ? item.GeneratedSuppressionIssue
-                        : indexer.BuildGeneratedCodeExtractionSkippedIssue(record.Path);
-                    long? existingId = null;
-                    if (!options.Rebuild && !startedWithNoIndexedFiles && !options.SymbolsOnly)
-                    {
-                        var languageRequiresRefresh = forceJavaScriptTypeScriptRefresh
-                            && IsJavaScriptTypeScriptLanguage(record.Lang);
-                        existingId = writer.GetUnchangedFileId(
-                            record.Path,
-                            record.Modified,
-                            record.Checksum,
-                            size: record.Size,
-                            lines: record.Lines,
-                            language: record.Lang,
-                            generated: record.Generated,
-                            allowReuse: symbolKindFilterMatchesPrior
-                                && !languageRequiresRefresh
-                                && !priorSymbolsOnlyGraphOmitted
-                                && (record.Lang != "csharp" || csharpSymbolNameContractMatchesCurrent)
-                                && (record.Lang != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
-                                && (record.Lang != "sql" || sqlGraphContractMatchesCurrent)
-                                && AllowReuseWithCurrentHotspotFamilyTrust(record.Lang, hotspotFamilyTrustMatchesCurrent));
-                    }
-                    if (existingId != null
-                        && ExistingFileBlocksReuse(
-                            writer,
-                            existingId.Value,
-                            options.MaxSymbolsPerFile,
-                            options.MaxReferencesPerFile,
-                            generatedSuppressionIssue))
-                    {
-                        existingId = null;
-                    }
-                    if (existingId != null)
-                    {
-                        var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
-                        if (stalePurged > 0)
-                        {
-                            ftsMutated = true;
-                            csharpMetadataTargetsNeedRefresh = true;
-                            RequireTypeScriptAugmentationRefresh();
-                        }
-                        skipped++;
-                        processed++;
-                        if (!string.IsNullOrWhiteSpace(record.Lang))
-                            skippedSymbolExtractorLanguages.Add(record.Lang);
-                        if (FileIndexer.SupportsHotspotFamilyMarkerLanguage(record.Lang) && record.Lang != null)
-                            reusedHotspotFamilyLanguages.Add(record.Lang);
-                        if (options.Verbose && !options.Json && !options.Quiet)
-                        {
-                            PauseIndexSpinnerForConsoleWrite();
-                            ConsoleUi.ClearProgressLine();
-                            Console.WriteLine($"  [SKIP] {record.Path}");
-                            ResumeIndexSpinnerAfterConsoleWrite();
-                        }
-                        if (!options.Json && !options.Quiet)
-                        {
-                            PauseIndexSpinnerForConsoleWrite();
-                            ConsoleUi.PrintProgress(processed, files.Count);
-                            ResumeIndexSpinnerAfterConsoleWrite();
-                        }
-                        ReportJsonIndexProgressIfNeeded();
-                        currentJsonIndexFile = null;
-                        continue;
-                    }
-
-                    if (record.Lang == "csharp")
-                        csharpMetadataTargetsNeedRefresh = true;
-                    if (record.Lang == "typescript")
-                        RequireTypeScriptAugmentationRefresh();
-
-                    using var txn = writer.BeginTransaction(cancellationToken, "full scan file");
-                    if (!startedWithNoIndexedFiles)
-                    {
-                        var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
-                        if (stalePurged > 0)
-                        {
-                            ftsMutated = true;
-                            csharpMetadataTargetsNeedRefresh = true;
-                        }
-                    }
-                    var fileId = writer.UpsertFile(record, cleanExistingData: !startedWithNoIndexedFiles);
-                    ftsMutated = true;
-                    currentJsonIndexFile = FormatIndexPhasePath(record.Path, "chunking");
-                    var chunks = item.Chunks == null
-                        ? ChunkSplitter.SplitNormalized(
-                            fileId,
-                            item.Content!,
-                            item.HasOversizeLine ?? ChunkSplitter.HasOversizeLine(item.Content!),
-                            record.Lines)
-                        : ReassignChunkFileIds(item.Chunks, fileId);
-                    if (generatedSuppressionIssue != null)
-                    {
-                        writer.InsertChunks(chunks, cancellationToken);
-                        writer.InsertSymbols([], cancellationToken);
-                        writer.InsertReferences([], cancellationToken);
-                        var generatedIssues = AppendIssueIfMissing(
-                            item.Issues ?? ValidateWorkItemContent(item, record),
-                            generatedSuppressionIssue);
-                        writer.InsertIssues(fileId, generatedIssues);
-                        if (options.Verbose)
-                            WriteIndexVerboseStatus($"  [OK  ] {record.Path} ({chunks.Count} chunks, generated-code extraction skipped)");
+                        writer.InsertReferences(references, refreshMutualRecursionFlags: false, cancellationToken);
+                        if (references.Count > 0)
+                            mutualRecursionRefreshNeeded = true;
+                        currentJsonIndexFile = FormatIndexPhasePath(record.Path, "validating");
+                        var issues = item.Issues ?? ValidateWorkItemContent(item, record);
+                        writer.InsertIssues(fileId, issues);
                         currentJsonIndexFile = FormatIndexPhasePath(record.Path, "committing");
                         WriteProjectRootOnce();
                         txn.Commit();
 
-                        processed++;
-                        if (!options.Json && !options.Quiet)
+                        WriteIndexVerboseStatus($"  [OK  ] {record.Path} ({chunks.Count} chunks, {symbols.Count} symbols, {references.Count} refs)");
+                    }
+                    catch (IndexExtractionStalledException)
+                    {
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        GlobalToolLog.Error($"index_file_failed path={CollapseLineBreaks(item.FilePath)}\n{GlobalToolLog.FormatExceptionChain(ex)}");
+                        errors++;
+                        var errorMessage = FormatIndexFileException(ex);
+                        errorList.Add(new CliJsonMessage(item.FilePath, errorMessage));
+                        if (!options.Json)
                         {
                             PauseIndexSpinnerForConsoleWrite();
-                            ConsoleUi.PrintProgress(processed, files.Count);
+                            ConsoleUi.ClearProgressLine();
+                            ConsoleUi.TryWriteErrorLine(FormatPerFileErrorLine("ERR ", item.FilePath, ex, errorMessage));
                             ResumeIndexSpinnerAfterConsoleWrite();
                         }
-                        ReportJsonIndexProgressIfNeeded();
-                        currentJsonIndexFile = null;
-                        continue;
                     }
-                    currentJsonIndexFile = FormatIndexPhasePath(record.Path, "symbols");
-                    SymbolExtractionResult? symbolExtraction = null;
-                    var symbols = item.Symbols == null
-                        ? (symbolExtraction = ExtractSymbolsWithStallTimeout(
-                            fileId,
-                            record.Lang,
-                            item.Content!,
-                            item.FilePath,
-                            Path.GetFullPath(options.ProjectPath!),
-                            record.Path,
-                            currentJsonIndexFile,
-                            true,
-                            item.HasOversizeLine,
-                            mainSymbolExtractionWorker,
-                            cancellationToken)).Symbols
-                        : ReassignSymbolFileIds(item.Symbols, fileId);
-                    var symbolRegexTimeoutIssue = symbolExtraction?.RegexTimeoutIssue;
-                    if (symbols.Count > options.MaxSymbolsPerFile)
-                    {
-                        var issue = BuildSymbolCountExceededIssue(record.Path, symbols.Count, options.MaxSymbolsPerFile);
-                        IReadOnlyList<FileIssue> capIssues = symbolRegexTimeoutIssue == null
-                            ? [issue]
-                            : AppendIssue([symbolRegexTimeoutIssue], issue);
-                        writer.InsertSymbols([], cancellationToken);
-                        writer.InsertReferences([], cancellationToken);
-                        writer.InsertIssues(fileId, capIssues);
-                        if (options.Verbose)
-                            WriteIndexVerboseStatus($"  [SKIP] {record.Path} ({issue.Message})");
-                        txn.Commit();
-                        processed++;
-                        if (!options.Json && !options.Quiet)
-                        {
-                            PauseIndexSpinnerForConsoleWrite();
-                            ConsoleUi.PrintProgress(processed, files.Count);
-                            ResumeIndexSpinnerAfterConsoleWrite();
-                        }
-                        ReportJsonIndexProgressIfNeeded();
-                        currentJsonIndexFile = null;
-                        continue;
-                    }
-                    if (item.Symbols == null)
-                        SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(item.FilePath, record.Lang));
-                    var fileContext = new FileContext(projectRoot, record.Path, item.FilePath, record.Lang);
-                    var mutableSymbols = symbols as IList<SymbolRecord> ?? symbols.ToList();
-                    postExtractionHooks.OnSymbolsExtracted(fileContext, mutableSymbols);
-                    symbolsDroppedByKindFilter += options.SymbolKindFilter.Apply(mutableSymbols);
-                    symbols = (IReadOnlyList<SymbolRecord>)mutableSymbols;
-                    if (symbols.Count > options.MaxSymbolsPerFile)
-                    {
-                        var issue = BuildSymbolCountExceededIssue(record.Path, symbols.Count, options.MaxSymbolsPerFile);
-                        IReadOnlyList<FileIssue> capIssues = symbolRegexTimeoutIssue == null
-                            ? [issue]
-                            : AppendIssue([symbolRegexTimeoutIssue], issue);
-                        writer.InsertSymbols([], cancellationToken);
-                        writer.InsertReferences([], cancellationToken);
-                        writer.InsertIssues(fileId, capIssues);
-                        if (options.Verbose)
-                            WriteIndexVerboseStatus($"  [SKIP] {record.Path} ({issue.Message})");
-                        txn.Commit();
-                        processed++;
-                        if (!options.Json && !options.Quiet)
-                        {
-                            PauseIndexSpinnerForConsoleWrite();
-                            ConsoleUi.PrintProgress(processed, files.Count);
-                            ResumeIndexSpinnerAfterConsoleWrite();
-                        }
-                        ReportJsonIndexProgressIfNeeded();
-                        currentJsonIndexFile = null;
-                        continue;
-                    }
-                    writer.InsertChunks(chunks, cancellationToken);
-                    FileIndexer.ValidateSymbolLineRanges(record, symbols);
-                    writer.InsertSymbols(symbols, cancellationToken);
-                    if (symbolRegexTimeoutIssue != null)
-                    {
-                        var baseIssues = item.Issues ?? ValidateWorkItemContent(item, record);
-                        item = item with { Issues = AppendIssue(baseIssues, symbolRegexTimeoutIssue) };
-                    }
-                    currentJsonIndexFile = FormatIndexPhasePath(record.Path, "references");
-                    IReadOnlyList<ReferenceRecord> references;
-                    if (options.SymbolsOnly)
-                    {
-                        references = [];
-                    }
-                    else
-                    {
-                        FileIssue? regexTimeoutIssue = null;
-                        ReferenceExtractionResult? referenceExtraction = null;
-                        if (item.References == null)
-                        {
-                            using var regexTimeouts = BoundedRegex.CaptureTimeouts(record.Lang, "reference_extraction");
-                            referenceExtraction = ReferenceExtractor.ExtractDetailedNormalized(
-                                fileId,
-                                record.Lang,
-                                item.Content!,
-                                item.HasOversizeLine ?? ChunkSplitter.HasOversizeLine(item.Content!),
-                                symbols,
-                                record.Path,
-                                record.Lang == "csharp" ? csharpWorkspace.Symbols : null,
-                                cancellationToken,
-                                maxReferenceCount: options.MaxReferencesPerFile + 1);
-                            references = referenceExtraction.References;
-                            regexTimeoutIssue = BuildRegexTimeoutIssue(record.Path, regexTimeouts);
-                        }
-                        else
-                        {
-                            references = ReassignReferenceFileIds(item.References, fileId);
-                        }
-                        postExtractionHooks.OnReferencesExtracted(fileContext, AsMutableList(references));
-                        if (regexTimeoutIssue != null)
-                        {
-                            var baseIssues = item.Issues ?? ValidateWorkItemContent(item, record);
-                            item = item with { Issues = AppendIssue(baseIssues, regexTimeoutIssue) };
-                        }
-                        if (referenceExtraction != null)
-                        {
-                            var baseIssues = item.Issues ?? ValidateWorkItemContent(item, record);
-                            item = item with
-                            {
-                                Issues = AppendReferenceExtractionDiagnosticIssues(baseIssues, record.Path, referenceExtraction.Diagnostics),
-                            };
-                        }
-                        if (references.Count > options.MaxReferencesPerFile)
-                        {
-                            var issue = BuildReferenceCountExceededIssue(record.Path, references.Count, options.MaxReferencesPerFile);
-                            references = [];
-                            var baseIssues = item.Issues ?? ValidateWorkItemContent(item, record);
-                            item = item with { Issues = AppendIssue(baseIssues, issue) };
-                        }
-                    }
-                    writer.InsertReferences(references, refreshMutualRecursionFlags: false, cancellationToken);
-                    if (references.Count > 0)
-                        mutualRecursionRefreshNeeded = true;
-                    currentJsonIndexFile = FormatIndexPhasePath(record.Path, "validating");
-                    var issues = item.Issues ?? ValidateWorkItemContent(item, record);
-                    writer.InsertIssues(fileId, issues);
-                    currentJsonIndexFile = FormatIndexPhasePath(record.Path, "committing");
-                    WriteProjectRootOnce();
-                    txn.Commit();
 
-                    WriteIndexVerboseStatus($"  [OK  ] {record.Path} ({chunks.Count} chunks, {symbols.Count} symbols, {references.Count} refs)");
-                }
-                catch (IndexExtractionStalledException)
-                {
-                    throw;
-                }
-                catch (Exception ex)
-                {
-                    GlobalToolLog.Error($"index_file_failed path={CollapseLineBreaks(item.FilePath)}\n{GlobalToolLog.FormatExceptionChain(ex)}");
-                    errors++;
-                    var errorMessage = FormatIndexFileException(ex);
-                    errorList.Add(new CliJsonMessage(item.FilePath, errorMessage));
-                    if (!options.Json)
+                    processed++;
+                    currentJsonIndexFile = null;
+                    ThrowIfFullScanCancelled(processed, files.Count);
+                    ReportJsonIndexProgressIfNeeded();
+                    if (!options.Json && !options.Quiet)
                     {
                         PauseIndexSpinnerForConsoleWrite();
-                        ConsoleUi.ClearProgressLine();
-                        ConsoleUi.TryWriteErrorLine(FormatPerFileErrorLine("ERR ", item.FilePath, ex, errorMessage));
+                        ConsoleUi.PrintProgress(processed, files.Count);
                         ResumeIndexSpinnerAfterConsoleWrite();
                     }
                 }
-
-                processed++;
-                currentJsonIndexFile = null;
-                ThrowIfFullScanCancelled(processed, files.Count);
-                ReportJsonIndexProgressIfNeeded();
-                if (!options.Json && !options.Quiet)
-                {
-                    PauseIndexSpinnerForConsoleWrite();
-                    ConsoleUi.PrintProgress(processed, files.Count);
-                    ResumeIndexSpinnerAfterConsoleWrite();
-                }
+                Task.WaitAll(workers, cancellationToken);
             }
-            Task.WaitAll(workers, cancellationToken);
-        }
-        finally
-        {
-            currentJsonIndexFile = null;
-            StopJsonHeartbeat();
+            finally
+            {
+                currentJsonIndexFile = null;
+                StopJsonHeartbeat();
+                postExtractionHooks?.Dispose();
+            }
         }
 
         PauseIndexSpinnerForConsoleWrite();
@@ -2316,8 +2328,11 @@ public static partial class IndexCommandRunner
             : FileIndexer.ValidateContent(record.Path, rawBytes, content, record.Lang);
     }
 
-    private static int AddPostExtractionHookWarnings(PostExtractionHookRunner runner, List<CliJsonMessage> warningList)
+    private static int AddPostExtractionHookWarnings(PostExtractionHookRunner? runner, List<CliJsonMessage> warningList)
     {
+        if (runner == null)
+            return 0;
+
         var added = 0;
         foreach (var diagnostic in runner.Diagnostics)
         {

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -1006,12 +1006,14 @@ public static partial class IndexCommandRunner
         var hasPostExtractionHooks = postExtractionHooks.Hooks.Count > 0;
         var existingFileCount = writer.GetCounts().files;
         var startedWithNoIndexedFiles = existingFileCount == 0;
+        var typeScriptAugmentationVersionMatchesCurrent = writer.TypeScriptAugmentationVersionMatchesCurrent();
         var typeScriptAugmentationNeedsRefresh = !options.SymbolsOnly
             && (options.Rebuild
                 || startedWithNoIndexedFiles
                 || purged > 0
                 || !projectRootWritten
-                || !writer.TypeScriptAugmentationVersionMatchesCurrent());
+                || !typeScriptAugmentationVersionMatchesCurrent);
+        var typeScriptAugmentationReadyCleared = !typeScriptAugmentationVersionMatchesCurrent;
         var csharpMetadataTargetsNeedRefresh = options.Rebuild
             || startedWithNoIndexedFiles
             || purged > 0
@@ -1025,6 +1027,21 @@ public static partial class IndexCommandRunner
         FullScanExtractionSchedulingForTesting?.Invoke(
             parallelizeExtraction,
             parallelizeExtractionReason);
+
+        void RequireTypeScriptAugmentationRefresh()
+        {
+            if (!typeScriptAugmentationReadyCleared)
+            {
+                writer.ClearTypeScriptAugmentationReady();
+                typeScriptAugmentationReadyCleared = true;
+            }
+
+            if (!options.SymbolsOnly)
+                typeScriptAugmentationNeedsRefresh = true;
+        }
+
+        if (purged > 0 || (options.SymbolsOnly && purgedRefs > 0))
+            RequireTypeScriptAugmentationRefresh();
 
         void StartIndexSpinnerIfNeeded()
         {
@@ -1562,7 +1579,7 @@ public static partial class IndexCommandRunner
                             {
                                 ftsMutated = true;
                                 csharpMetadataTargetsNeedRefresh = true;
-                                typeScriptAugmentationNeedsRefresh = true;
+                                RequireTypeScriptAugmentationRefresh();
                                 WriteProjectRootOnce();
                                 deleteTxn.Commit();
                             }
@@ -1634,7 +1651,7 @@ public static partial class IndexCommandRunner
                         {
                             ftsMutated = true;
                             csharpMetadataTargetsNeedRefresh = true;
-                            typeScriptAugmentationNeedsRefresh = true;
+                            RequireTypeScriptAugmentationRefresh();
                         }
                         skipped++;
                         processed++;
@@ -1663,7 +1680,7 @@ public static partial class IndexCommandRunner
                     if (record.Lang == "csharp")
                         csharpMetadataTargetsNeedRefresh = true;
                     if (record.Lang == "typescript")
-                        typeScriptAugmentationNeedsRefresh = true;
+                        RequireTypeScriptAugmentationRefresh();
 
                     using var txn = writer.BeginTransaction(cancellationToken, "full scan file");
                     if (!startedWithNoIndexedFiles)

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -121,10 +121,7 @@ public static partial class IndexCommandRunner
     }
 
     private static bool ExistingFileViolatesExtractionCaps(DbWriter writer, long fileId, int maxSymbolsPerFile, int maxReferencesPerFile) =>
-        writer.CountSymbolsForFile(fileId) > maxSymbolsPerFile
-        || writer.HasIssueForFile(fileId, "symbol_count_exceeded")
-        || writer.CountReferencesForFile(fileId) > maxReferencesPerFile
-        || writer.HasIssueForFile(fileId, "reference_count_exceeded");
+        writer.HasExtractionCapViolationForFile(fileId, maxSymbolsPerFile, maxReferencesPerFile);
 
     internal static bool ExistingFileGeneratedSuppressionMismatch(DbWriter writer, long fileId, FileIssue? generatedSuppressionIssue)
         => writer.HasIssueForFile(fileId, FileIndexer.GeneratedCodeExtractionSkippedIssueKind) != (generatedSuppressionIssue != null);

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -965,6 +965,7 @@ public static partial class IndexCommandRunner
 
         CancellationTokenSource? indexCts = null;
         int processed = 0, skipped = 0, warnings = warningList.Count, errors = errorList.Count;
+        var ftsMutated = purged > 0;
         var symbolsDroppedByKindFilter = 0;
         var mutualRecursionRefreshNeeded = false;
 
@@ -1510,6 +1511,7 @@ public static partial class IndexCommandRunner
                             using var deleteTxn = writer.BeginTransaction(cancellationToken, "full scan delete skipped file");
                             if (writer.DeleteFileByPath(currentJsonIndexFile))
                             {
+                                ftsMutated = true;
                                 WriteProjectRootOnce();
                                 deleteTxn.Commit();
                             }
@@ -1573,7 +1575,8 @@ public static partial class IndexCommandRunner
                     }
                     if (existingId != null)
                     {
-                        writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
+                        if (writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum) > 0)
+                            ftsMutated = true;
                         skipped++;
                         processed++;
                         if (!string.IsNullOrWhiteSpace(record.Lang))
@@ -1600,8 +1603,12 @@ public static partial class IndexCommandRunner
 
                     using var txn = writer.BeginTransaction(cancellationToken, "full scan file");
                     if (!startedWithNoIndexedFiles)
-                        writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
+                    {
+                        if (writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum) > 0)
+                            ftsMutated = true;
+                    }
                     var fileId = writer.UpsertFile(record, cleanExistingData: !startedWithNoIndexedFiles);
+                    ftsMutated = true;
                     currentJsonIndexFile = FormatIndexPhasePath(record.Path, "chunking");
                     var chunks = item.Chunks == null
                         ? ChunkSplitter.SplitNormalized(
@@ -1832,15 +1839,19 @@ public static partial class IndexCommandRunner
             }
         }
         ThrowIfFullScanCancelled(processed, files.Count);
-        WriteFullScanJsonLiveness(options, "optimizing index...");
-        var optimizeHeartbeat = StartFullScanJsonPhaseHeartbeat(options, "optimizing index");
-        try
+        if (ftsMutated)
         {
-            writer.OptimizeFts();
-        }
-        finally
-        {
-            StopFullScanJsonPhaseHeartbeat(optimizeHeartbeat);
+            WriteFullScanJsonLiveness(options, "optimizing index...");
+            var optimizeHeartbeat = StartFullScanJsonPhaseHeartbeat(options, "optimizing index");
+            try
+            {
+                FullScanFtsOptimizeForTesting?.Invoke();
+                writer.OptimizeFts();
+            }
+            finally
+            {
+                StopFullScanJsonPhaseHeartbeat(optimizeHeartbeat);
+            }
         }
         ThrowIfFullScanCancelled(processed, files.Count);
         // Only stamp readiness on a fully successful run (errors == 0). A partial / error

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -126,11 +126,24 @@ public static partial class IndexCommandRunner
         int maxSymbolsPerFile,
         int maxReferencesPerFile,
         FileIssue? generatedSuppressionIssue) =>
-        writer.HasReusableFileBlockingIssueForFile(
+        ExistingFileBlocksReuse(
+            writer,
             fileId,
             maxSymbolsPerFile,
             maxReferencesPerFile,
             generatedSuppressionIssue != null);
+
+    private static bool ExistingFileBlocksReuse(
+        DbWriter writer,
+        long fileId,
+        int maxSymbolsPerFile,
+        int maxReferencesPerFile,
+        bool generatedExtractionSuppressed) =>
+        writer.HasReusableFileBlockingIssueForFile(
+            fileId,
+            maxSymbolsPerFile,
+            maxReferencesPerFile,
+            generatedExtractionSuppressed);
 
     internal static IReadOnlyList<FileIssue> AppendIssue(IReadOnlyList<FileIssue> issues, FileIssue issue)
     {
@@ -1162,7 +1175,7 @@ public static partial class IndexCommandRunner
                 existingId.Value,
                 options.MaxSymbolsPerFile,
                 options.MaxReferencesPerFile,
-                indexer.BuildGeneratedCodeExtractionSkippedIssue(target.IndexPath));
+                indexer.IsGeneratedCodeExtractionSuppressed(target.IndexPath));
         }
 
         CSharpStaticInterfaceWorkspaceSymbols csharpWorkspace;
@@ -1235,7 +1248,7 @@ public static partial class IndexCommandRunner
                 existingId.Value,
                 options.MaxSymbolsPerFile,
                 options.MaxReferencesPerFile,
-                indexer.BuildGeneratedCodeExtractionSkippedIssue(target.IndexPath)))
+                indexer.IsGeneratedCodeExtractionSuppressed(target.IndexPath)))
             {
                 return false;
             }

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -898,6 +898,7 @@ public static partial class IndexCommandRunner
             purgeCts = ConsoleUi.StartSpinner("Cleaning up stale entries...", spinnerFrames);
         var purged = 0;
         var retainedPaths = fileTargets.Select(target => target.IndexPath).ToHashSet(StringComparer.Ordinal);
+        var indexedJavaScriptTypeScriptConfigPathsBeforePurge = writer.GetIndexedJavaScriptTypeScriptConfigPaths();
         if (scanResult.HadErrors)
         {
             SaveScanCheckpoint(
@@ -1029,6 +1030,11 @@ public static partial class IndexCommandRunner
         if (purged > 0 || (options.SymbolsOnly && purgedRefs > 0))
             RequireTypeScriptAugmentationRefresh();
 
+        var javaScriptTypeScriptRefreshRequired = forceJavaScriptTypeScriptRefresh
+            || (!options.Rebuild
+                && !startedWithNoIndexedFiles
+                && FullScanJavaScriptTypeScriptConfigChanged());
+
         void StartIndexSpinnerIfNeeded()
         {
             if (!interactiveIndexSpinner || indexCts != null)
@@ -1158,6 +1164,33 @@ public static partial class IndexCommandRunner
             jsonHeartbeatTask = null;
         }
 
+        bool FullScanJavaScriptTypeScriptConfigChanged()
+        {
+            foreach (var indexedConfigPath in indexedJavaScriptTypeScriptConfigPathsBeforePurge)
+            {
+                if (!retainedPaths.Contains(indexedConfigPath))
+                    return true;
+            }
+
+            foreach (var target in fileTargets)
+            {
+                if (!IsJavaScriptTypeScriptConfigPath(target.IndexPath))
+                    continue;
+
+                var existingId = TryGetUnchangedFileIdFromStat(
+                    writer,
+                    target.FilePath,
+                    target.IndexPath,
+                    target.Language,
+                    allowReuse: true,
+                    out _);
+                if (existingId == null)
+                    return true;
+            }
+
+            return false;
+        }
+
         bool CanReuseCSharpPrepassTargetWithoutRead(CSharpStaticInterfacePrepass.FileTarget target)
         {
             if (options.Rebuild || startedWithNoIndexedFiles || !symbolKindFilterMatchesPrior || !csharpSymbolNameContractMatchesCurrent)
@@ -1241,7 +1274,7 @@ public static partial class IndexCommandRunner
 
             var target = fileTargets[fileIndex];
             var language = target.Language;
-            var languageRequiresRefresh = forceJavaScriptTypeScriptRefresh
+            var languageRequiresRefresh = javaScriptTypeScriptRefreshRequired
                 && IsJavaScriptTypeScriptLanguage(language);
             var allowReuse = symbolKindFilterMatchesPrior
                 && !languageRequiresRefresh
@@ -1633,7 +1666,7 @@ public static partial class IndexCommandRunner
                         long? existingId = null;
                         if (!options.Rebuild && !startedWithNoIndexedFiles && !options.SymbolsOnly)
                         {
-                            var languageRequiresRefresh = forceJavaScriptTypeScriptRefresh
+                            var languageRequiresRefresh = javaScriptTypeScriptRefreshRequired
                                 && IsJavaScriptTypeScriptLanguage(record.Lang);
                             existingId = writer.GetUnchangedFileId(
                                 record.Path,

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -1137,8 +1137,8 @@ public static partial class IndexCommandRunner
 
             var existingId = TryGetUnchangedFileIdFromStat(
                 writer,
-                projectRoot,
                 target.FilePath,
+                target.IndexPath,
                 target.Language,
                 allowReuse: true);
             if (existingId == null)
@@ -1209,8 +1209,8 @@ public static partial class IndexCommandRunner
                 && AllowReuseWithCurrentHotspotFamilyTrust(language, hotspotFamilyTrustMatchesCurrent);
             var existingId = TryGetUnchangedFileIdFromStat(
                 writer,
-                projectRoot,
                 target.FilePath,
+                target.IndexPath,
                 language,
                 allowReuse);
             if (existingId == null)

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -991,6 +991,12 @@ public static partial class IndexCommandRunner
         var hasPostExtractionHooks = postExtractionHooks.Hooks.Count > 0;
         var existingFileCount = writer.GetCounts().files;
         var startedWithNoIndexedFiles = existingFileCount == 0;
+        var typeScriptAugmentationNeedsRefresh = !options.SymbolsOnly
+            && (options.Rebuild
+                || startedWithNoIndexedFiles
+                || purged > 0
+                || !projectRootWritten
+                || !writer.TypeScriptAugmentationVersionMatchesCurrent());
         var csharpMetadataTargetsNeedRefresh = options.Rebuild
             || startedWithNoIndexedFiles
             || purged > 0
@@ -1525,6 +1531,7 @@ public static partial class IndexCommandRunner
                             {
                                 ftsMutated = true;
                                 csharpMetadataTargetsNeedRefresh = true;
+                                typeScriptAugmentationNeedsRefresh = true;
                                 WriteProjectRootOnce();
                                 deleteTxn.Commit();
                             }
@@ -1592,6 +1599,7 @@ public static partial class IndexCommandRunner
                         {
                             ftsMutated = true;
                             csharpMetadataTargetsNeedRefresh = true;
+                            typeScriptAugmentationNeedsRefresh = true;
                         }
                         skipped++;
                         processed++;
@@ -1619,6 +1627,8 @@ public static partial class IndexCommandRunner
 
                     if (record.Lang == "csharp")
                         csharpMetadataTargetsNeedRefresh = true;
+                    if (record.Lang == "typescript")
+                        typeScriptAugmentationNeedsRefresh = true;
 
                     using var txn = writer.BeginTransaction(cancellationToken, "full scan file");
                     if (!startedWithNoIndexedFiles)
@@ -1927,7 +1937,11 @@ public static partial class IndexCommandRunner
             csharpSymbolNameReadyAfter = true;
             if (!options.SymbolsOnly)
             {
-                writer.RebuildTypeScriptAugmentationReferences(projectRoot);
+                if (typeScriptAugmentationNeedsRefresh)
+                {
+                    FullScanTypeScriptAugmentationRebuildForTesting?.Invoke();
+                    writer.RebuildTypeScriptAugmentationReferences(projectRoot);
+                }
             }
             RestampHotspotFamilyTrustForFullScan(
                 writer,

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -852,6 +852,7 @@ public static partial class IndexCommandRunner
             projectRoot,
             filePath,
             FileIndexer.GetReusableDetectedLanguage(filePath, scanResult.FileLanguages))).ToArray();
+        var knownReadableFileSizes = new Dictionary<string, long>(StringComparer.Ordinal);
         var errorList = discovery.ErrorList;
         var warningList = discovery.WarningList;
         AddProjectMarkerFingerprintWarnings(currentHotspotFamilyMarkerFingerprints, warningList, options);
@@ -1152,7 +1153,8 @@ public static partial class IndexCommandRunner
                 target.FilePath,
                 target.IndexPath,
                 target.Language,
-                allowReuse: true);
+                allowReuse: true,
+                out _);
             if (existingId == null)
                 return false;
             return !ExistingFileBlocksReuse(
@@ -1224,7 +1226,8 @@ public static partial class IndexCommandRunner
                 target.FilePath,
                 target.IndexPath,
                 language,
-                allowReuse);
+                allowReuse,
+                out var statSize);
             if (existingId == null)
                 return false;
             if (ExistingFileBlocksReuse(
@@ -1239,6 +1242,8 @@ public static partial class IndexCommandRunner
 
             skipped++;
             processed++;
+            if (statSize.HasValue)
+                knownReadableFileSizes[target.FilePath] = statSize.Value;
             if (!string.IsNullOrWhiteSpace(language))
                 skippedSymbolExtractorLanguages.Add(language);
             if (FileIndexer.SupportsHotspotFamilyMarkerLanguage(language) && language != null)
@@ -1554,6 +1559,7 @@ public static partial class IndexCommandRunner
                     }
 
                     var record = item.Record!;
+                    knownReadableFileSizes[item.FilePath] = record.Size;
                     if (item.Warning != null && !options.Json && !options.Quiet)
                     {
                         PauseIndexSpinnerForConsoleWrite();
@@ -2031,7 +2037,7 @@ public static partial class IndexCommandRunner
             if (options.MemoryTrace)
                 memorySamples.Add(CaptureMemorySample("finalize", stopwatch));
             var memoryTimelineForStamp = BuildMemoryTimeline(memorySamples);
-            var bytesRead = MeasureReadableFileBytes(files, projectRoot, indexRunDiagnostics);
+            var bytesRead = MeasureReadableFileBytes(files, projectRoot, indexRunDiagnostics, knownReadableFileSizes);
             StampLastIndexRunMetadata(
                 writer,
                 options.Rebuild ? "rebuild" : "incremental",

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -1327,7 +1327,11 @@ public static partial class IndexCommandRunner
                 }
 
                 FullScanExtractionWorkStartedForTesting?.Invoke();
-                using var extractionResults = new BlockingCollection<FullScanFileWorkItem>(Math.Max(1, extractionParallelism * 4));
+                var extractionQueueCapacity = parallelizeExtraction
+                    ? Math.Max(1, extractionParallelism * 4)
+                    : 1;
+                FullScanExtractionQueueCapacityForTesting?.Invoke(extractionQueueCapacity);
+                using var extractionResults = new BlockingCollection<FullScanFileWorkItem>(extractionQueueCapacity);
                 using var extractionStallCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
                 using var mainSymbolExtractionWorker = new SymbolExtractionWorkerClient(options.MaxFileSizeBytes);
                 var extractionCancellationToken = extractionStallCts.Token;
@@ -1459,6 +1463,11 @@ public static partial class IndexCommandRunner
                                         issues = AppendIssue(issues, issue);
                                     }
                                 }
+                                else
+                                {
+                                    activeJsonExtractionPhases[workerIndex] = FormatIndexPhasePath(record.Path, "validating");
+                                    issues = FileIndexer.ValidateContent(record.Path, rawBytes, content, record.Lang, loaded.Inspection, hasOversizeLine);
+                                }
                                 extractionResults.Add(
                                     parallelizeExtraction
                                         ? FullScanFileWorkItem.Precomputed(
@@ -1477,8 +1486,8 @@ public static partial class IndexCommandRunner
                                             displayRelativePath,
                                             record,
                                             content,
-                                            rawBytes,
-                                            loaded.Inspection,
+                                            null,
+                                            null,
                                             hasOversizeLine,
                                             warning,
                                             chunks,

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -791,7 +791,8 @@ public static partial class IndexCommandRunner
         string? initialCwd,
         List<string>? indexRunDiagnostics,
         bool showNextSteps,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool forceJavaScriptTypeScriptRefresh = false)
     {
         var jsonContext = CliJsonSerializerContextFactory.Create(jsonOptions);
         var memorySamples = options.MemoryTrace ? new List<IndexMemorySampleJsonResult> { CaptureMemorySample("start", stopwatch) } : [];
@@ -1237,7 +1238,10 @@ public static partial class IndexCommandRunner
 
             var target = fileTargets[fileIndex];
             var language = target.Language;
+            var languageRequiresRefresh = forceJavaScriptTypeScriptRefresh
+                && IsJavaScriptTypeScriptLanguage(language);
             var allowReuse = symbolKindFilterMatchesPrior
+                && !languageRequiresRefresh
                 && !priorSymbolsOnlyGraphOmitted
                 && (language != "csharp" || csharpSymbolNameContractMatchesCurrent)
                 && (language != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
@@ -1595,6 +1599,8 @@ public static partial class IndexCommandRunner
                     long? existingId = null;
                     if (!options.Rebuild && !startedWithNoIndexedFiles && !options.SymbolsOnly)
                     {
+                        var languageRequiresRefresh = forceJavaScriptTypeScriptRefresh
+                            && IsJavaScriptTypeScriptLanguage(record.Lang);
                         existingId = writer.GetUnchangedFileId(
                             record.Path,
                             record.Modified,
@@ -1604,6 +1610,7 @@ public static partial class IndexCommandRunner
                             language: record.Lang,
                             generated: record.Generated,
                             allowReuse: symbolKindFilterMatchesPrior
+                                && !languageRequiresRefresh
                                 && !priorSymbolsOnlyGraphOmitted
                                 && (record.Lang != "csharp" || csharpSymbolNameContractMatchesCurrent)
                                 && (record.Lang != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -134,8 +134,10 @@ public static partial class IndexCommandRunner
             ? null
             : Path.GetFullPath(priorIndexedProjectRoot);
         var projectRootWritten = PathsEqual(normalizedPriorIndexedProjectRoot, normalizedProjectRoot);
+        var typeScriptAugmentationVersionMatchesCurrent = writer.TypeScriptAugmentationVersionMatchesCurrent();
         var typeScriptAugmentationNeedsRefresh = !options.SymbolsOnly
-            && (!projectRootWritten || !writer.TypeScriptAugmentationVersionMatchesCurrent());
+            && (!projectRootWritten || !typeScriptAugmentationVersionMatchesCurrent);
+        var typeScriptAugmentationReadyCleared = !typeScriptAugmentationVersionMatchesCurrent;
         var ftsMutated = false;
         var purgedRefs = 0;
         var supportedGraphLanguages = ReferenceExtractor.GetSupportedLanguages();
@@ -168,6 +170,18 @@ public static partial class IndexCommandRunner
             writer.ClearHotspotFamilyReady();
             writer.ClearMetadataTargetReady();
             readinessDemoted = true;
+        }
+
+        void RequireTypeScriptAugmentationRefresh()
+        {
+            if (!typeScriptAugmentationReadyCleared)
+            {
+                writer.ClearTypeScriptAugmentationReady();
+                typeScriptAugmentationReadyCleared = true;
+            }
+
+            if (!options.SymbolsOnly)
+                typeScriptAugmentationNeedsRefresh = true;
         }
 
         void WriteProjectRootOnce()
@@ -623,10 +637,10 @@ public static partial class IndexCommandRunner
                         if (writer.DeleteFileByPath(dbPath))
                         {
                             WriteProjectRootOnce();
+                            RequireTypeScriptAugmentationRefresh();
                             deleteTxn.Commit();
                             removed++;
                             ftsMutated = true;
-                            typeScriptAugmentationNeedsRefresh = true;
                         }
                         else
                         {
@@ -725,10 +739,10 @@ public static partial class IndexCommandRunner
                         {
                             DemoteReadinessOnce();
                             WriteProjectRootOnce();
+                            RequireTypeScriptAugmentationRefresh();
                             purgeTxn.Commit();
                             removed += purged;
                             ftsMutated = true;
-                            typeScriptAugmentationNeedsRefresh = true;
                         }
                         skipped++;
                         if (options.Verbose && !options.Json && !options.Quiet)
@@ -747,14 +761,15 @@ public static partial class IndexCommandRunner
                     fileBatchMarked = true;
                     if (record.Lang == "csharp")
                         csharpMetadataTargetsNeedRefresh = true;
-                    if (record.Lang == "typescript")
-                        typeScriptAugmentationNeedsRefresh = true;
+                    var recordRequiresTypeScriptAugmentationRefresh = record.Lang == "typescript";
                     using var txn = writer.BeginTransaction(cancellationToken, "update file");
+                    if (recordRequiresTypeScriptAugmentationRefresh)
+                        RequireTypeScriptAugmentationRefresh();
                     var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
                     if (projectRootWritten)
                         stalePurged += writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, record.Path);
                     if (stalePurged > 0)
-                        typeScriptAugmentationNeedsRefresh = true;
+                        RequireTypeScriptAugmentationRefresh();
                     WriteProjectRootOnce();
                     var fileId = writer.UpsertFile(record);
                     currentUpdatePath = FormatIndexPhasePath(relPath, "chunking");
@@ -910,8 +925,8 @@ public static partial class IndexCommandRunner
                         var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, skippedRecord.Path, skippedRecord.Checksum);
                         if (projectRootWritten)
                             stalePurged += writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, skippedRecord.Path);
-                        if (stalePurged > 0)
-                            typeScriptAugmentationNeedsRefresh = true;
+                        if (skippedRecord.Lang == "typescript" || stalePurged > 0)
+                            RequireTypeScriptAugmentationRefresh();
                         WriteProjectRootOnce();
                         var fileId = writer.UpsertFile(skippedRecord);
                         writer.InsertChunks([], cancellationToken);
@@ -939,8 +954,8 @@ public static partial class IndexCommandRunner
                         var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, skippedRecord.Path, skippedRecord.Checksum);
                         if (projectRootWritten)
                             stalePurged += writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, skippedRecord.Path);
-                        if (stalePurged > 0)
-                            typeScriptAugmentationNeedsRefresh = true;
+                        if (skippedRecord.Lang == "typescript" || stalePurged > 0)
+                            RequireTypeScriptAugmentationRefresh();
                         WriteProjectRootOnce();
                         var fileId = writer.UpsertFile(skippedRecord);
                         writer.InsertChunks([], cancellationToken);
@@ -986,10 +1001,10 @@ public static partial class IndexCommandRunner
                             if (writer.DeleteFileByPath(dbPath))
                             {
                                 WriteProjectRootOnce();
+                                RequireTypeScriptAugmentationRefresh();
                                 deleteTxn.Commit();
                                 removed++;
                                 ftsMutated = true;
-                                typeScriptAugmentationNeedsRefresh = true;
                             }
                         }
                         else

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -607,7 +607,6 @@ public static partial class IndexCommandRunner
                         absPath,
                         statReusableLanguage,
                         allowReuse: symbolKindFilterMatchesPrior
-                            && statReusableLanguage is not ("javascript" or "typescript")
                             && (statReusableLanguage != "csharp" || csharpSymbolNameContractMatchesCurrent)
                             && (statReusableLanguage != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
                             && (statReusableLanguage != "sql" || sqlGraphContractMatchesCurrent));
@@ -663,7 +662,6 @@ public static partial class IndexCommandRunner
                         language: record.Lang,
                         generated: record.Generated,
                         allowReuse: symbolKindFilterMatchesPrior
-                            && record.Lang is not ("javascript" or "typescript")
                             && (record.Lang != "csharp" || csharpSymbolNameContractMatchesCurrent)
                             && (record.Lang != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
                             && (record.Lang != "sql" || sqlGraphContractMatchesCurrent));

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -141,10 +141,11 @@ public static partial class IndexCommandRunner
         var ftsMutated = false;
         var purgedRefs = 0;
         var supportedGraphLanguages = ReferenceExtractor.GetSupportedLanguages();
-        using var postExtractionHooks = PostExtractionHookRunner.DiscoverDefault(
-            options.MaxFileSizeBytes,
-            maxSymbolCount: options.MaxSymbolsPerFile + 1,
-            maxReferenceCount: options.MaxReferencesPerFile + 1);
+        using var postExtractionHooks = new LazyDisposable<PostExtractionHookRunner>(
+            () => PostExtractionHookRunner.DiscoverDefault(
+                options.MaxFileSizeBytes,
+                maxSymbolCount: options.MaxSymbolsPerFile + 1,
+                maxReferenceCount: options.MaxReferencesPerFile + 1));
         var currentFoldVersion = NameFold.Version.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var currentFoldFingerprint = NameFold.Fingerprint();
         var currentCSharpSymbolNameContractVersion = DbContext.CSharpSymbolNameContractVersion.ToString(System.Globalization.CultureInfo.InvariantCulture);
@@ -402,7 +403,11 @@ public static partial class IndexCommandRunner
             () => currentUpdatePath == null
                 ? $"{updated + removed + skipped:N0}/{targetPaths.Count:N0} files processed"
                 : $"{updated + removed + skipped:N0}/{targetPaths.Count:N0} files processed, current {currentUpdatePath}");
-        using var symbolExtractionWorker = new SymbolExtractionWorkerClient(options.MaxFileSizeBytes);
+        using var symbolExtractionWorker = new LazyDisposable<SymbolExtractionWorkerClient>(() =>
+        {
+            UpdateExtractionWorkStartedForTesting?.Invoke();
+            return new SymbolExtractionWorkerClient(options.MaxFileSizeBytes);
+        });
         try
         {
             foreach (var targetPath in targetPaths)
@@ -804,7 +809,7 @@ public static partial class IndexCommandRunner
                         currentUpdatePath,
                         true,
                         loaded.HasOversizeLine,
-                        symbolExtractionWorker,
+                        symbolExtractionWorker.Value,
                         cancellationToken);
                     var symbols = symbolExtraction.Symbols;
                     var symbolRegexTimeoutIssue = symbolExtraction.RegexTimeoutIssue;
@@ -827,7 +832,7 @@ public static partial class IndexCommandRunner
                     }
                     SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(absPath, record.Lang));
                     var fileContext = new FileContext(projectRoot, record.Path, absPath, record.Lang);
-                    postExtractionHooks.OnSymbolsExtracted(fileContext, symbols);
+                    postExtractionHooks.Value.OnSymbolsExtracted(fileContext, symbols);
                     symbolsDroppedByKindFilter += options.SymbolKindFilter.Apply(symbols);
                     if (symbols.Count > options.MaxSymbolsPerFile)
                     {
@@ -868,7 +873,7 @@ public static partial class IndexCommandRunner
                         references = referenceExtraction.References;
                         referenceRegexTimeoutIssue = BuildRegexTimeoutIssue(record.Path, regexTimeouts);
                     }
-                    postExtractionHooks.OnReferencesExtracted(fileContext, references);
+                    postExtractionHooks.Value.OnReferencesExtracted(fileContext, references);
                     FileIssue? referenceCapIssue = null;
                     if (references.Count > options.MaxReferencesPerFile)
                     {
@@ -1218,7 +1223,7 @@ public static partial class IndexCommandRunner
             warningList.Add(new CliJsonMessage("<process_cwd>", cwdDriftNotice!));
             warnings++;
         }
-        warnings += AddPostExtractionHookWarnings(postExtractionHooks, warningList);
+        warnings += AddPostExtractionHookWarnings(postExtractionHooks.ValueIfCreated, warningList);
         var (totalFiles, totalChunks, totalSymbols, totalReferences) = writer.GetCounts();
         var signalReader = new DbReader(writer.Connection);
         var sqlGraphContractSignalAfter = signalReader.GetSqlGraphContractSignal(lang: null);

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -267,9 +267,10 @@ public static partial class IndexCommandRunner
                 ? Path.GetRelativePath(projectRoot, path)
                 : path;
 
-        IEnumerable<CSharpStaticInterfacePrepass.FileTarget> BuildCSharpPrepassTargets(
+        List<CSharpStaticInterfacePrepass.FileTarget> BuildCSharpPrepassTargets(
             IReadOnlyDictionary<string, string>? scannedLanguages)
         {
+            var targets = new List<CSharpStaticInterfacePrepass.FileTarget>();
             foreach (var targetPath in targetPaths)
             {
                 var absPath = ToUpdateAbsolutePath(targetPath);
@@ -281,23 +282,42 @@ public static partial class IndexCommandRunner
 
                     language = scannedLanguage;
                 }
+                else
+                {
+                    var detection = FileIndexer.TryDetectLanguage(absPath);
+                    if (detection.Status != FileIndexer.FileProbeStatus.Supported || detection.Language != "csharp")
+                        continue;
 
-                yield return CSharpStaticInterfacePrepass.FileTarget.Create(projectRoot, absPath, language);
+                    language = detection.Language;
+                }
+
+                targets.Add(CSharpStaticInterfacePrepass.FileTarget.Create(projectRoot, absPath, language));
             }
+
+            return targets;
         }
 
         IReadOnlyDictionary<string, string>? scannedUpdateLanguages = null;
         ThrowIfUpdateCancelled();
         WriteIndexJsonLiveness(options, "checking C# workspace contracts...");
         var csharpWorkspaceHeartbeat = StartIndexJsonPhaseHeartbeat(options, "checking C# workspace contracts");
+        var csharpPrepassTargets = BuildCSharpPrepassTargets(scannedUpdateLanguages);
         CSharpStaticInterfaceWorkspaceSymbols csharpWorkspace;
         try
         {
-            csharpWorkspace = CSharpStaticInterfacePrepass.BuildWorkspaceSymbols(
-                writer,
-                indexer,
-                BuildCSharpPrepassTargets(scannedUpdateLanguages),
-                cancellationToken: cancellationToken);
+            if (csharpPrepassTargets.Count == 0)
+            {
+                csharpWorkspace = new CSharpStaticInterfaceWorkspaceSymbols([], false);
+            }
+            else
+            {
+                UpdateCSharpPrepassForTesting?.Invoke();
+                csharpWorkspace = CSharpStaticInterfacePrepass.BuildWorkspaceSymbols(
+                    writer,
+                    indexer,
+                    csharpPrepassTargets,
+                    cancellationToken: cancellationToken);
+            }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -322,11 +342,20 @@ public static partial class IndexCommandRunner
                         targetPaths.Add(filePath);
                 }
 
-                csharpWorkspace = CSharpStaticInterfacePrepass.BuildWorkspaceSymbols(
-                    writer,
-                    indexer,
-                    BuildCSharpPrepassTargets(scannedUpdateLanguages),
-                    cancellationToken: cancellationToken);
+                csharpPrepassTargets = BuildCSharpPrepassTargets(scannedUpdateLanguages);
+                if (csharpPrepassTargets.Count == 0)
+                {
+                    csharpWorkspace = new CSharpStaticInterfaceWorkspaceSymbols([], false);
+                }
+                else
+                {
+                    UpdateCSharpPrepassForTesting?.Invoke();
+                    csharpWorkspace = CSharpStaticInterfacePrepass.BuildWorkspaceSymbols(
+                        writer,
+                        indexer,
+                        csharpPrepassTargets,
+                        cancellationToken: cancellationToken);
+                }
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -436,6 +436,7 @@ public static partial class IndexCommandRunner
                         if (writer.DeleteFileByPath(dbPath))
                         {
                             WriteProjectRootOnce();
+                            RequireTypeScriptAugmentationRefresh();
                             deleteTxn.Commit();
                             removed++;
                             ftsMutated = true;
@@ -482,6 +483,7 @@ public static partial class IndexCommandRunner
                         if (writer.DeleteFileByPath(dbPath))
                         {
                             WriteProjectRootOnce();
+                            RequireTypeScriptAugmentationRefresh();
                             deleteTxn.Commit();
                             removed++;
                             ftsMutated = true;
@@ -526,6 +528,7 @@ public static partial class IndexCommandRunner
                             if (writer.DeleteFileByPath(dbPath))
                             {
                                 WriteProjectRootOnce();
+                                RequireTypeScriptAugmentationRefresh();
                                 deleteTxn.Commit();
                                 removed++;
                                 ftsMutated = true;
@@ -568,6 +571,7 @@ public static partial class IndexCommandRunner
                             {
                                 DemoteReadinessOnce();
                                 WriteProjectRootOnce();
+                                RequireTypeScriptAugmentationRefresh();
                                 purgeTxn.Commit();
                                 removed += purged;
                                 ftsMutated = true;
@@ -596,6 +600,7 @@ public static partial class IndexCommandRunner
                         if (writer.DeleteFileByPath(dbPath))
                         {
                             WriteProjectRootOnce();
+                            RequireTypeScriptAugmentationRefresh();
                             deleteTxn.Commit();
                             removed++;
                             ftsMutated = true;

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -113,7 +113,8 @@ public static partial class IndexCommandRunner
                 initialCwd,
                 indexRunDiagnostics,
                 showNextSteps: false,
-                cancellationToken);
+                cancellationToken,
+                forceJavaScriptTypeScriptRefresh: typeScriptJavaScriptConfigChanged);
         }
 
         if (!options.Json && !options.Quiet)

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -622,7 +622,7 @@ public static partial class IndexCommandRunner
                             statMatchedId.Value,
                             options.MaxSymbolsPerFile,
                             options.MaxReferencesPerFile,
-                            indexer.BuildGeneratedCodeExtractionSkippedIssue(dbPath)))
+                            indexer.IsGeneratedCodeExtractionSuppressed(dbPath)))
                     {
                         statMatchedId = null;
                     }

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -714,7 +714,7 @@ public static partial class IndexCommandRunner
                     WriteProjectRootOnce();
                     var fileId = writer.UpsertFile(record);
                     currentUpdatePath = FormatIndexPhasePath(relPath, "chunking");
-                    var chunks = ChunkSplitter.SplitNormalized(fileId, content, loaded.HasOversizeLine);
+                    var chunks = ChunkSplitter.SplitNormalized(fileId, content, loaded.HasOversizeLine, record.Lines);
                     if (generatedSuppressionIssue != null)
                     {
                         writer.InsertChunks(chunks, cancellationToken);

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -132,6 +132,8 @@ public static partial class IndexCommandRunner
             ? null
             : Path.GetFullPath(priorIndexedProjectRoot);
         var projectRootWritten = PathsEqual(normalizedPriorIndexedProjectRoot, normalizedProjectRoot);
+        var typeScriptAugmentationNeedsRefresh = !options.SymbolsOnly
+            && (!projectRootWritten || !writer.TypeScriptAugmentationVersionMatchesCurrent());
         var ftsMutated = false;
         var purgedRefs = 0;
         var supportedGraphLanguages = ReferenceExtractor.GetSupportedLanguages();
@@ -593,6 +595,7 @@ public static partial class IndexCommandRunner
                             deleteTxn.Commit();
                             removed++;
                             ftsMutated = true;
+                            typeScriptAugmentationNeedsRefresh = true;
                         }
                         else
                         {
@@ -690,6 +693,7 @@ public static partial class IndexCommandRunner
                             purgeTxn.Commit();
                             removed += purged;
                             ftsMutated = true;
+                            typeScriptAugmentationNeedsRefresh = true;
                         }
                         skipped++;
                         if (options.Verbose && !options.Json && !options.Quiet)
@@ -708,10 +712,14 @@ public static partial class IndexCommandRunner
                     fileBatchMarked = true;
                     if (record.Lang == "csharp")
                         csharpMetadataTargetsNeedRefresh = true;
+                    if (record.Lang == "typescript")
+                        typeScriptAugmentationNeedsRefresh = true;
                     using var txn = writer.BeginTransaction(cancellationToken, "update file");
-                    writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
+                    var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
                     if (projectRootWritten)
-                        writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, record.Path);
+                        stalePurged += writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, record.Path);
+                    if (stalePurged > 0)
+                        typeScriptAugmentationNeedsRefresh = true;
                     WriteProjectRootOnce();
                     var fileId = writer.UpsertFile(record);
                     currentUpdatePath = FormatIndexPhasePath(relPath, "chunking");
@@ -863,9 +871,11 @@ public static partial class IndexCommandRunner
                         writer.MarkBatchInProgress();
                         using var txn = writer.BeginTransaction(cancellationToken, "update skipped binary");
                         var skippedRecord = indexer.BuildSkippedFileRecord(absPath, relPath, knownLanguage);
-                        writer.PurgeStaleFilesSharingChecksum(projectRoot, skippedRecord.Path, skippedRecord.Checksum);
+                        var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, skippedRecord.Path, skippedRecord.Checksum);
                         if (projectRootWritten)
-                            writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, skippedRecord.Path);
+                            stalePurged += writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, skippedRecord.Path);
+                        if (stalePurged > 0)
+                            typeScriptAugmentationNeedsRefresh = true;
                         WriteProjectRootOnce();
                         var fileId = writer.UpsertFile(skippedRecord);
                         writer.InsertChunks([], cancellationToken);
@@ -889,9 +899,11 @@ public static partial class IndexCommandRunner
                         writer.MarkBatchInProgress();
                         using var txn = writer.BeginTransaction(cancellationToken, "update skipped oversized file");
                         var skippedRecord = indexer.BuildSkippedFileRecord(absPath, relPath, knownLanguage);
-                        writer.PurgeStaleFilesSharingChecksum(projectRoot, skippedRecord.Path, skippedRecord.Checksum);
+                        var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, skippedRecord.Path, skippedRecord.Checksum);
                         if (projectRootWritten)
-                            writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, skippedRecord.Path);
+                            stalePurged += writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, skippedRecord.Path);
+                        if (stalePurged > 0)
+                            typeScriptAugmentationNeedsRefresh = true;
                         WriteProjectRootOnce();
                         var fileId = writer.UpsertFile(skippedRecord);
                         writer.InsertChunks([], cancellationToken);
@@ -940,6 +952,7 @@ public static partial class IndexCommandRunner
                                 deleteTxn.Commit();
                                 removed++;
                                 ftsMutated = true;
+                                typeScriptAugmentationNeedsRefresh = true;
                             }
                         }
                         else
@@ -1074,7 +1087,11 @@ public static partial class IndexCommandRunner
             // family_key/container_qualified_name state as authoritative (#1488).
             using (var hotspotFamilyTxn = writer.BeginTransaction(cancellationToken, "update hotspot-family restamp"))
             {
-                writer.RebuildTypeScriptAugmentationReferences(projectRoot);
+                if (typeScriptAugmentationNeedsRefresh)
+                {
+                    UpdateTypeScriptAugmentationRebuildForTesting?.Invoke();
+                    writer.RebuildTypeScriptAugmentationReferences(projectRoot);
+                }
                 RestampHotspotFamilyTrustForUpdate(
                     writer,
                     priorHotspotFamilyVersions,

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -611,12 +611,12 @@ public static partial class IndexCommandRunner
                             && (statReusableLanguage != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
                             && (statReusableLanguage != "sql" || sqlGraphContractMatchesCurrent));
                     if (statMatchedId != null
-                        && ExistingFileViolatesExtractionCaps(writer, statMatchedId.Value, options.MaxSymbolsPerFile, options.MaxReferencesPerFile))
-                    {
-                        statMatchedId = null;
-                    }
-                    if (statMatchedId != null
-                        && ExistingFileGeneratedSuppressionMismatch(writer, statMatchedId.Value, indexer.BuildGeneratedCodeExtractionSkippedIssue(dbPath)))
+                        && ExistingFileBlocksReuse(
+                            writer,
+                            statMatchedId.Value,
+                            options.MaxSymbolsPerFile,
+                            options.MaxReferencesPerFile,
+                            indexer.BuildGeneratedCodeExtractionSkippedIssue(dbPath)))
                     {
                         statMatchedId = null;
                     }
@@ -666,12 +666,12 @@ public static partial class IndexCommandRunner
                             && (record.Lang != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
                             && (record.Lang != "sql" || sqlGraphContractMatchesCurrent));
                     if (existingId != null
-                        && ExistingFileViolatesExtractionCaps(writer, existingId.Value, options.MaxSymbolsPerFile, options.MaxReferencesPerFile))
-                    {
-                        existingId = null;
-                    }
-                    if (existingId != null
-                        && ExistingFileGeneratedSuppressionMismatch(writer, existingId.Value, generatedSuppressionIssue))
+                        && ExistingFileBlocksReuse(
+                            writer,
+                            existingId.Value,
+                            options.MaxSymbolsPerFile,
+                            options.MaxReferencesPerFile,
+                            generatedSuppressionIssue))
                     {
                         existingId = null;
                     }

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -145,6 +145,7 @@ public static partial class IndexCommandRunner
         var csharpSymbolNameContractMatchesCurrent = priorCSharpSymbolNameContractVersion == currentCSharpSymbolNameContractVersion;
         var currentMetadataTargetVersion = DbContext.MetadataTargetVersion.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var priorMetadataTargetCsharpMatchesCurrent = priorMetadataTargetCsharp == currentMetadataTargetVersion;
+        var csharpMetadataTargetsNeedRefresh = !priorMetadataTargetCsharpMatchesCurrent;
         var symbolsDroppedByKindFilter = 0;
 
         void DemoteReadinessOnce()
@@ -705,6 +706,8 @@ public static partial class IndexCommandRunner
                     DemoteReadinessOnce();
                     writer.MarkBatchInProgress();
                     fileBatchMarked = true;
+                    if (record.Lang == "csharp")
+                        csharpMetadataTargetsNeedRefresh = true;
                     using var txn = writer.BeginTransaction(cancellationToken, "update file");
                     writer.PurgeStaleFilesSharingChecksum(projectRoot, record.Path, record.Checksum);
                     if (projectRootWritten)
@@ -1053,7 +1056,11 @@ public static partial class IndexCommandRunner
             // authoritative になる。csharp ファイルがある場合のみ readiness も立てる。
             if (writer.HasAnyFilesWithLanguage("csharp"))
             {
-                writer.ResolveCSharpMetadataTargets();
+                if (csharpMetadataTargetsNeedRefresh)
+                {
+                    UpdateCSharpMetadataResolveForTesting?.Invoke();
+                    writer.ResolveCSharpMetadataTargets();
+                }
                 writer.MarkMetadataTargetReady("csharp");
                 csharpMetadataTargetReadyAfter = true;
             }

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -123,6 +123,7 @@ public static partial class IndexCommandRunner
         int updated = 0, removed = 0, skipped = 0, warnings = 0, errors = 0;
         var errorList = new List<CliJsonMessage>();
         var warningList = new List<CliJsonMessage>();
+        var knownReadableFileSizes = new Dictionary<string, long>(StringComparer.Ordinal);
         warnings += AddProjectMarkerFingerprintWarnings(currentHotspotFamilyMarkerFingerprints, warningList, options);
         var scanErrorKeys = new HashSet<string>(StringComparer.Ordinal);
         var visitedFileIdentities = new HashSet<FileIndexer.FileIdentity>();
@@ -613,7 +614,8 @@ public static partial class IndexCommandRunner
                         allowReuse: symbolKindFilterMatchesPrior
                             && (statReusableLanguage != "csharp" || csharpSymbolNameContractMatchesCurrent)
                             && (statReusableLanguage != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
-                            && (statReusableLanguage != "sql" || sqlGraphContractMatchesCurrent));
+                            && (statReusableLanguage != "sql" || sqlGraphContractMatchesCurrent),
+                        out var statSize);
                     if (statMatchedId != null
                         && ExistingFileBlocksReuse(
                             writer,
@@ -627,6 +629,8 @@ public static partial class IndexCommandRunner
                     if (statMatchedId != null)
                     {
                         skipped++;
+                        if (statSize.HasValue)
+                            knownReadableFileSizes[absPath] = statSize.Value;
                         if (options.Verbose && !options.Json && !options.Quiet)
                         {
                             PauseUpdateSpinnerForConsoleWrite();
@@ -645,6 +649,7 @@ public static partial class IndexCommandRunner
                         knownLanguage,
                         cancellationToken);
                     var record = loaded.Record;
+                    knownReadableFileSizes[absPath] = record.Size;
                     var content = loaded.Content;
                     var rawBytes = loaded.RawBytes;
                     var warning = loaded.Warning;
@@ -871,6 +876,7 @@ public static partial class IndexCommandRunner
                         writer.MarkBatchInProgress();
                         using var txn = writer.BeginTransaction(cancellationToken, "update skipped binary");
                         var skippedRecord = indexer.BuildSkippedFileRecord(absPath, relPath, knownLanguage);
+                        knownReadableFileSizes[absPath] = skippedRecord.Size;
                         var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, skippedRecord.Path, skippedRecord.Checksum);
                         if (projectRootWritten)
                             stalePurged += writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, skippedRecord.Path);
@@ -899,6 +905,7 @@ public static partial class IndexCommandRunner
                         writer.MarkBatchInProgress();
                         using var txn = writer.BeginTransaction(cancellationToken, "update skipped oversized file");
                         var skippedRecord = indexer.BuildSkippedFileRecord(absPath, relPath, knownLanguage);
+                        knownReadableFileSizes[absPath] = skippedRecord.Size;
                         var stalePurged = writer.PurgeStaleFilesSharingChecksum(projectRoot, skippedRecord.Path, skippedRecord.Checksum);
                         if (projectRootWritten)
                             stalePurged += writer.PurgeStaleFilesSharingDirectoryAndStem(projectRoot, skippedRecord.Path);
@@ -1132,9 +1139,10 @@ public static partial class IndexCommandRunner
                 memorySamples.Add(CaptureMemorySample("finalize", stopwatch));
             var memoryTimelineForStamp = BuildMemoryTimeline(memorySamples);
             var bytesRead = MeasureReadableFileBytes(
-                targetPaths.Select(path => Path.Combine(projectRoot, path.Replace('/', Path.DirectorySeparatorChar))),
+                targetPaths.Select(ToUpdateAbsolutePath),
                 projectRoot,
-                indexRunDiagnostics);
+                indexRunDiagnostics,
+                knownReadableFileSizes);
             StampLastIndexRunMetadata(
                 writer,
                 "update",

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -603,8 +603,8 @@ public static partial class IndexCommandRunner
                     var statReusableLanguage = GetStatReusableLanguage(absPath, detection);
                     var statMatchedId = TryGetUnchangedFileIdFromStat(
                         writer,
-                        projectRoot,
                         absPath,
+                        dbPath,
                         statReusableLanguage,
                         allowReuse: symbolKindFilterMatchesPrior
                             && (statReusableLanguage != "csharp" || csharpSymbolNameContractMatchesCurrent)

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -1002,15 +1002,17 @@ public static partial class IndexCommandRunner
         // degraded rather than authoritative. Interrupted runs also stay unstamped because
         // readiness was demoted before the first committed mutation.
         // errors==0 の成功 run のみマーカーを打つ。途中失敗は未 stamp のままで縮退扱い。
+        var hasCSharpFilesAfter = writer.HasAnyFilesWithLanguage("csharp");
+        var hasSqlFilesAfter = writer.HasAnyFilesWithLanguage("sql");
         var graphTableAvailableAfter = !readinessDemoted
             ? (priorReadiness & DbContext.GraphReadyFlag) != 0
             : false;
         var issuesTableAvailableAfter = !readinessDemoted
             ? (priorReadiness & DbContext.IssuesReadyFlag) != 0
             : false;
-        var csharpSymbolNameReadyAfter = !writer.HasAnyFilesWithLanguage("csharp")
+        var csharpSymbolNameReadyAfter = !hasCSharpFilesAfter
             || (!readinessDemoted && csharpSymbolNameContractMatchesCurrent);
-        var csharpMetadataTargetReadyAfter = !writer.HasAnyFilesWithLanguage("csharp")
+        var csharpMetadataTargetReadyAfter = !hasCSharpFilesAfter
             || (!readinessDemoted && priorMetadataTargetCsharpMatchesCurrent);
         var foldReadyAfter = !readinessDemoted
             && (priorReadiness & DbContext.FoldReadyFlag) != 0
@@ -1052,9 +1054,9 @@ public static partial class IndexCommandRunner
                 writer.MarkIssuesReady();
                 issuesTableAvailableAfter = true;
             }
-            if (sqlGraphContractMatchesCurrent || !writer.HasAnyFilesWithLanguage("sql"))
+            if (sqlGraphContractMatchesCurrent || !hasSqlFilesAfter)
                 writer.MarkSqlGraphContractReady();
-            if (csharpSymbolNameContractMatchesCurrent || !writer.HasAnyFilesWithLanguage("csharp"))
+            if (csharpSymbolNameContractMatchesCurrent || !hasCSharpFilesAfter)
             {
                 writer.MarkCSharpSymbolNameContractReady();
                 csharpSymbolNameReadyAfter = true;
@@ -1067,7 +1069,7 @@ public static partial class IndexCommandRunner
             // Issue #435: 成功 update の末尾で全 csharp class 行を resolver で再分類する。
             // resolver は全行を書き直すので pre-#435 DB の NULL 行と未更新行の両方が
             // authoritative になる。csharp ファイルがある場合のみ readiness も立てる。
-            if (writer.HasAnyFilesWithLanguage("csharp"))
+            if (hasCSharpFilesAfter)
             {
                 if (csharpMetadataTargetsNeedRefresh)
                 {

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -51,6 +51,7 @@ public static partial class IndexCommandRunner
     internal static Action? FullScanWritePhaseStartedForTesting { get; set; }
     internal static Action<bool, string?>? FullScanExtractionSchedulingForTesting { get; set; }
     internal static Action<string>? FullScanFileContentLoadForTesting { get; set; }
+    internal static Action? FullScanFtsOptimizeForTesting { get; set; }
     internal static Action<int, int>? UpdateFileCommittedForTesting { get; set; }
     internal static Func<TimeSpan>? IndexExtractionStallTimeoutForTesting { get; set; }
     internal static Action? HotspotFamilyUpdateRestampReadyForCommitForTesting { get; set; }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -52,6 +52,7 @@ public static partial class IndexCommandRunner
     internal static Action<bool, string?>? FullScanExtractionSchedulingForTesting { get; set; }
     internal static Action<string>? FullScanFileContentLoadForTesting { get; set; }
     internal static Action? FullScanFtsOptimizeForTesting { get; set; }
+    internal static Action? FullScanCSharpMetadataResolveForTesting { get; set; }
     internal static Action<int, int>? UpdateFileCommittedForTesting { get; set; }
     internal static Func<TimeSpan>? IndexExtractionStallTimeoutForTesting { get; set; }
     internal static Action? HotspotFamilyUpdateRestampReadyForCommitForTesting { get; set; }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -1240,8 +1240,6 @@ public static partial class IndexCommandRunner
         string RelativePath,
         FileRecord? Record,
         string? Content,
-        byte[]? RawBytes,
-        FileContentInspection? Inspection,
         bool? HasOversizeLine,
         string? Warning,
         IReadOnlyList<ChunkRecord>? Chunks,
@@ -1257,8 +1255,6 @@ public static partial class IndexCommandRunner
             string relativePath,
             FileRecord record,
             string? content,
-            byte[]? rawBytes,
-            FileContentInspection? inspection,
             bool hasOversizeLine,
             string? warning,
             IReadOnlyList<ChunkRecord>? chunks,
@@ -1273,8 +1269,6 @@ public static partial class IndexCommandRunner
                 relativePath,
                 record,
                 content,
-                rawBytes,
-                inspection,
                 hasOversizeLine,
                 warning,
                 chunks,
@@ -1304,8 +1298,6 @@ public static partial class IndexCommandRunner
                 record,
                 null,
                 null,
-                null,
-                null,
                 warning,
                 chunks,
                 symbols,
@@ -1317,10 +1309,10 @@ public static partial class IndexCommandRunner
         }
 
         public static FullScanFileWorkItem Failure(string filePath, string relativePath, Exception exception)
-            => new(filePath, relativePath, null, null, null, null, null, null, null, null, null, null, null, false, exception);
+            => new(filePath, relativePath, null, null, null, null, null, null, null, null, null, false, exception);
 
         public static FullScanFileWorkItem Skipped(string filePath, string relativePath, string warning)
-            => new(filePath, relativePath, null, null, null, null, null, warning, null, null, null, null, null, false, null);
+            => new(filePath, relativePath, null, null, null, warning, null, null, null, null, null, false, null);
     }
 
     private sealed record FoldOnlyRemediation(

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -48,6 +48,21 @@ public static partial class IndexCommandRunner
         IReadOnlySet<string> Directories,
         string? WarningMessage);
 
+    private sealed class LazyDisposable<T>(Func<T> factory) : IDisposable
+        where T : class, IDisposable
+    {
+        private T? value;
+
+        internal T Value => value ??= factory();
+        internal T? ValueIfCreated => value;
+
+        public void Dispose()
+        {
+            value?.Dispose();
+            value = null;
+        }
+    }
+
     internal static Action? FullScanWritePhaseStartedForTesting { get; set; }
     internal static Action<bool, string?>? FullScanExtractionSchedulingForTesting { get; set; }
     internal static Action? FullScanExtractionWorkStartedForTesting { get; set; }
@@ -59,6 +74,7 @@ public static partial class IndexCommandRunner
     internal static Action? UpdateCSharpPrepassForTesting { get; set; }
     internal static Action? UpdateCSharpMetadataResolveForTesting { get; set; }
     internal static Action? UpdateTypeScriptAugmentationRebuildForTesting { get; set; }
+    internal static Action? UpdateExtractionWorkStartedForTesting { get; set; }
     internal static Action<int, int>? UpdateFileCommittedForTesting { get; set; }
     internal static Func<TimeSpan>? IndexExtractionStallTimeoutForTesting { get; set; }
     internal static Action? HotspotFamilyUpdateRestampReadyForCommitForTesting { get; set; }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -55,6 +55,7 @@ public static partial class IndexCommandRunner
     internal static Action? FullScanCSharpMetadataResolveForTesting { get; set; }
     internal static Action? FullScanTypeScriptAugmentationRebuildForTesting { get; set; }
     internal static Action? UpdateCSharpMetadataResolveForTesting { get; set; }
+    internal static Action? UpdateTypeScriptAugmentationRebuildForTesting { get; set; }
     internal static Action<int, int>? UpdateFileCommittedForTesting { get; set; }
     internal static Func<TimeSpan>? IndexExtractionStallTimeoutForTesting { get; set; }
     internal static Action? HotspotFamilyUpdateRestampReadyForCommitForTesting { get; set; }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -1137,8 +1137,8 @@ public static partial class IndexCommandRunner
 
     private static long? TryGetUnchangedFileIdFromStat(
         DbWriter writer,
-        string projectRoot,
         string absolutePath,
+        string relativePath,
         string? language,
         bool allowReuse)
     {
@@ -1151,7 +1151,6 @@ public static partial class IndexCommandRunner
             if (!info.Exists)
                 return null;
 
-            var relativePath = FileIndexer.NormalizePathSeparators(Path.GetRelativePath(projectRoot, absolutePath));
             return writer.GetUnchangedFileId(
                 relativePath,
                 info.LastWriteTimeUtc,

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -851,6 +851,10 @@ public static partial class IndexCommandRunner
     private static bool ContainsJavaScriptTypeScriptConfigPath(IEnumerable<string> paths)
         => paths.Any(IsJavaScriptTypeScriptConfigPath);
 
+    private static bool IsJavaScriptTypeScriptLanguage(string? language)
+        => string.Equals(language, "javascript", StringComparison.Ordinal)
+            || string.Equals(language, "typescript", StringComparison.Ordinal);
+
     private static bool IsJavaScriptTypeScriptConfigPath(string path)
     {
         var fileName = Path.GetFileName(path);

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -67,6 +67,7 @@ public static partial class IndexCommandRunner
     internal static Action<bool, string?>? FullScanExtractionSchedulingForTesting { get; set; }
     internal static Action? FullScanExtractionWorkStartedForTesting { get; set; }
     internal static Action<string>? FullScanFileContentLoadForTesting { get; set; }
+    internal static Action<int>? FullScanExtractionQueueCapacityForTesting { get; set; }
     internal static Action? FullScanFtsOptimizeForTesting { get; set; }
     internal static Action? FullScanCSharpPrepassForTesting { get; set; }
     internal static Action? FullScanCSharpMetadataResolveForTesting { get; set; }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -48,7 +48,7 @@ public static partial class IndexCommandRunner
         IReadOnlySet<string> Directories,
         string? WarningMessage);
 
-    private sealed class LazyDisposable<T>(Func<T> factory) : IDisposable
+    internal sealed class LazyDisposable<T>(Func<T> factory) : IDisposable
         where T : class, IDisposable
     {
         private T? value;

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -53,6 +53,7 @@ public static partial class IndexCommandRunner
     internal static Action<string>? FullScanFileContentLoadForTesting { get; set; }
     internal static Action? FullScanFtsOptimizeForTesting { get; set; }
     internal static Action? FullScanCSharpMetadataResolveForTesting { get; set; }
+    internal static Action? FullScanTypeScriptAugmentationRebuildForTesting { get; set; }
     internal static Action? UpdateCSharpMetadataResolveForTesting { get; set; }
     internal static Action<int, int>? UpdateFileCommittedForTesting { get; set; }
     internal static Func<TimeSpan>? IndexExtractionStallTimeoutForTesting { get; set; }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -652,12 +652,22 @@ public static partial class IndexCommandRunner
         }
     }
 
-    internal static FileByteReadSummary MeasureReadableFileBytes(IEnumerable<string> paths, string? projectRoot = null, List<string>? diagnostics = null)
+    internal static FileByteReadSummary MeasureReadableFileBytes(
+        IEnumerable<string> paths,
+        string? projectRoot = null,
+        List<string>? diagnostics = null,
+        IReadOnlyDictionary<string, long>? knownFileSizes = null)
     {
         long total = 0;
         long skipped = 0;
         foreach (var path in paths)
         {
+            if (knownFileSizes != null && knownFileSizes.TryGetValue(path, out var knownSize))
+            {
+                total += knownSize;
+                continue;
+            }
+
             try
             {
                 var info = new FileInfo(path);
@@ -1143,8 +1153,10 @@ public static partial class IndexCommandRunner
         string absolutePath,
         string relativePath,
         string? language,
-        bool allowReuse)
+        bool allowReuse,
+        out long? size)
     {
+        size = null;
         if (!allowReuse || language == null)
             return null;
 
@@ -1154,6 +1166,7 @@ public static partial class IndexCommandRunner
             if (!info.Exists)
                 return null;
 
+            size = info.Length;
             return writer.GetUnchangedFileId(
                 relativePath,
                 info.LastWriteTimeUtc,

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -53,6 +53,7 @@ public static partial class IndexCommandRunner
     internal static Action<string>? FullScanFileContentLoadForTesting { get; set; }
     internal static Action? FullScanFtsOptimizeForTesting { get; set; }
     internal static Action? FullScanCSharpMetadataResolveForTesting { get; set; }
+    internal static Action? UpdateCSharpMetadataResolveForTesting { get; set; }
     internal static Action<int, int>? UpdateFileCommittedForTesting { get; set; }
     internal static Func<TimeSpan>? IndexExtractionStallTimeoutForTesting { get; set; }
     internal static Action? HotspotFamilyUpdateRestampReadyForCommitForTesting { get; set; }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -54,6 +54,7 @@ public static partial class IndexCommandRunner
     internal static Action? FullScanFtsOptimizeForTesting { get; set; }
     internal static Action? FullScanCSharpMetadataResolveForTesting { get; set; }
     internal static Action? FullScanTypeScriptAugmentationRebuildForTesting { get; set; }
+    internal static Action? UpdateCSharpPrepassForTesting { get; set; }
     internal static Action? UpdateCSharpMetadataResolveForTesting { get; set; }
     internal static Action? UpdateTypeScriptAugmentationRebuildForTesting { get; set; }
     internal static Action<int, int>? UpdateFileCommittedForTesting { get; set; }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -52,6 +52,7 @@ public static partial class IndexCommandRunner
     internal static Action<bool, string?>? FullScanExtractionSchedulingForTesting { get; set; }
     internal static Action<string>? FullScanFileContentLoadForTesting { get; set; }
     internal static Action? FullScanFtsOptimizeForTesting { get; set; }
+    internal static Action? FullScanCSharpPrepassForTesting { get; set; }
     internal static Action? FullScanCSharpMetadataResolveForTesting { get; set; }
     internal static Action? FullScanTypeScriptAugmentationRebuildForTesting { get; set; }
     internal static Action? UpdateCSharpPrepassForTesting { get; set; }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -50,6 +50,7 @@ public static partial class IndexCommandRunner
 
     internal static Action? FullScanWritePhaseStartedForTesting { get; set; }
     internal static Action<bool, string?>? FullScanExtractionSchedulingForTesting { get; set; }
+    internal static Action? FullScanExtractionWorkStartedForTesting { get; set; }
     internal static Action<string>? FullScanFileContentLoadForTesting { get; set; }
     internal static Action? FullScanFtsOptimizeForTesting { get; set; }
     internal static Action? FullScanCSharpPrepassForTesting { get; set; }

--- a/src/CodeIndex/Cli/IndexCommandRunner.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.cs
@@ -50,6 +50,7 @@ public static partial class IndexCommandRunner
 
     internal static Action? FullScanWritePhaseStartedForTesting { get; set; }
     internal static Action<bool, string?>? FullScanExtractionSchedulingForTesting { get; set; }
+    internal static Action<string>? FullScanFileContentLoadForTesting { get; set; }
     internal static Action<int, int>? UpdateFileCommittedForTesting { get; set; }
     internal static Func<TimeSpan>? IndexExtractionStallTimeoutForTesting { get; set; }
     internal static Action? HotspotFamilyUpdateRestampReadyForCommitForTesting { get; set; }

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -1648,6 +1648,8 @@ public class DbContext : IDisposable
     // source-aware storage で再 index されるまで縮退させる。
     public const int MetadataTargetVersion = 7;
     public static string GetMetadataTargetVersionMetaKey(string lang) => $"metadata_target_version_{lang}";
+    public const int TypeScriptAugmentationVersion = 1;
+    public const string TypeScriptAugmentationVersionMetaKey = "typescript_augmentation_version";
     // Audit trail: cdidx version string (e.g. "1.22.0") that produced the most recent
     // successful end-of-index pass on this DB. Readers use it to surface "DB written by
     // a newer cdidx" warnings when any persisted contract version exceeds this binary's

--- a/src/CodeIndex/Database/DbReader.cs
+++ b/src/CodeIndex/Database/DbReader.cs
@@ -664,6 +664,7 @@ public partial class DbReader : IDisposable
         // the contract a newer cdidx wrote.
         // 数値で stamp される contract version は「stored > current」のときだけ未来 DB と判断する。
         AppendIfStoredGreater(conn, DbContext.GetMetadataTargetVersionMetaKey("csharp"), DbContext.MetadataTargetVersion, "metadata_target_version_csharp", newerContracts);
+        AppendIfStoredGreater(conn, DbContext.TypeScriptAugmentationVersionMetaKey, DbContext.TypeScriptAugmentationVersion, "typescript_augmentation_version", newerContracts);
         AppendIfStoredGreater(conn, DbContext.CSharpSymbolNameContractVersionMetaKey, DbContext.CSharpSymbolNameContractVersion, "csharp_symbol_name_contract_version", newerContracts);
         AppendIfStoredGreater(conn, DbContext.SqlGraphContractVersionMetaKey, DbContext.SqlGraphContractVersion, "sql_graph_contract_version", newerContracts);
         AppendIfStoredGreater(conn, "fold_key_version", NameFold.Version, "fold_key_version", newerContracts);

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -1955,7 +1955,7 @@ public class DbWriter
     /// </summary>
     /// <param name="projectRoot">Absolute path to project root / プロジェクトルートの絶対パス</param>
     /// <returns>Number of stale files removed / 削除された古いファイル数</returns>
-    public int PurgeStaleFiles(string projectRoot)
+    public int PurgeStaleFiles(string projectRoot, Action? beforeCommit = null)
     {
         // Collect all paths currently in DB / DB内の全パスを収集
         var dbPaths = new List<(long id, string path)>();
@@ -1997,6 +1997,7 @@ public class DbWriter
             pId.Value = id;
             deleteCmd.ExecuteNonQuery();
         }
+        beforeCommit?.Invoke();
         txn.Commit();
 
         return staleIds.Count;
@@ -2454,6 +2455,11 @@ public class DbWriter
             GetMetaString(DbContext.TypeScriptAugmentationVersionMetaKey),
             DbContext.TypeScriptAugmentationVersion.ToString(System.Globalization.CultureInfo.InvariantCulture),
             StringComparison.Ordinal);
+    }
+
+    public void ClearTypeScriptAugmentationReady()
+    {
+        SetMeta(DbContext.TypeScriptAugmentationVersionMetaKey, null);
     }
 
     /// <summary>

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -785,6 +785,32 @@ public class DbWriter
         return SqliteCommandPolicy.ReadInt32Scalar(cmd, "symbol reference count for file");
     }
 
+    public bool HasExtractionCapViolationForFile(long fileId, int maxSymbolsPerFile, int maxReferencesPerFile)
+    {
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = @"
+            SELECT CASE WHEN
+                (SELECT COUNT(*) FROM symbols WHERE file_id = @file_id) > @max_symbols
+                OR EXISTS (
+                    SELECT 1
+                    FROM file_issues
+                    WHERE file_id = @file_id
+                      AND kind = 'symbol_count_exceeded'
+                )
+                OR (SELECT COUNT(*) FROM symbol_references WHERE file_id = @file_id) > @max_references
+                OR EXISTS (
+                    SELECT 1
+                    FROM file_issues
+                    WHERE file_id = @file_id
+                      AND kind = 'reference_count_exceeded'
+                )
+            THEN 1 ELSE 0 END";
+        SqliteCommandPolicy.AddInt64(cmd, "@file_id", fileId);
+        SqliteCommandPolicy.AddInt32(cmd, "@max_symbols", maxSymbolsPerFile);
+        SqliteCommandPolicy.AddInt32(cmd, "@max_references", maxReferencesPerFile);
+        return SqliteCommandPolicy.ReadInt32Scalar(cmd, "file extraction cap violation") != 0;
+    }
+
     public bool HasIssueForFile(long fileId, string kind)
     {
         using var cmd = _conn.CreateCommand();

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -1058,6 +1058,25 @@ public class DbWriter
         }
     }
 
+    public IReadOnlyList<string> GetIndexedJavaScriptTypeScriptConfigPaths()
+    {
+        using var cmd = _conn.CreateCommand();
+        cmd.CommandText = """
+            SELECT path
+            FROM files
+            WHERE path = 'jsconfig.json'
+               OR path = 'tsconfig.json'
+               OR path LIKE '%/jsconfig.json'
+               OR path LIKE '%/tsconfig.json'
+            ORDER BY path
+            """;
+        var paths = new List<string>();
+        using var reader = cmd.ExecuteTrackedReader();
+        while (reader.TrackedRead())
+            paths.Add(reader.GetString(0));
+        return paths;
+    }
+
     /// <summary>
     /// Upsert a file record and return its ID.
     /// Uses ON CONFLICT DO UPDATE to preserve the existing file ID (avoids

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -1064,10 +1064,14 @@ public class DbWriter
         cmd.CommandText = """
             SELECT path
             FROM files
-            WHERE path = 'jsconfig.json'
-               OR path = 'tsconfig.json'
-               OR path LIKE '%/jsconfig.json'
-               OR path LIKE '%/tsconfig.json'
+            WHERE lower(path) = 'jsconfig.json'
+               OR lower(path) = 'tsconfig.json'
+               OR lower(path) LIKE '%/jsconfig.json'
+               OR lower(path) LIKE '%/tsconfig.json'
+               OR lower(path) LIKE 'jsconfig.%.json'
+               OR lower(path) LIKE 'tsconfig.%.json'
+               OR lower(path) LIKE '%/jsconfig.%.json'
+               OR lower(path) LIKE '%/tsconfig.%.json'
             ORDER BY path
             """;
         var paths = new List<string>();

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -1777,6 +1777,9 @@ public class DbWriter
         }
 
         InsertReferences(references);
+        SetMeta(
+            DbContext.TypeScriptAugmentationVersionMetaKey,
+            DbContext.TypeScriptAugmentationVersion.ToString(System.Globalization.CultureInfo.InvariantCulture));
         transaction.Commit();
         return references.Count;
     }
@@ -2443,6 +2446,14 @@ public class DbWriter
         SetMeta(
             DbContext.GetMetadataTargetVersionMetaKey(lang),
             DbContext.MetadataTargetVersion.ToString(System.Globalization.CultureInfo.InvariantCulture));
+    }
+
+    public bool TypeScriptAugmentationVersionMatchesCurrent()
+    {
+        return string.Equals(
+            GetMetaString(DbContext.TypeScriptAugmentationVersionMetaKey),
+            DbContext.TypeScriptAugmentationVersion.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -786,6 +786,13 @@ public class DbWriter
     }
 
     public bool HasExtractionCapViolationForFile(long fileId, int maxSymbolsPerFile, int maxReferencesPerFile)
+        => HasReusableFileBlockingIssueForFile(fileId, maxSymbolsPerFile, maxReferencesPerFile, generatedExtractionSuppressed: null);
+
+    public bool HasReusableFileBlockingIssueForFile(
+        long fileId,
+        int maxSymbolsPerFile,
+        int maxReferencesPerFile,
+        bool? generatedExtractionSuppressed)
     {
         using var cmd = _conn.CreateCommand();
         cmd.CommandText = @"
@@ -804,11 +811,24 @@ public class DbWriter
                     WHERE file_id = @file_id
                       AND kind = 'reference_count_exceeded'
                 )
+                OR (
+                    @generated_suppressed IS NOT NULL
+                    AND (
+                        EXISTS (
+                            SELECT 1
+                            FROM file_issues
+                            WHERE file_id = @file_id
+                              AND kind = @generated_issue_kind
+                        )
+                    ) <> @generated_suppressed
+                )
             THEN 1 ELSE 0 END";
         SqliteCommandPolicy.AddInt64(cmd, "@file_id", fileId);
         SqliteCommandPolicy.AddInt32(cmd, "@max_symbols", maxSymbolsPerFile);
         SqliteCommandPolicy.AddInt32(cmd, "@max_references", maxReferencesPerFile);
-        return SqliteCommandPolicy.ReadInt32Scalar(cmd, "file extraction cap violation") != 0;
+        SqliteCommandPolicy.AddNullableBoolean(cmd, "@generated_suppressed", generatedExtractionSuppressed);
+        SqliteCommandPolicy.AddText(cmd, "@generated_issue_kind", FileIndexer.GeneratedCodeExtractionSkippedIssueKind);
+        return SqliteCommandPolicy.ReadInt32Scalar(cmd, "reusable file blocking issue") != 0;
     }
 
     public bool HasIssueForFile(long fileId, string kind)

--- a/src/CodeIndex/Indexer/CSharpStaticInterfacePrepass.cs
+++ b/src/CodeIndex/Indexer/CSharpStaticInterfacePrepass.cs
@@ -15,6 +15,7 @@ internal static class CSharpStaticInterfacePrepass
         FileIndexer indexer,
         IEnumerable<FileTarget> fileTargets,
         bool includeExistingSymbols = true,
+        Func<FileTarget, bool>? canReuseExistingSymbolsWithoutRead = null,
         Action<string?>? reportCurrentFile = null,
         CancellationToken cancellationToken = default)
     {
@@ -43,6 +44,9 @@ internal static class CSharpStaticInterfacePrepass
 
             try
             {
+                if (includeExistingSymbols && canReuseExistingSymbolsWithoutRead?.Invoke(target) == true)
+                    continue;
+
                 reportCurrentFile?.Invoke(relativePath);
                 if (indexer.IsGeneratedCodeExtractionSuppressed(target.IndexPath))
                     continue;
@@ -99,8 +103,9 @@ internal static class CSharpStaticInterfacePrepass
             indexer,
             fileTargets,
             includeExistingSymbols,
-            reportCurrentFile,
-            cancellationToken);
+            canReuseExistingSymbolsWithoutRead: null,
+            reportCurrentFile: reportCurrentFile,
+            cancellationToken: cancellationToken);
     }
 
     internal static bool MayContainCSharpStaticInterfaceContract(string content)

--- a/src/CodeIndex/Indexer/Scanning/ChunkSplitter.cs
+++ b/src/CodeIndex/Indexer/Scanning/ChunkSplitter.cs
@@ -81,7 +81,7 @@ public static class ChunkSplitter
         return SplitNormalized(fileId, content, HasOversizeLine(content));
     }
 
-    internal static List<ChunkRecord> SplitNormalized(long fileId, string content, bool hasOversizeLine)
+    internal static List<ChunkRecord> SplitNormalized(long fileId, string content, bool hasOversizeLine, int? lineCount = null)
     {
         if (string.IsNullOrEmpty(content))
             return [];
@@ -100,10 +100,10 @@ public static class ChunkSplitter
         if (hasOversizeLine)
             return [];
 
-        return SplitNormalizedCore(fileId, content);
+        return SplitNormalizedCore(fileId, content, lineCount);
     }
 
-    private static List<ChunkRecord> SplitNormalizedCore(long fileId, string content)
+    private static List<ChunkRecord> SplitNormalizedCore(long fileId, string content, int? lineCount)
     {
         // Track line start offsets instead of materializing every line string. Large
         // source files can still be valid and under the file-size cap, and chunking
@@ -114,7 +114,7 @@ public static class ChunkSplitter
         // でも file-size 上限内なら有効なため、chunking では永続化する chunk 本文以外に
         // ファイル全体分の string[] や chunk ごとの slice 配列を作らない。末尾改行を
         // 余分な空行として扱わない点は従来の Split('\n') 経路と同じ。
-        var lineStarts = GetLineStartOffsets(content);
+        var lineStarts = GetLineStartOffsets(content, lineCount);
         int step = ChunkSize - Overlap;
         var estimatedChunkCount = Math.Max(1, (lineStarts.Count + step - 1) / step);
         var chunks = new List<ChunkRecord>(estimatedChunkCount);
@@ -149,9 +149,12 @@ public static class ChunkSplitter
         return chunks;
     }
 
-    private static List<int> GetLineStartOffsets(string content)
+    private static List<int> GetLineStartOffsets(string content, int? lineCount)
     {
-        var lineStarts = new List<int> { 0 };
+        var lineStarts = lineCount is > 0
+            ? new List<int>(lineCount.Value)
+            : [];
+        lineStarts.Add(0);
         for (var i = 0; i < content.Length; i++)
         {
             if (content[i] == '\n' && i + 1 < content.Length)

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -6054,7 +6054,7 @@ public partial class McpServer
                 MarkSymbolKindFilterMetaIncompleteOnce();
                 using var txn = writer.BeginTransaction(requestToken, "mcp index file");
                 var fileId = writer.UpsertFile(record);
-                var chunks = ChunkSplitter.SplitNormalized(fileId, content, loaded.HasOversizeLine);
+                var chunks = ChunkSplitter.SplitNormalized(fileId, content, loaded.HasOversizeLine, record.Lines);
                 if (generatedSuppressionIssue != null)
                 {
                     writer.InsertChunks(chunks, requestToken);

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -48,6 +48,7 @@ public partial class McpServer
     };
     internal const int MaxMcpIndexFailureMessageLength = 512;
     internal static Action<string>? McpIndexFileCommittedForTesting { get; set; }
+    internal static Action? McpIndexTypeScriptAugmentationRebuildForTesting { get; set; }
     internal static Func<string, CancellationToken, UpdateCheckResult>? StatusUpdateCheckForTesting { get; set; }
     private QueryCommandRunner.ProjectFilterRootResolution? _projectFilterRootResolutionForCurrentToolCall;
 
@@ -5866,6 +5867,8 @@ public partial class McpServer
             ? null
             : Path.GetFullPath(priorIndexedProjectRoot);
         var projectRootWritten = PathsEqual(normalizedPriorIndexedProjectRoot, normalizedProjectPath);
+        var typeScriptAugmentationNeedsRefresh = !projectRootWritten
+            || !writer.TypeScriptAugmentationVersionMatchesCurrent();
 
         static bool PathsEqual(string? left, string? right)
         {
@@ -5960,7 +5963,10 @@ public partial class McpServer
         // Purge stale files / 古いファイルをパージ
         var purged = writer.PurgeStaleFiles(projectPath);
         if (purged > 0)
+        {
+            typeScriptAugmentationNeedsRefresh = true;
             WriteProjectRootOnce();
+        }
 
         // Purge references for languages no longer graph-supported / グラフ非対応になった言語の参照をパージ
         writer.PurgeUnsupportedReferences(ReferenceExtractor.GetSupportedLanguages());
@@ -6045,6 +6051,8 @@ public partial class McpServer
                 writer.MarkBatchInProgress();
                 fileBatchMarked = true;
                 MarkSymbolKindFilterMetaIncompleteOnce();
+                if (record.Lang == "typescript")
+                    typeScriptAugmentationNeedsRefresh = true;
                 using var txn = writer.BeginTransaction(requestToken, "mcp index file");
                 var fileId = writer.UpsertFile(record);
                 var chunks = ChunkSplitter.SplitNormalized(fileId, content, loaded.HasOversizeLine, record.Lines);
@@ -6142,6 +6150,8 @@ public partial class McpServer
                 try
                 {
                     var skippedRecord = indexer.BuildSkippedFileRecord(filePath, target.RelativePath, target.Language);
+                    if (skippedRecord.Lang == "typescript")
+                        typeScriptAugmentationNeedsRefresh = true;
                     using var txn = writer.BeginTransaction(requestToken, "mcp index skipped binary");
                     var fileId = writer.UpsertFile(skippedRecord);
                     writer.InsertChunks([], requestToken);
@@ -6169,6 +6179,7 @@ public partial class McpServer
                     {
                         using var txn = writer.BeginTransaction(requestToken, "mcp index delete missing file");
                         writer.DeleteFileByPath(relativePath);
+                        typeScriptAugmentationNeedsRefresh = true;
                         WriteProjectRootOnce();
                         txn.Commit();
                     }
@@ -6229,7 +6240,11 @@ public partial class McpServer
                 csharpMetadataTargetReadyAfter = true;
             }
             sqlGraphContractReadyAfter = true;
-            writer.RebuildTypeScriptAugmentationReferences(projectPath);
+            if (typeScriptAugmentationNeedsRefresh)
+            {
+                McpIndexTypeScriptAugmentationRebuildForTesting?.Invoke();
+                writer.RebuildTypeScriptAugmentationReferences(projectPath);
+            }
             RestampHotspotFamilyTrust(
                 writer,
                 reusedHotspotFamilyLanguages,

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -6024,18 +6024,12 @@ public partial class McpServer
                         && (record.Lang != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
                         && (record.Lang != "sql" || sqlGraphContractMatchesCurrent)
                         && AllowReuseWithCurrentHotspotFamilyTrust(record.Lang, hotspotFamilyTrustMatchesCurrent));
-                if (existingId != null)
-                {
-                    if (writer.CountSymbolsForFile(existingId.Value) > maxSymbolsPerFile
-                        || writer.HasIssueForFile(existingId.Value, "symbol_count_exceeded")
-                        || writer.CountReferencesForFile(existingId.Value) > maxReferencesPerFile
-                        || writer.HasIssueForFile(existingId.Value, "reference_count_exceeded"))
-                    {
-                        existingId = null;
-                    }
-                }
                 if (existingId != null
-                    && IndexCommandRunner.ExistingFileGeneratedSuppressionMismatch(writer, existingId.Value, generatedSuppressionIssue))
+                    && writer.HasReusableFileBlockingIssueForFile(
+                        existingId.Value,
+                        maxSymbolsPerFile,
+                        maxReferencesPerFile,
+                        generatedSuppressionIssue != null))
                 {
                     existingId = null;
                 }

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -50,6 +50,7 @@ public partial class McpServer
     internal static Action<string>? McpIndexFileCommittedForTesting { get; set; }
     internal static Action<string>? McpIndexFileContentLoadForTesting { get; set; }
     internal static Action? McpIndexFtsOptimizeForTesting { get; set; }
+    internal static Action? McpIndexCSharpPrepassForTesting { get; set; }
     internal static Action? McpIndexCSharpMetadataResolveForTesting { get; set; }
     internal static Action? McpIndexTypeScriptAugmentationRebuildForTesting { get; set; }
     internal static Func<string, CancellationToken, UpdateCheckResult>? StatusUpdateCheckForTesting { get; set; }
@@ -6060,12 +6061,21 @@ public partial class McpServer
                 indexer.IsGeneratedCodeExtractionSuppressed(target.IndexPath));
         }
 
-        var csharpWorkspace = CSharpStaticInterfacePrepass.BuildWorkspaceSymbols(
-            writer,
-            indexer,
-            csharpPrepassTargets,
-            canReuseExistingSymbolsWithoutRead: CanReuseCSharpPrepassTargetWithoutRead,
-            cancellationToken: requestToken);
+        CSharpStaticInterfaceWorkspaceSymbols csharpWorkspace;
+        if (csharpPrepassTargets.Length == 0)
+        {
+            csharpWorkspace = new CSharpStaticInterfaceWorkspaceSymbols([], false);
+        }
+        else
+        {
+            McpIndexCSharpPrepassForTesting?.Invoke();
+            csharpWorkspace = CSharpStaticInterfacePrepass.BuildWorkspaceSymbols(
+                writer,
+                indexer,
+                csharpPrepassTargets,
+                canReuseExistingSymbolsWithoutRead: CanReuseCSharpPrepassTargetWithoutRead,
+                cancellationToken: requestToken);
+        }
         if (purged > 0 && hadCSharpStaticInterfaceContractsBeforePurge)
             csharpWorkspace = csharpWorkspace with { HasStaticInterfaceContracts = true };
         var fatalScanErrors = scanResult.Errors

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -6057,7 +6057,7 @@ public partial class McpServer
                 existingId.Value,
                 maxSymbolsPerFile,
                 maxReferencesPerFile,
-                indexer.BuildGeneratedCodeExtractionSkippedIssue(target.IndexPath) != null);
+                indexer.IsGeneratedCodeExtractionSuppressed(target.IndexPath));
         }
 
         var csharpWorkspace = CSharpStaticInterfacePrepass.BuildWorkspaceSymbols(
@@ -6102,7 +6102,7 @@ public partial class McpServer
                         statMatchedId.Value,
                         maxSymbolsPerFile,
                         maxReferencesPerFile,
-                        indexer.BuildGeneratedCodeExtractionSkippedIssue(target.IndexPath) != null))
+                        indexer.IsGeneratedCodeExtractionSuppressed(target.IndexPath)))
                 {
                     statMatchedId = null;
                 }

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -6322,9 +6322,11 @@ public partial class McpServer
         // path is no longer accurate. Bits are only stamped when every file committed without
         // throwing, so a partial failure leaves trust degraded and `validate` still surfaces it.
         // MCP index は CLI と同等に file_issues を永続化するため、成功時は graph / issues の両方を stamp する。
-        var csharpSymbolNameReadyAfter = !writer.HasAnyFilesWithLanguage("csharp");
-        var csharpMetadataTargetReadyAfter = !writer.HasAnyFilesWithLanguage("csharp");
-        var sqlGraphContractReadyAfter = !writer.HasAnyFilesWithLanguage("sql");
+        var hasCSharpFilesAfter = writer.HasAnyFilesWithLanguage("csharp");
+        var hasSqlFilesAfter = writer.HasAnyFilesWithLanguage("sql");
+        var csharpSymbolNameReadyAfter = !hasCSharpFilesAfter;
+        var csharpMetadataTargetReadyAfter = !hasCSharpFilesAfter;
+        var sqlGraphContractReadyAfter = !hasSqlFilesAfter;
         var foldReadyAfter = false;
         string? foldReadyReason = null;
         if (!scanResult.HadErrors && errors == 0)
@@ -6337,7 +6339,7 @@ public partial class McpServer
             writer.MarkSqlGraphContractReady();
             writer.MarkCSharpSymbolNameContractReady();
             csharpSymbolNameReadyAfter = true;
-            if (writer.HasAnyFilesWithLanguage("csharp"))
+            if (hasCSharpFilesAfter)
             {
                 if (csharpMetadataTargetsNeedRefresh)
                 {

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -48,6 +48,7 @@ public partial class McpServer
     };
     internal const int MaxMcpIndexFailureMessageLength = 512;
     internal static Action<string>? McpIndexFileCommittedForTesting { get; set; }
+    internal static Action<string>? McpIndexFileContentLoadForTesting { get; set; }
     internal static Action? McpIndexCSharpMetadataResolveForTesting { get; set; }
     internal static Action? McpIndexTypeScriptAugmentationRebuildForTesting { get; set; }
     internal static Func<string, CancellationToken, UpdateCheckResult>? StatusUpdateCheckForTesting { get; set; }
@@ -3096,6 +3097,39 @@ public partial class McpServer
             && matchesCurrent;
     }
 
+    private static long? TryGetUnchangedFileIdFromStat(
+        DbWriter writer,
+        string absolutePath,
+        string relativePath,
+        string? language,
+        bool allowReuse)
+    {
+        if (!allowReuse || language == null)
+            return null;
+
+        try
+        {
+            var info = new FileInfo(absolutePath);
+            if (!info.Exists)
+                return null;
+
+            return writer.GetUnchangedFileId(
+                relativePath,
+                info.LastWriteTimeUtc,
+                checksum: null,
+                size: info.Length,
+                language: language);
+        }
+        catch (IOException)
+        {
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
     private static void AddHotspotFamilySignal(JsonObject payload, HotspotFamilySignal signal)
     {
         payload["hotspot_family_ready"] = signal.Ready;
@@ -5988,10 +6022,34 @@ public partial class McpServer
         var csharpPrepassTargets = fileTargets
             .Where(static target => target.Language == "csharp")
             .ToArray();
+        bool CanReuseCSharpPrepassTargetWithoutRead(CSharpStaticInterfacePrepass.FileTarget target)
+        {
+            if (!symbolKindFilterMatchesPrior || !csharpSymbolNameContractMatchesCurrent)
+                return false;
+            if (target.Language != "csharp")
+                return false;
+
+            var existingId = TryGetUnchangedFileIdFromStat(
+                writer,
+                target.FilePath,
+                target.IndexPath,
+                target.Language,
+                allowReuse: true);
+            if (existingId == null)
+                return false;
+
+            return !writer.HasReusableFileBlockingIssueForFile(
+                existingId.Value,
+                maxSymbolsPerFile,
+                maxReferencesPerFile,
+                indexer.BuildGeneratedCodeExtractionSkippedIssue(target.IndexPath) != null);
+        }
+
         var csharpWorkspace = CSharpStaticInterfacePrepass.BuildWorkspaceSymbols(
             writer,
             indexer,
             csharpPrepassTargets,
+            canReuseExistingSymbolsWithoutRead: CanReuseCSharpPrepassTargetWithoutRead,
             cancellationToken: requestToken);
         if (purged > 0 && hadCSharpStaticInterfaceContractsBeforePurge)
             csharpWorkspace = csharpWorkspace with { HasStaticInterfaceContracts = true };
@@ -6012,6 +6070,37 @@ public partial class McpServer
             try
             {
                 requestToken.ThrowIfCancellationRequested();
+                var allowStatReuse = symbolKindFilterMatchesPrior
+                    && (target.Language != "csharp" || csharpSymbolNameContractMatchesCurrent)
+                    && (target.Language != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
+                    && (target.Language != "sql" || sqlGraphContractMatchesCurrent)
+                    && AllowReuseWithCurrentHotspotFamilyTrust(target.Language, hotspotFamilyTrustMatchesCurrent);
+                var statMatchedId = TryGetUnchangedFileIdFromStat(
+                    writer,
+                    filePath,
+                    target.IndexPath,
+                    target.Language,
+                    allowStatReuse);
+                if (statMatchedId != null
+                    && writer.HasReusableFileBlockingIssueForFile(
+                        statMatchedId.Value,
+                        maxSymbolsPerFile,
+                        maxReferencesPerFile,
+                        indexer.BuildGeneratedCodeExtractionSkippedIssue(target.IndexPath) != null))
+                {
+                    statMatchedId = null;
+                }
+                if (statMatchedId != null)
+                {
+                    skipped++;
+                    processed++;
+                    if (FileIndexer.SupportsHotspotFamilyMarkerLanguage(target.Language) && target.Language != null)
+                        reusedHotspotFamilyLanguages.Add(target.Language);
+                    await EmitProgressNotificationAsync(progressToken, processed, files.Count).ConfigureAwait(false);
+                    continue;
+                }
+
+                McpIndexFileContentLoadForTesting?.Invoke(target.IndexPath);
                 var loaded = indexer.BuildLoadedRecordWithRawBytes(
                     filePath,
                     target.RelativePath,

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -49,6 +49,7 @@ public partial class McpServer
     internal const int MaxMcpIndexFailureMessageLength = 512;
     internal static Action<string>? McpIndexFileCommittedForTesting { get; set; }
     internal static Action<string>? McpIndexFileContentLoadForTesting { get; set; }
+    internal static Action? McpIndexFtsOptimizeForTesting { get; set; }
     internal static Action? McpIndexCSharpMetadataResolveForTesting { get; set; }
     internal static Action? McpIndexTypeScriptAugmentationRebuildForTesting { get; set; }
     internal static Func<string, CancellationToken, UpdateCheckResult>? StatusUpdateCheckForTesting { get; set; }
@@ -5906,6 +5907,7 @@ public partial class McpServer
         var projectRootWritten = PathsEqual(normalizedPriorIndexedProjectRoot, normalizedProjectPath);
         var typeScriptAugmentationNeedsRefresh = !projectRootWritten
             || !writer.TypeScriptAugmentationVersionMatchesCurrent();
+        var ftsMutated = false;
 
         static bool PathsEqual(string? left, string? right)
         {
@@ -6003,6 +6005,7 @@ public partial class McpServer
         {
             csharpMetadataTargetsNeedRefresh = true;
             typeScriptAugmentationNeedsRefresh = true;
+            ftsMutated = true;
             WriteProjectRootOnce();
         }
 
@@ -6163,6 +6166,7 @@ public partial class McpServer
                     WriteProjectRootOnce();
                     writer.ClearBatchInProgress();
                     txn.Commit();
+                    ftsMutated = true;
                     processed++;
                     await EmitProgressNotificationAsync(progressToken, processed, files.Count).ConfigureAwait(false);
                     McpIndexFileCommittedForTesting?.Invoke(record.Path);
@@ -6238,6 +6242,7 @@ public partial class McpServer
                 WriteProjectRootOnce();
                 writer.ClearBatchInProgress();
                 txn.Commit();
+                ftsMutated = true;
                 McpIndexFileCommittedForTesting?.Invoke(record.Path);
             }
             catch (FileIndexer.BinaryFileSkippedException ex)
@@ -6257,6 +6262,7 @@ public partial class McpServer
                     writer.InsertIssues(fileId, [IndexCommandRunner.BuildNullByteIssue(ex)]);
                     WriteProjectRootOnce();
                     txn.Commit();
+                    ftsMutated = true;
                 }
                 catch (Exception cleanupEx)
                 {
@@ -6280,6 +6286,7 @@ public partial class McpServer
                         typeScriptAugmentationNeedsRefresh = true;
                         WriteProjectRootOnce();
                         txn.Commit();
+                        ftsMutated = true;
                     }
                 }
                 catch (Exception cleanupEx)
@@ -6305,7 +6312,11 @@ public partial class McpServer
             await EmitProgressNotificationAsync(progressToken, processed, files.Count).ConfigureAwait(false);
         }
 
-        writer.OptimizeFts();
+        if (ftsMutated)
+        {
+            McpIndexFtsOptimizeForTesting?.Invoke();
+            writer.OptimizeFts();
+        }
         // MCP index now runs ValidateContent + InsertIssues per file (bdbb2bd) on par with CLI
         // index, so stamp both graph-ready and issues-ready on clean runs — the old "graph only"
         // path is no longer accurate. Bits are only stamped when every file committed without

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -6020,7 +6020,6 @@ public partial class McpServer
                     language: record.Lang,
                     generated: record.Generated,
                     allowReuse: symbolKindFilterMatchesPrior
-                        && record.Lang is not ("javascript" or "typescript")
                         && (record.Lang != "csharp" || csharpSymbolNameContractMatchesCurrent)
                         && (record.Lang != "csharp" || !csharpWorkspace.HasStaticInterfaceContracts)
                         && (record.Lang != "sql" || sqlGraphContractMatchesCurrent)

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -3103,8 +3103,10 @@ public partial class McpServer
         string absolutePath,
         string relativePath,
         string? language,
-        bool allowReuse)
+        bool allowReuse,
+        out long? size)
     {
+        size = null;
         if (!allowReuse || language == null)
             return null;
 
@@ -3114,6 +3116,7 @@ public partial class McpServer
             if (!info.Exists)
                 return null;
 
+            size = info.Length;
             return writer.GetUnchangedFileId(
                 relativePath,
                 info.LastWriteTimeUtc,
@@ -5938,12 +5941,19 @@ public partial class McpServer
             IEnumerable<string> paths,
             string projectRoot,
             List<string> diagnostics,
-            List<McpIndexDiagnostic> structuredDiagnostics)
+            List<McpIndexDiagnostic> structuredDiagnostics,
+            IReadOnlyDictionary<string, long>? knownFileSizes = null)
         {
             long total = 0;
             long skipped = 0;
             foreach (var filePath in paths)
             {
+                if (knownFileSizes != null && knownFileSizes.TryGetValue(filePath, out var knownSize))
+                {
+                    total += knownSize;
+                    continue;
+                }
+
                 try
                 {
                     var info = new FileInfo(filePath);
@@ -6021,6 +6031,7 @@ public partial class McpServer
             projectPath,
             filePath,
             FileIndexer.GetReusableDetectedLanguage(filePath, scanResult.FileLanguages))).ToArray();
+        var knownReadableFileSizes = new Dictionary<string, long>(StringComparer.Ordinal);
         await EmitProgressNotificationAsync(progressToken, 0, files.Count, "Index scan complete; indexing files.").ConfigureAwait(false);
         var csharpPrepassTargets = fileTargets
             .Where(static target => target.Language == "csharp")
@@ -6037,7 +6048,8 @@ public partial class McpServer
                 target.FilePath,
                 target.IndexPath,
                 target.Language,
-                allowReuse: true);
+                allowReuse: true,
+                out _);
             if (existingId == null)
                 return false;
 
@@ -6083,7 +6095,8 @@ public partial class McpServer
                     filePath,
                     target.IndexPath,
                     target.Language,
-                    allowStatReuse);
+                    allowStatReuse,
+                    out var statSize);
                 if (statMatchedId != null
                     && writer.HasReusableFileBlockingIssueForFile(
                         statMatchedId.Value,
@@ -6097,6 +6110,8 @@ public partial class McpServer
                 {
                     skipped++;
                     processed++;
+                    if (statSize.HasValue)
+                        knownReadableFileSizes[filePath] = statSize.Value;
                     if (FileIndexer.SupportsHotspotFamilyMarkerLanguage(target.Language) && target.Language != null)
                         reusedHotspotFamilyLanguages.Add(target.Language);
                     await EmitProgressNotificationAsync(progressToken, processed, files.Count).ConfigureAwait(false);
@@ -6110,6 +6125,7 @@ public partial class McpServer
                     target.Language,
                     requestToken);
                 var record = loaded.Record;
+                knownReadableFileSizes[filePath] = record.Size;
                 var content = loaded.Content;
                 var rawBytes = loaded.RawBytes;
                 var generatedSuppressionIssue = indexer.BuildGeneratedCodeExtractionSkippedIssue(record.Path);
@@ -6250,6 +6266,7 @@ public partial class McpServer
                 try
                 {
                     var skippedRecord = indexer.BuildSkippedFileRecord(filePath, target.RelativePath, target.Language);
+                    knownReadableFileSizes[filePath] = skippedRecord.Size;
                     if (skippedRecord.Lang == "csharp")
                         csharpMetadataTargetsNeedRefresh = true;
                     if (skippedRecord.Lang == "typescript")
@@ -6410,7 +6427,7 @@ public partial class McpServer
             // MCP の no-op full-scan root backfill も readiness stamp 後に限定する。
             WriteProjectRootOnce();
             writer.WriteUnknownExtensionFileMetadata(scanResult.UnknownExtensionFiles);
-            var bytesRead = SumReadableFileBytes(files, projectPath, indexRunDiagnostics, mcpIndexDiagnostics);
+            var bytesRead = SumReadableFileBytes(files, projectPath, indexRunDiagnostics, mcpIndexDiagnostics, knownReadableFileSizes);
             writer.SetMeta(DbContext.LastIndexRunModeMetaKey, rebuild ? "rebuild" : "mcp");
             writer.SetMeta(DbContext.LastIndexRunStartedAtMetaKey, runStartedAtUtc.ToString("o", System.Globalization.CultureInfo.InvariantCulture));
             writer.SetMeta(DbContext.LastIndexRunDurationMsMetaKey, runStopwatch.ElapsedMilliseconds.ToString(System.Globalization.CultureInfo.InvariantCulture));

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -49,6 +49,7 @@ public partial class McpServer
     internal const int MaxMcpIndexFailureMessageLength = 512;
     internal static Action<string>? McpIndexFileCommittedForTesting { get; set; }
     internal static Action<string>? McpIndexFileContentLoadForTesting { get; set; }
+    internal static Action? McpIndexPostExtractionHookDiscoveryForTesting { get; set; }
     internal static Action? McpIndexFtsOptimizeForTesting { get; set; }
     internal static Action? McpIndexCSharpPrepassForTesting { get; set; }
     internal static Action? McpIndexCSharpMetadataResolveForTesting { get; set; }
@@ -5887,7 +5888,11 @@ public partial class McpServer
             directoryIgnoreCaseProbe: null,
             symlinkPolicy: symlinkPolicy,
             generatedCodePatterns: IndexCommandRunner.ReadGeneratedCodePatternsFromEnvironment());
-        using var postExtractionHooks = PostExtractionHookRunner.DiscoverDefault(maxFileBytes);
+        using var postExtractionHooks = new IndexCommandRunner.LazyDisposable<PostExtractionHookRunner>(() =>
+        {
+            McpIndexPostExtractionHookDiscoveryForTesting?.Invoke();
+            return PostExtractionHookRunner.DiscoverDefault(maxFileBytes);
+        });
         var currentHotspotFamilyMarkerFingerprints = GetHotspotFamilyMarkerFingerprints(indexer, requestToken);
         var currentCSharpSymbolNameContractVersion = DbContext.CSharpSymbolNameContractVersion.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var csharpSymbolNameContractMatchesCurrent = priorCSharpSymbolNameContractVersion == currentCSharpSymbolNameContractVersion;
@@ -6227,7 +6232,7 @@ public partial class McpServer
                 }
                 SymbolExtractor.ApplyFamilyScope(symbols, indexer.GetFamilyScopeKey(filePath, record.Lang));
                 var fileContext = new FileContext(projectPath, record.Path, filePath, record.Lang);
-                postExtractionHooks.OnSymbolsExtracted(fileContext, symbols);
+                postExtractionHooks.Value.OnSymbolsExtracted(fileContext, symbols);
                 symbolsDroppedByKindFilter += symbolKindFilter.Apply(symbols);
                 if (symbols.Count > maxSymbolsPerFile)
                 {
@@ -6259,7 +6264,7 @@ public partial class McpServer
                             maxReferenceCount: maxReferencesPerFile + 1);
                         regexTimeoutIssue = IndexCommandRunner.BuildRegexTimeoutIssue(record.Path, regexTimeouts);
                     }
-                    postExtractionHooks.OnReferencesExtracted(fileContext, references);
+                    postExtractionHooks.Value.OnReferencesExtracted(fileContext, references);
                     FileIssue? referenceCapIssue = null;
                     if (references.Count > maxReferencesPerFile)
                     {

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -48,6 +48,7 @@ public partial class McpServer
     };
     internal const int MaxMcpIndexFailureMessageLength = 512;
     internal static Action<string>? McpIndexFileCommittedForTesting { get; set; }
+    internal static Action? McpIndexCSharpMetadataResolveForTesting { get; set; }
     internal static Action? McpIndexTypeScriptAugmentationRebuildForTesting { get; set; }
     internal static Func<string, CancellationToken, UpdateCheckResult>? StatusUpdateCheckForTesting { get; set; }
     private QueryCommandRunner.ProjectFilterRootResolution? _projectFilterRootResolutionForCurrentToolCall;
@@ -5851,6 +5852,8 @@ public partial class McpServer
         var currentHotspotFamilyMarkerFingerprints = GetHotspotFamilyMarkerFingerprints(indexer, requestToken);
         var currentCSharpSymbolNameContractVersion = DbContext.CSharpSymbolNameContractVersion.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var csharpSymbolNameContractMatchesCurrent = priorCSharpSymbolNameContractVersion == currentCSharpSymbolNameContractVersion;
+        var currentMetadataTargetVersion = DbContext.MetadataTargetVersion.ToString(System.Globalization.CultureInfo.InvariantCulture);
+        var csharpMetadataTargetsNeedRefresh = priorMetadataTargetCsharp != currentMetadataTargetVersion;
         var currentSqlGraphContractVersion = DbContext.SqlGraphContractVersion.ToString(System.Globalization.CultureInfo.InvariantCulture);
         var sqlGraphContractMatchesCurrent = priorSqlGraphContractVersion == currentSqlGraphContractVersion;
         var hotspotFamilyTrustMatchesCurrent = GetHotspotFamilyTrustMatchesCurrent(
@@ -5964,6 +5967,7 @@ public partial class McpServer
         var purged = writer.PurgeStaleFiles(projectPath);
         if (purged > 0)
         {
+            csharpMetadataTargetsNeedRefresh = true;
             typeScriptAugmentationNeedsRefresh = true;
             WriteProjectRootOnce();
         }
@@ -6051,6 +6055,8 @@ public partial class McpServer
                 writer.MarkBatchInProgress();
                 fileBatchMarked = true;
                 MarkSymbolKindFilterMetaIncompleteOnce();
+                if (record.Lang == "csharp")
+                    csharpMetadataTargetsNeedRefresh = true;
                 if (record.Lang == "typescript")
                     typeScriptAugmentationNeedsRefresh = true;
                 using var txn = writer.BeginTransaction(requestToken, "mcp index file");
@@ -6150,6 +6156,8 @@ public partial class McpServer
                 try
                 {
                     var skippedRecord = indexer.BuildSkippedFileRecord(filePath, target.RelativePath, target.Language);
+                    if (skippedRecord.Lang == "csharp")
+                        csharpMetadataTargetsNeedRefresh = true;
                     if (skippedRecord.Lang == "typescript")
                         typeScriptAugmentationNeedsRefresh = true;
                     using var txn = writer.BeginTransaction(requestToken, "mcp index skipped binary");
@@ -6179,6 +6187,7 @@ public partial class McpServer
                     {
                         using var txn = writer.BeginTransaction(requestToken, "mcp index delete missing file");
                         writer.DeleteFileByPath(relativePath);
+                        csharpMetadataTargetsNeedRefresh = true;
                         typeScriptAugmentationNeedsRefresh = true;
                         WriteProjectRootOnce();
                         txn.Commit();
@@ -6218,7 +6227,6 @@ public partial class McpServer
         var sqlGraphContractReadyAfter = !writer.HasAnyFilesWithLanguage("sql");
         var foldReadyAfter = false;
         string? foldReadyReason = null;
-        _ = priorMetadataTargetCsharp;
         if (!scanResult.HadErrors && errors == 0)
         {
             await EmitProgressNotificationAsync(progressToken, processed, files.Count, "Finalizing index metadata.").ConfigureAwait(false);
@@ -6231,7 +6239,11 @@ public partial class McpServer
             csharpSymbolNameReadyAfter = true;
             if (writer.HasAnyFilesWithLanguage("csharp"))
             {
-                writer.ResolveCSharpMetadataTargets();
+                if (csharpMetadataTargetsNeedRefresh)
+                {
+                    McpIndexCSharpMetadataResolveForTesting?.Invoke();
+                    writer.ResolveCSharpMetadataTargets();
+                }
                 writer.MarkMetadataTargetReady("csharp");
                 csharpMetadataTargetReadyAfter = true;
             }

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -5909,8 +5909,10 @@ public partial class McpServer
             ? null
             : Path.GetFullPath(priorIndexedProjectRoot);
         var projectRootWritten = PathsEqual(normalizedPriorIndexedProjectRoot, normalizedProjectPath);
+        var typeScriptAugmentationVersionMatchesCurrent = writer.TypeScriptAugmentationVersionMatchesCurrent();
         var typeScriptAugmentationNeedsRefresh = !projectRootWritten
-            || !writer.TypeScriptAugmentationVersionMatchesCurrent();
+            || !typeScriptAugmentationVersionMatchesCurrent;
+        var typeScriptAugmentationReadyCleared = !typeScriptAugmentationVersionMatchesCurrent;
         var ftsMutated = false;
 
         static bool PathsEqual(string? left, string? right)
@@ -5936,6 +5938,17 @@ public partial class McpServer
                 return;
             writer.SetMeta(IndexCommandRunner.SymbolKindFilterMetaKey, null);
             symbolKindFilterMetaMarkedIncomplete = true;
+        }
+
+        void RequireTypeScriptAugmentationRefresh()
+        {
+            if (!typeScriptAugmentationReadyCleared)
+            {
+                writer.ClearTypeScriptAugmentationReady();
+                typeScriptAugmentationReadyCleared = true;
+            }
+
+            typeScriptAugmentationNeedsRefresh = true;
         }
 
         static (long BytesRead, long SkippedFileCount) SumReadableFileBytes(
@@ -6011,11 +6024,10 @@ public partial class McpServer
             writer.LoadCSharpStaticInterfaceContractSymbols().Count > 0;
 
         // Purge stale files / 古いファイルをパージ
-        var purged = writer.PurgeStaleFiles(projectPath);
+        var purged = writer.PurgeStaleFiles(projectPath, beforeCommit: RequireTypeScriptAugmentationRefresh);
         if (purged > 0)
         {
             csharpMetadataTargetsNeedRefresh = true;
-            typeScriptAugmentationNeedsRefresh = true;
             ftsMutated = true;
             WriteProjectRootOnce();
         }
@@ -6175,9 +6187,10 @@ public partial class McpServer
                 MarkSymbolKindFilterMetaIncompleteOnce();
                 if (record.Lang == "csharp")
                     csharpMetadataTargetsNeedRefresh = true;
-                if (record.Lang == "typescript")
-                    typeScriptAugmentationNeedsRefresh = true;
+                var recordRequiresTypeScriptAugmentationRefresh = record.Lang == "typescript";
                 using var txn = writer.BeginTransaction(requestToken, "mcp index file");
+                if (recordRequiresTypeScriptAugmentationRefresh)
+                    RequireTypeScriptAugmentationRefresh();
                 var fileId = writer.UpsertFile(record);
                 var chunks = ChunkSplitter.SplitNormalized(fileId, content, loaded.HasOversizeLine, record.Lines);
                 if (generatedSuppressionIssue != null)
@@ -6279,9 +6292,10 @@ public partial class McpServer
                     knownReadableFileSizes[filePath] = skippedRecord.Size;
                     if (skippedRecord.Lang == "csharp")
                         csharpMetadataTargetsNeedRefresh = true;
-                    if (skippedRecord.Lang == "typescript")
-                        typeScriptAugmentationNeedsRefresh = true;
+                    var skippedRecordRequiresTypeScriptAugmentationRefresh = skippedRecord.Lang == "typescript";
                     using var txn = writer.BeginTransaction(requestToken, "mcp index skipped binary");
+                    if (skippedRecordRequiresTypeScriptAugmentationRefresh)
+                        RequireTypeScriptAugmentationRefresh();
                     var fileId = writer.UpsertFile(skippedRecord);
                     writer.InsertChunks([], requestToken);
                     writer.InsertSymbols([], requestToken);
@@ -6310,7 +6324,7 @@ public partial class McpServer
                         using var txn = writer.BeginTransaction(requestToken, "mcp index delete missing file");
                         writer.DeleteFileByPath(relativePath);
                         csharpMetadataTargetsNeedRefresh = true;
-                        typeScriptAugmentationNeedsRefresh = true;
+                        RequireTypeScriptAugmentationRefresh();
                         WriteProjectRootOnce();
                         txn.Commit();
                         ftsMutated = true;

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -1761,6 +1761,51 @@ public class DatabaseTests : IDisposable
     }
 
     [Fact]
+    public void HasExtractionCapViolationForFile_CombinesCountsAndIssues()
+    {
+        var modified = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var fileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/caps.cs",
+            Lang = "csharp",
+            Size = 20,
+            Lines = 2,
+            Modified = modified,
+        });
+
+        Assert.False(_writer.HasExtractionCapViolationForFile(fileId, maxSymbolsPerFile: 2, maxReferencesPerFile: 2));
+
+        _writer.InsertSymbols(
+        [
+            new SymbolRecord { FileId = fileId, Name = "One", Kind = "class", Line = 1 },
+            new SymbolRecord { FileId = fileId, Name = "Two", Kind = "class", Line = 2 },
+        ]);
+        Assert.False(_writer.HasExtractionCapViolationForFile(fileId, maxSymbolsPerFile: 2, maxReferencesPerFile: 2));
+        Assert.True(_writer.HasExtractionCapViolationForFile(fileId, maxSymbolsPerFile: 1, maxReferencesPerFile: 2));
+
+        var issueFileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/cap-issue.cs",
+            Lang = "csharp",
+            Size = 20,
+            Lines = 2,
+            Modified = modified,
+        });
+        _writer.InsertIssues(issueFileId,
+        [
+            new FileIssue
+            {
+                Path = "src/cap-issue.cs",
+                Kind = "reference_count_exceeded",
+                Line = 0,
+                Message = "too many references",
+            },
+        ]);
+
+        Assert.True(_writer.HasExtractionCapViolationForFile(issueFileId, maxSymbolsPerFile: 10, maxReferencesPerFile: 10));
+    }
+
+    [Fact]
     public void PurgeStaleFilesSharingChecksum_RemovesDeletedRenameRowsOnly()
     {
         var projectRoot = Path.Combine(Path.GetTempPath(), $"cdidx_checksum_purge_{Guid.NewGuid():N}");

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -1774,6 +1774,8 @@ public class DatabaseTests : IDisposable
         });
 
         Assert.False(_writer.HasExtractionCapViolationForFile(fileId, maxSymbolsPerFile: 2, maxReferencesPerFile: 2));
+        Assert.False(_writer.HasReusableFileBlockingIssueForFile(fileId, maxSymbolsPerFile: 2, maxReferencesPerFile: 2, generatedExtractionSuppressed: false));
+        Assert.True(_writer.HasReusableFileBlockingIssueForFile(fileId, maxSymbolsPerFile: 2, maxReferencesPerFile: 2, generatedExtractionSuppressed: true));
 
         _writer.InsertSymbols(
         [
@@ -1803,6 +1805,28 @@ public class DatabaseTests : IDisposable
         ]);
 
         Assert.True(_writer.HasExtractionCapViolationForFile(issueFileId, maxSymbolsPerFile: 10, maxReferencesPerFile: 10));
+
+        var generatedFileId = _writer.UpsertFile(new FileRecord
+        {
+            Path = "src/generated.g.cs",
+            Lang = "csharp",
+            Size = 20,
+            Lines = 2,
+            Modified = modified,
+        });
+        _writer.InsertIssues(generatedFileId,
+        [
+            new FileIssue
+            {
+                Path = "src/generated.g.cs",
+                Kind = FileIndexer.GeneratedCodeExtractionSkippedIssueKind,
+                Line = 0,
+                Message = "generated extraction skipped",
+            },
+        ]);
+
+        Assert.False(_writer.HasReusableFileBlockingIssueForFile(generatedFileId, maxSymbolsPerFile: 10, maxReferencesPerFile: 10, generatedExtractionSuppressed: true));
+        Assert.True(_writer.HasReusableFileBlockingIssueForFile(generatedFileId, maxSymbolsPerFile: 10, maxReferencesPerFile: 10, generatedExtractionSuppressed: false));
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2238,6 +2238,7 @@ public sealed class Caller
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_head_changed_skip_before_extract");
         bool? parallelized = null;
         string? reason = null;
+        var loadedPaths = new List<string>();
         try
         {
             RunGit(projectRoot, "init");
@@ -2257,6 +2258,7 @@ public sealed class Caller
                 parallelized = enabled;
                 reason = why;
             };
+            IndexCommandRunner.FullScanFileContentLoadForTesting = path => loadedPaths.Add(path);
 
             var (refreshExitCode, refreshJson) = RunAndCaptureJson([projectRoot, "--json"]);
 
@@ -2266,10 +2268,13 @@ public sealed class Caller
             Assert.False(parallelized);
             Assert.Null(reason);
             Assert.Equal(1, refreshJson.GetProperty("summary").GetProperty("files_skipped").GetInt32());
+            Assert.DoesNotContain("app.cs", loadedPaths);
+            Assert.Contains("feature.cs", loadedPaths);
         }
         finally
         {
             IndexCommandRunner.FullScanExtractionSchedulingForTesting = null;
+            IndexCommandRunner.FullScanFileContentLoadForTesting = null;
             SqliteConnection.ClearAllPools();
             DeleteDirectory(projectRoot);
         }

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2283,6 +2283,32 @@ public sealed class Caller
     }
 
     [Fact]
+    public void Run_FullScanWithoutCSharp_DoesNotRunCSharpPrepass()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_fullscan_no_csharp_prepass");
+        var ranCSharpPrepass = false;
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.ts"), "interface AppApi { run(): void; }\n");
+            File.WriteAllText(Path.Combine(projectRoot, "tool.py"), "def run():\n    return 1\n");
+
+            IndexCommandRunner.FullScanCSharpPrepassForTesting = () => ranCSharpPrepass = true;
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("success", json.GetProperty("status").GetString());
+            Assert.False(ranCSharpPrepass);
+        }
+        finally
+        {
+            IndexCommandRunner.FullScanCSharpPrepassForTesting = null;
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_NoOpFullScan_DoesNotOptimizeFts()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_noop_fullscan_no_fts_optimize");

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2285,6 +2285,7 @@ public sealed class Caller
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_noop_fullscan_no_fts_optimize");
         var optimized = false;
+        var resolvedMetadataTargets = false;
         try
         {
             File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { public void Run() { } }\n");
@@ -2293,6 +2294,7 @@ public sealed class Caller
             Assert.Equal(CommandExitCodes.Success, initialExitCode);
 
             IndexCommandRunner.FullScanFtsOptimizeForTesting = () => optimized = true;
+            IndexCommandRunner.FullScanCSharpMetadataResolveForTesting = () => resolvedMetadataTargets = true;
 
             var (refreshExitCode, refreshJson) = RunAndCaptureJson([projectRoot, "--json"]);
 
@@ -2300,10 +2302,12 @@ public sealed class Caller
             Assert.Equal("success", refreshJson.GetProperty("status").GetString());
             Assert.Equal(1, refreshJson.GetProperty("summary").GetProperty("files_skipped").GetInt32());
             Assert.False(optimized);
+            Assert.False(resolvedMetadataTargets);
         }
         finally
         {
             IndexCommandRunner.FullScanFtsOptimizeForTesting = null;
+            IndexCommandRunner.FullScanCSharpMetadataResolveForTesting = null;
             SqliteConnection.ClearAllPools();
             DeleteDirectory(projectRoot);
         }

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2283,6 +2283,39 @@ public sealed class Caller
     }
 
     [Fact]
+    public void Run_FullScanAfterTypeScriptConfigChange_ReprocessesUnchangedTypeScriptFiles()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_fullscan_tsconfig_refresh");
+        var loadedPaths = new List<string>();
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.ts"), "export interface AppApi { run(): void; }\n");
+            File.WriteAllText(Path.Combine(projectRoot, "tsconfig.json"), "{ \"compilerOptions\": { \"baseUrl\": \".\" } }\n");
+
+            var (initialExitCode, _) = RunAndCaptureJson([projectRoot, "--json"]);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            File.WriteAllText(Path.Combine(projectRoot, "tsconfig.json"), "{ \"compilerOptions\": { \"baseUrl\": \".\", \"paths\": {} } }\n");
+            File.SetLastWriteTimeUtc(Path.Combine(projectRoot, "tsconfig.json"), DateTime.UtcNow.AddSeconds(2));
+
+            IndexCommandRunner.FullScanFileContentLoadForTesting = path => loadedPaths.Add(path);
+
+            var (refreshExitCode, refreshJson) = RunAndCaptureJson([projectRoot, "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, refreshExitCode);
+            Assert.Equal("success", refreshJson.GetProperty("status").GetString());
+            Assert.Contains("app.ts", loadedPaths);
+            Assert.Contains("tsconfig.json", loadedPaths);
+        }
+        finally
+        {
+            IndexCommandRunner.FullScanFileContentLoadForTesting = null;
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_FullScanWithSequentialExtraction_PersistsValidationIssues()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_fullscan_sequential_validation");

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2283,6 +2283,40 @@ public sealed class Caller
     }
 
     [Fact]
+    public void Run_FullScanWithSequentialExtraction_PersistsValidationIssues()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_fullscan_sequential_validation");
+        bool? parallelized = null;
+        int? queueCapacity = null;
+        try
+        {
+            File.WriteAllText(
+                Path.Combine(projectRoot, "app.cs"),
+                "public class App\rpublic class Other\n");
+
+            IndexCommandRunner.FullScanExtractionSchedulingForTesting = (enabled, _) => parallelized = enabled;
+            IndexCommandRunner.FullScanExtractionQueueCapacityForTesting = capacity => queueCapacity = capacity;
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--exclude-symbol-kind", "test.method", "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("success", json.GetProperty("status").GetString());
+            Assert.False(parallelized);
+            Assert.Equal(1, queueCapacity);
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            var issue = Assert.Single(ReadFileIssues(dbPath, "mixed_line_endings"));
+            Assert.Equal("app.cs", issue.Path);
+        }
+        finally
+        {
+            IndexCommandRunner.FullScanExtractionSchedulingForTesting = null;
+            IndexCommandRunner.FullScanExtractionQueueCapacityForTesting = null;
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_FullScanWithoutCSharp_DoesNotRunCSharpPrepass()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_fullscan_no_csharp_prepass");

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2315,6 +2315,9 @@ public sealed class Caller
         var optimized = false;
         var resolvedMetadataTargets = false;
         var rebuiltTypeScriptAugmentation = false;
+        var startedExtractionWork = false;
+        bool? parallelized = null;
+        string? parallelizeReason = null;
         try
         {
             File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { public void Run() { } }\n");
@@ -2326,12 +2329,21 @@ public sealed class Caller
             IndexCommandRunner.FullScanFtsOptimizeForTesting = () => optimized = true;
             IndexCommandRunner.FullScanCSharpMetadataResolveForTesting = () => resolvedMetadataTargets = true;
             IndexCommandRunner.FullScanTypeScriptAugmentationRebuildForTesting = () => rebuiltTypeScriptAugmentation = true;
+            IndexCommandRunner.FullScanExtractionWorkStartedForTesting = () => startedExtractionWork = true;
+            IndexCommandRunner.FullScanExtractionSchedulingForTesting = (enabled, reason) =>
+            {
+                parallelized = enabled;
+                parallelizeReason = reason;
+            };
 
             var (refreshExitCode, refreshJson) = RunAndCaptureJson([projectRoot, "--json"]);
 
             Assert.Equal(CommandExitCodes.Success, refreshExitCode);
             Assert.Equal("success", refreshJson.GetProperty("status").GetString());
             Assert.Equal(2, refreshJson.GetProperty("summary").GetProperty("files_skipped").GetInt32());
+            Assert.False(parallelized);
+            Assert.Null(parallelizeReason);
+            Assert.False(startedExtractionWork);
             Assert.False(optimized);
             Assert.False(resolvedMetadataTargets);
             Assert.False(rebuiltTypeScriptAugmentation);
@@ -2341,6 +2353,8 @@ public sealed class Caller
             IndexCommandRunner.FullScanFtsOptimizeForTesting = null;
             IndexCommandRunner.FullScanCSharpMetadataResolveForTesting = null;
             IndexCommandRunner.FullScanTypeScriptAugmentationRebuildForTesting = null;
+            IndexCommandRunner.FullScanExtractionWorkStartedForTesting = null;
+            IndexCommandRunner.FullScanExtractionSchedulingForTesting = null;
             SqliteConnection.ClearAllPools();
             DeleteDirectory(projectRoot);
         }

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -7201,6 +7201,68 @@ public sealed class Caller
     }
 
     [Fact]
+    public void Run_UpdateMode_CancelledAfterTypeScriptCommit_ClearsAugmentationVersion()
+    {
+        var projectRoot = CreateTempProject();
+        using var cancellation = new CancellationTokenSource();
+        try
+        {
+            var sourcePath = Path.Combine(projectRoot, "types.ts");
+            File.WriteAllText(sourcePath, "export interface Options { value: string }\n");
+
+            var initialExitCode = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            using (var db = new DbContext(dbPath))
+            {
+                Assert.Equal(
+                    DbContext.TypeScriptAugmentationVersion.ToString(CultureInfo.InvariantCulture),
+                    db.GetMetaString(DbContext.TypeScriptAugmentationVersionMetaKey));
+            }
+
+            File.WriteAllText(sourcePath, "export interface Options { value: string; enabled: boolean }\n");
+
+            var hookInvoked = false;
+            IndexCommandRunner.UpdateFileCommittedForTesting = (filesProcessed, filesTotal) =>
+            {
+                Assert.Equal(1, filesProcessed);
+                Assert.Equal(1, filesTotal);
+                hookInvoked = true;
+                cancellation.Cancel();
+            };
+
+            int interruptedExitCode;
+            lock (TestConsoleLock.Gate)
+            {
+                var originalOut = Console.Out;
+                using var stdout = new StringWriter();
+                try
+                {
+                    Console.SetOut(stdout);
+                    interruptedExitCode = IndexCommandRunner.Run([projectRoot, "--files", "types.ts", "--json"], _jsonOptions, cancellation);
+                }
+                finally
+                {
+                    Console.SetOut(originalOut);
+                    IndexCommandRunner.UpdateFileCommittedForTesting = null;
+                }
+            }
+
+            Assert.True(hookInvoked);
+            Assert.Equal(CommandExitCodes.Interrupted, interruptedExitCode);
+            using (var db = new DbContext(dbPath))
+                Assert.Null(db.GetMetaString(DbContext.TypeScriptAugmentationVersionMetaKey));
+        }
+        finally
+        {
+            IndexCommandRunner.UpdateFileCommittedForTesting = null;
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_Rebuild_WhenIndexedFileBecomesBinary_PersistsNullByteIssue()
     {
         var projectRoot = CreateTempProject();

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2316,6 +2316,38 @@ public sealed class Caller
     }
 
     [Fact]
+    public void Run_UpdateNonCSharpFile_DoesNotResolveCSharpMetadataTargets()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_update_non_csharp_no_csharp_metadata");
+        var resolvedMetadataTargets = false;
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { public void Run() { } }\n");
+            File.WriteAllText(Path.Combine(projectRoot, "tool.py"), "def run():\n    return 1\n");
+
+            var (initialExitCode, _) = RunAndCaptureJson([projectRoot, "--json"]);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            File.WriteAllText(Path.Combine(projectRoot, "tool.py"), "def run():\n    return 2\n");
+            File.SetLastWriteTimeUtc(Path.Combine(projectRoot, "tool.py"), DateTime.UtcNow.AddSeconds(2));
+
+            IndexCommandRunner.UpdateCSharpMetadataResolveForTesting = () => resolvedMetadataTargets = true;
+
+            var (updateExitCode, updateJson) = RunAndCaptureJson([projectRoot, "--files", "tool.py", "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, updateExitCode);
+            Assert.Equal("success", updateJson.GetProperty("status").GetString());
+            Assert.False(resolvedMetadataTargets);
+        }
+        finally
+        {
+            IndexCommandRunner.UpdateCSharpMetadataResolveForTesting = null;
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void ParseArgs_NotifyFlag_ParsesCompletionNotificationMode()
     {
         var options = IndexCommandRunner.ParseArgs([".", "--notify=osc9"]);

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2316,6 +2316,37 @@ public sealed class Caller
     }
 
     [Fact]
+    public void Run_FullScanAfterDerivedTypeScriptConfigDelete_ReprocessesUnchangedTypeScriptFiles()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_fullscan_tsconfig_base_delete");
+        var loadedPaths = new List<string>();
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.ts"), "export interface AppApi { run(): void; }\n");
+            File.WriteAllText(Path.Combine(projectRoot, "tsconfig.base.json"), "{ \"compilerOptions\": { \"baseUrl\": \".\" } }\n");
+
+            var (initialExitCode, _) = RunAndCaptureJson([projectRoot, "--json"]);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            File.Delete(Path.Combine(projectRoot, "tsconfig.base.json"));
+
+            IndexCommandRunner.FullScanFileContentLoadForTesting = path => loadedPaths.Add(path);
+
+            var (refreshExitCode, refreshJson) = RunAndCaptureJson([projectRoot, "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, refreshExitCode);
+            Assert.Equal("success", refreshJson.GetProperty("status").GetString());
+            Assert.Contains("app.ts", loadedPaths);
+        }
+        finally
+        {
+            IndexCommandRunner.FullScanFileContentLoadForTesting = null;
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_FullScanWithSequentialExtraction_PersistsValidationIssues()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_fullscan_sequential_validation");

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -7307,6 +7307,37 @@ public sealed class Caller
     }
 
     [Fact]
+    public void Run_UpdateMode_DeleteTypeScriptFile_RebuildsAugmentationReferences()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            var sourcePath = Path.Combine(projectRoot, "types.ts");
+            File.WriteAllText(sourcePath, "export interface Options { value: string }\n");
+
+            var initialExitCode = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            File.Delete(sourcePath);
+            var rebuiltTypeScriptAugmentation = false;
+            IndexCommandRunner.UpdateTypeScriptAugmentationRebuildForTesting = () => rebuiltTypeScriptAugmentation = true;
+
+            var (updateExitCode, updateJson) = RunAndCaptureJson([projectRoot, "--files", "types.ts", "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, updateExitCode);
+            Assert.Equal("success", updateJson.GetProperty("status").GetString());
+            Assert.Equal(1, updateJson.GetProperty("summary").GetProperty("removed").GetInt32());
+            Assert.True(rebuiltTypeScriptAugmentation);
+        }
+        finally
+        {
+            IndexCommandRunner.UpdateTypeScriptAugmentationRebuildForTesting = null;
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_Rebuild_WhenIndexedFileBecomesBinary_PersistsNullByteIssue()
     {
         var projectRoot = CreateTempProject();

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2325,9 +2325,11 @@ public sealed class Caller
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_update_non_csharp_no_csharp_metadata");
         var resolvedMetadataTargets = false;
+        var rebuiltTypeScriptAugmentation = false;
         try
         {
             File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { public void Run() { } }\n");
+            File.WriteAllText(Path.Combine(projectRoot, "app.ts"), "interface AppApi { run(): void; }\n");
             File.WriteAllText(Path.Combine(projectRoot, "tool.py"), "def run():\n    return 1\n");
 
             var (initialExitCode, _) = RunAndCaptureJson([projectRoot, "--json"]);
@@ -2337,16 +2339,19 @@ public sealed class Caller
             File.SetLastWriteTimeUtc(Path.Combine(projectRoot, "tool.py"), DateTime.UtcNow.AddSeconds(2));
 
             IndexCommandRunner.UpdateCSharpMetadataResolveForTesting = () => resolvedMetadataTargets = true;
+            IndexCommandRunner.UpdateTypeScriptAugmentationRebuildForTesting = () => rebuiltTypeScriptAugmentation = true;
 
             var (updateExitCode, updateJson) = RunAndCaptureJson([projectRoot, "--files", "tool.py", "--json"]);
 
             Assert.Equal(CommandExitCodes.Success, updateExitCode);
             Assert.Equal("success", updateJson.GetProperty("status").GetString());
             Assert.False(resolvedMetadataTargets);
+            Assert.False(rebuiltTypeScriptAugmentation);
         }
         finally
         {
             IndexCommandRunner.UpdateCSharpMetadataResolveForTesting = null;
+            IndexCommandRunner.UpdateTypeScriptAugmentationRebuildForTesting = null;
             SqliteConnection.ClearAllPools();
             DeleteDirectory(projectRoot);
         }

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2402,6 +2402,36 @@ public sealed class Caller
     }
 
     [Fact]
+    public void Run_NoOpUpdate_DoesNotStartExtractionWork()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_noop_update_no_extraction_work");
+        var startedExtractionWork = false;
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "tool.py"), "def run():\n    return 1\n");
+
+            var (initialExitCode, _) = RunAndCaptureJson([projectRoot, "--json"]);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            IndexCommandRunner.UpdateExtractionWorkStartedForTesting = () => startedExtractionWork = true;
+
+            var (updateExitCode, updateJson) = RunAndCaptureJson([projectRoot, "--files", "tool.py", "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, updateExitCode);
+            Assert.Equal("success", updateJson.GetProperty("status").GetString());
+            Assert.Equal(0, updateJson.GetProperty("summary").GetProperty("updated").GetInt32());
+            Assert.Equal(1, updateJson.GetProperty("summary").GetProperty("skipped").GetInt32());
+            Assert.False(startedExtractionWork);
+        }
+        finally
+        {
+            IndexCommandRunner.UpdateExtractionWorkStartedForTesting = null;
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void ParseArgs_NotifyFlag_ParsesCompletionNotificationMode()
     {
         var options = IndexCommandRunner.ParseArgs([".", "--notify=osc9"]);

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -4234,6 +4234,24 @@ public sealed class Caller
     }
 
     [Fact]
+    public void MeasureReadableFileBytes_UsesKnownSizeWithoutProbingPath()
+    {
+        var diagnostics = new List<string>();
+
+        var summary = IndexCommandRunner.MeasureReadableFileBytes(
+            ["bad\0path.txt"],
+            diagnostics: diagnostics,
+            knownFileSizes: new Dictionary<string, long>(StringComparer.Ordinal)
+            {
+                ["bad\0path.txt"] = 7,
+            });
+
+        Assert.Equal(7, summary.BytesRead);
+        Assert.Equal(0, summary.SkippedFileCount);
+        Assert.Empty(diagnostics);
+    }
+
+    [Fact]
     public void FormatIndexRunDiagnostic_CollapsesAndBoundsExceptionMessages()
     {
         var message = "first line\n" + new string('x', 700);

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2288,28 +2288,33 @@ public sealed class Caller
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_noop_fullscan_no_fts_optimize");
         var optimized = false;
         var resolvedMetadataTargets = false;
+        var rebuiltTypeScriptAugmentation = false;
         try
         {
             File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { public void Run() { } }\n");
+            File.WriteAllText(Path.Combine(projectRoot, "app.ts"), "interface AppApi { run(): void; }\n");
 
             var (initialExitCode, _) = RunAndCaptureJson([projectRoot, "--json"]);
             Assert.Equal(CommandExitCodes.Success, initialExitCode);
 
             IndexCommandRunner.FullScanFtsOptimizeForTesting = () => optimized = true;
             IndexCommandRunner.FullScanCSharpMetadataResolveForTesting = () => resolvedMetadataTargets = true;
+            IndexCommandRunner.FullScanTypeScriptAugmentationRebuildForTesting = () => rebuiltTypeScriptAugmentation = true;
 
             var (refreshExitCode, refreshJson) = RunAndCaptureJson([projectRoot, "--json"]);
 
             Assert.Equal(CommandExitCodes.Success, refreshExitCode);
             Assert.Equal("success", refreshJson.GetProperty("status").GetString());
-            Assert.Equal(1, refreshJson.GetProperty("summary").GetProperty("files_skipped").GetInt32());
+            Assert.Equal(2, refreshJson.GetProperty("summary").GetProperty("files_skipped").GetInt32());
             Assert.False(optimized);
             Assert.False(resolvedMetadataTargets);
+            Assert.False(rebuiltTypeScriptAugmentation);
         }
         finally
         {
             IndexCommandRunner.FullScanFtsOptimizeForTesting = null;
             IndexCommandRunner.FullScanCSharpMetadataResolveForTesting = null;
+            IndexCommandRunner.FullScanTypeScriptAugmentationRebuildForTesting = null;
             SqliteConnection.ClearAllPools();
             DeleteDirectory(projectRoot);
         }

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2281,6 +2281,35 @@ public sealed class Caller
     }
 
     [Fact]
+    public void Run_NoOpFullScan_DoesNotOptimizeFts()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_noop_fullscan_no_fts_optimize");
+        var optimized = false;
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { public void Run() { } }\n");
+
+            var (initialExitCode, _) = RunAndCaptureJson([projectRoot, "--json"]);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+
+            IndexCommandRunner.FullScanFtsOptimizeForTesting = () => optimized = true;
+
+            var (refreshExitCode, refreshJson) = RunAndCaptureJson([projectRoot, "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, refreshExitCode);
+            Assert.Equal("success", refreshJson.GetProperty("status").GetString());
+            Assert.Equal(1, refreshJson.GetProperty("summary").GetProperty("files_skipped").GetInt32());
+            Assert.False(optimized);
+        }
+        finally
+        {
+            IndexCommandRunner.FullScanFtsOptimizeForTesting = null;
+            SqliteConnection.ClearAllPools();
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void ParseArgs_NotifyFlag_ParsesCompletionNotificationMode()
     {
         var options = IndexCommandRunner.ParseArgs([".", "--notify=osc9"]);

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2324,6 +2324,7 @@ public sealed class Caller
     public void Run_UpdateNonCSharpFile_DoesNotResolveCSharpMetadataTargets()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_update_non_csharp_no_csharp_metadata");
+        var ranCSharpPrepass = false;
         var resolvedMetadataTargets = false;
         var rebuiltTypeScriptAugmentation = false;
         try
@@ -2338,6 +2339,7 @@ public sealed class Caller
             File.WriteAllText(Path.Combine(projectRoot, "tool.py"), "def run():\n    return 2\n");
             File.SetLastWriteTimeUtc(Path.Combine(projectRoot, "tool.py"), DateTime.UtcNow.AddSeconds(2));
 
+            IndexCommandRunner.UpdateCSharpPrepassForTesting = () => ranCSharpPrepass = true;
             IndexCommandRunner.UpdateCSharpMetadataResolveForTesting = () => resolvedMetadataTargets = true;
             IndexCommandRunner.UpdateTypeScriptAugmentationRebuildForTesting = () => rebuiltTypeScriptAugmentation = true;
 
@@ -2345,11 +2347,13 @@ public sealed class Caller
 
             Assert.Equal(CommandExitCodes.Success, updateExitCode);
             Assert.Equal("success", updateJson.GetProperty("status").GetString());
+            Assert.False(ranCSharpPrepass);
             Assert.False(resolvedMetadataTargets);
             Assert.False(rebuiltTypeScriptAugmentation);
         }
         finally
         {
+            IndexCommandRunner.UpdateCSharpPrepassForTesting = null;
             IndexCommandRunner.UpdateCSharpMetadataResolveForTesting = null;
             IndexCommandRunner.UpdateTypeScriptAugmentationRebuildForTesting = null;
             SqliteConnection.ClearAllPools();

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -2243,7 +2243,8 @@ public sealed class Caller
         {
             RunGit(projectRoot, "init");
             File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "public class App { public void Run() { } }\n");
-            RunGit(projectRoot, "add", "app.cs");
+            File.WriteAllText(Path.Combine(projectRoot, "app.ts"), "export interface AppApi { run(): void; }\n");
+            RunGit(projectRoot, "add", "app.cs", "app.ts");
             RunGit(projectRoot, "commit", "-m", "initial");
 
             var (initialExitCode, _) = RunAndCaptureJson([projectRoot, "--json"]);
@@ -2267,8 +2268,9 @@ public sealed class Caller
             Assert.True(refreshJson.GetProperty("head_changed").GetBoolean());
             Assert.False(parallelized);
             Assert.Null(reason);
-            Assert.Equal(1, refreshJson.GetProperty("summary").GetProperty("files_skipped").GetInt32());
+            Assert.Equal(2, refreshJson.GetProperty("summary").GetProperty("files_skipped").GetInt32());
             Assert.DoesNotContain("app.cs", loadedPaths);
+            Assert.DoesNotContain("app.ts", loadedPaths);
             Assert.Contains("feature.cs", loadedPaths);
         }
         finally

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -11241,6 +11241,7 @@ public sealed class Caller
         var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_mcp_index_noop_ts_augmentation_{Guid.NewGuid():N}.db");
         var resolvedCSharpMetadataTargets = false;
         var rebuiltTypeScriptAugmentation = false;
+        var loadedPaths = new List<string>();
         try
         {
             File.WriteAllText(Path.Combine(fixtureDir, "app.cs"), "public class App { public void Run() { } }\n");
@@ -11251,17 +11252,20 @@ public sealed class Caller
 
             Assert.False(firstResponse["result"]?["isError"]?.GetValue<bool>() ?? false);
 
+            McpServer.McpIndexFileContentLoadForTesting = path => loadedPaths.Add(path);
             McpServer.McpIndexCSharpMetadataResolveForTesting = () => resolvedCSharpMetadataTargets = true;
             McpServer.McpIndexTypeScriptAugmentationRebuildForTesting = () => rebuiltTypeScriptAugmentation = true;
 
             var secondResponse = CallIndex(server, fixtureDir);
 
             Assert.False(secondResponse["result"]?["isError"]?.GetValue<bool>() ?? false);
+            Assert.Empty(loadedPaths);
             Assert.False(resolvedCSharpMetadataTargets);
             Assert.False(rebuiltTypeScriptAugmentation);
         }
         finally
         {
+            McpServer.McpIndexFileContentLoadForTesting = null;
             McpServer.McpIndexCSharpMetadataResolveForTesting = null;
             McpServer.McpIndexTypeScriptAugmentationRebuildForTesting = null;
             TestProjectHelper.DeleteDirectory(fixtureDir);

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -11234,14 +11234,16 @@ public sealed class Caller
     }
 
     [Fact]
-    public void ToolsCall_Index_NoOpDoesNotRebuildTypeScriptAugmentation()
+    public void ToolsCall_Index_NoOpSkipsUnchangedFinalizers()
     {
         var fixtureDir = Path.Combine(Path.GetFullPath("."), $"mcp_index_noop_ts_augmentation_{Guid.NewGuid():N}");
         Directory.CreateDirectory(fixtureDir);
         var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_mcp_index_noop_ts_augmentation_{Guid.NewGuid():N}.db");
+        var resolvedCSharpMetadataTargets = false;
         var rebuiltTypeScriptAugmentation = false;
         try
         {
+            File.WriteAllText(Path.Combine(fixtureDir, "app.cs"), "public class App { public void Run() { } }\n");
             File.WriteAllText(Path.Combine(fixtureDir, "app.ts"), "interface AppApi { run(): void; }\n");
             using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
 
@@ -11249,15 +11251,18 @@ public sealed class Caller
 
             Assert.False(firstResponse["result"]?["isError"]?.GetValue<bool>() ?? false);
 
+            McpServer.McpIndexCSharpMetadataResolveForTesting = () => resolvedCSharpMetadataTargets = true;
             McpServer.McpIndexTypeScriptAugmentationRebuildForTesting = () => rebuiltTypeScriptAugmentation = true;
 
             var secondResponse = CallIndex(server, fixtureDir);
 
             Assert.False(secondResponse["result"]?["isError"]?.GetValue<bool>() ?? false);
+            Assert.False(resolvedCSharpMetadataTargets);
             Assert.False(rebuiltTypeScriptAugmentation);
         }
         finally
         {
+            McpServer.McpIndexCSharpMetadataResolveForTesting = null;
             McpServer.McpIndexTypeScriptAugmentationRebuildForTesting = null;
             TestProjectHelper.DeleteDirectory(fixtureDir);
             TestProjectHelper.DeleteSqliteDatabaseFiles(dbPath);

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -11241,6 +11241,7 @@ public sealed class Caller
         var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_mcp_index_noop_ts_augmentation_{Guid.NewGuid():N}.db");
         var resolvedCSharpMetadataTargets = false;
         var rebuiltTypeScriptAugmentation = false;
+        var optimizedFts = false;
         var loadedPaths = new List<string>();
         try
         {
@@ -11253,6 +11254,7 @@ public sealed class Caller
             Assert.False(firstResponse["result"]?["isError"]?.GetValue<bool>() ?? false);
 
             McpServer.McpIndexFileContentLoadForTesting = path => loadedPaths.Add(path);
+            McpServer.McpIndexFtsOptimizeForTesting = () => optimizedFts = true;
             McpServer.McpIndexCSharpMetadataResolveForTesting = () => resolvedCSharpMetadataTargets = true;
             McpServer.McpIndexTypeScriptAugmentationRebuildForTesting = () => rebuiltTypeScriptAugmentation = true;
 
@@ -11260,12 +11262,14 @@ public sealed class Caller
 
             Assert.False(secondResponse["result"]?["isError"]?.GetValue<bool>() ?? false);
             Assert.Empty(loadedPaths);
+            Assert.False(optimizedFts);
             Assert.False(resolvedCSharpMetadataTargets);
             Assert.False(rebuiltTypeScriptAugmentation);
         }
         finally
         {
             McpServer.McpIndexFileContentLoadForTesting = null;
+            McpServer.McpIndexFtsOptimizeForTesting = null;
             McpServer.McpIndexCSharpMetadataResolveForTesting = null;
             McpServer.McpIndexTypeScriptAugmentationRebuildForTesting = null;
             TestProjectHelper.DeleteDirectory(fixtureDir);

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -11234,6 +11234,34 @@ public sealed class Caller
     }
 
     [Fact]
+    public void ToolsCall_Index_WithoutCSharpSkipsCSharpPrepass()
+    {
+        var fixtureDir = Path.Combine(Path.GetFullPath("."), $"mcp_index_no_csharp_prepass_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(fixtureDir);
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_mcp_index_no_csharp_prepass_{Guid.NewGuid():N}.db");
+        var ranCSharpPrepass = false;
+        try
+        {
+            File.WriteAllText(Path.Combine(fixtureDir, "app.ts"), "interface AppApi { run(): void; }\n");
+            File.WriteAllText(Path.Combine(fixtureDir, "tool.py"), "def run():\n    return 1\n");
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+
+            McpServer.McpIndexCSharpPrepassForTesting = () => ranCSharpPrepass = true;
+
+            var response = CallIndex(server, fixtureDir);
+
+            Assert.False(response["result"]?["isError"]?.GetValue<bool>() ?? false);
+            Assert.False(ranCSharpPrepass);
+        }
+        finally
+        {
+            McpServer.McpIndexCSharpPrepassForTesting = null;
+            TestProjectHelper.DeleteDirectory(fixtureDir);
+            TestProjectHelper.DeleteSqliteDatabaseFiles(dbPath);
+        }
+    }
+
+    [Fact]
     public void ToolsCall_Index_NoOpSkipsUnchangedFinalizers()
     {
         var fixtureDir = Path.Combine(Path.GetFullPath("."), $"mcp_index_noop_ts_augmentation_{Guid.NewGuid():N}");

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -11270,6 +11270,7 @@ public sealed class Caller
         var resolvedCSharpMetadataTargets = false;
         var rebuiltTypeScriptAugmentation = false;
         var optimizedFts = false;
+        var discoveredPostExtractionHooks = false;
         var loadedPaths = new List<string>();
         try
         {
@@ -11282,6 +11283,7 @@ public sealed class Caller
             Assert.False(firstResponse["result"]?["isError"]?.GetValue<bool>() ?? false);
 
             McpServer.McpIndexFileContentLoadForTesting = path => loadedPaths.Add(path);
+            McpServer.McpIndexPostExtractionHookDiscoveryForTesting = () => discoveredPostExtractionHooks = true;
             McpServer.McpIndexFtsOptimizeForTesting = () => optimizedFts = true;
             McpServer.McpIndexCSharpMetadataResolveForTesting = () => resolvedCSharpMetadataTargets = true;
             McpServer.McpIndexTypeScriptAugmentationRebuildForTesting = () => rebuiltTypeScriptAugmentation = true;
@@ -11290,6 +11292,7 @@ public sealed class Caller
 
             Assert.False(secondResponse["result"]?["isError"]?.GetValue<bool>() ?? false);
             Assert.Empty(loadedPaths);
+            Assert.False(discoveredPostExtractionHooks);
             Assert.False(optimizedFts);
             Assert.False(resolvedCSharpMetadataTargets);
             Assert.False(rebuiltTypeScriptAugmentation);
@@ -11297,6 +11300,7 @@ public sealed class Caller
         finally
         {
             McpServer.McpIndexFileContentLoadForTesting = null;
+            McpServer.McpIndexPostExtractionHookDiscoveryForTesting = null;
             McpServer.McpIndexFtsOptimizeForTesting = null;
             McpServer.McpIndexCSharpMetadataResolveForTesting = null;
             McpServer.McpIndexTypeScriptAugmentationRebuildForTesting = null;

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -11234,6 +11234,37 @@ public sealed class Caller
     }
 
     [Fact]
+    public void ToolsCall_Index_NoOpDoesNotRebuildTypeScriptAugmentation()
+    {
+        var fixtureDir = Path.Combine(Path.GetFullPath("."), $"mcp_index_noop_ts_augmentation_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(fixtureDir);
+        var dbPath = Path.Combine(Path.GetTempPath(), $"cdidx_mcp_index_noop_ts_augmentation_{Guid.NewGuid():N}.db");
+        var rebuiltTypeScriptAugmentation = false;
+        try
+        {
+            File.WriteAllText(Path.Combine(fixtureDir, "app.ts"), "interface AppApi { run(): void; }\n");
+            using var server = new McpServer(dbPath, ConsoleUi.LoadVersion());
+
+            var firstResponse = CallIndex(server, fixtureDir);
+
+            Assert.False(firstResponse["result"]?["isError"]?.GetValue<bool>() ?? false);
+
+            McpServer.McpIndexTypeScriptAugmentationRebuildForTesting = () => rebuiltTypeScriptAugmentation = true;
+
+            var secondResponse = CallIndex(server, fixtureDir);
+
+            Assert.False(secondResponse["result"]?["isError"]?.GetValue<bool>() ?? false);
+            Assert.False(rebuiltTypeScriptAugmentation);
+        }
+        finally
+        {
+            McpServer.McpIndexTypeScriptAugmentationRebuildForTesting = null;
+            TestProjectHelper.DeleteDirectory(fixtureDir);
+            TestProjectHelper.DeleteSqliteDatabaseFiles(dbPath);
+        }
+    }
+
+    [Fact]
     public void ToolsCall_Index_ReprocessesAfterPartialSymbolKindFilterChange_Issue3543()
     {
         var fixtureDir = Path.Combine(Path.GetFullPath("."), $"mcp_index_symbol_filter_partial_{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary

- Reduce full-scan work for unchanged files by skipping redundant content reads, FTS optimization, extraction scheduling, C# metadata resolution, TypeScript augmentation rebuilds, and other no-op finalizers.
- Extend the same no-op/indexing shortcuts across CLI update mode and MCP index entry points where the existing correctness contracts allow reuse.
- Keep correctness gates for generated-file suppression, cap issues, JS/TS config changes, C# static-interface contracts, SQL graph contracts, hotspot-family readiness, and TypeScript augmentation refreshes.
- Lower sequential full-scan memory pressure by avoiding queued raw validation payloads.

## Why

Large repositories were spending substantial time and memory re-reading or finalizing unchanged rows during normal indexing runs. The changes preserve readiness and stale-data safeguards while making no-op and mostly-no-op indexes cheaper.

## Validation

- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet test CodeIndex.sln -p:UseSharedCompilation=false`
  - net8.0: 8602 passed, 6 skipped
  - net9.0: 8585 passed, 23 skipped
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check origin/main..HEAD`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Adversarial review: No blocking/actionable issues found.