### PR TITLE
[codex] Improve index file failure logging

### DIFF
--- a/changelog.d/unreleased/+index-error-logging.fixed.md
+++ b/changelog.d/unreleased/+index-error-logging.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - tests/CodeIndex.Tests/GlobalToolLogTests.cs
+---
+
+## English
+
+- **Index file failures now include sanitized stack traces in the persistent log** — per-file index exceptions now use the global tool log's stack-preserving exception formatter, making `.sql`, `.js`, and other extraction failures diagnosable without changing stderr or JSON error output.
+
+## 日本語
+
+- **インデックス対象ファイル単位の失敗で、永続ログに sanitization 済み stack trace を残すようにしました** — `.sql` や `.js` などの抽出例外を原因調査できるよう、stderr / JSON のエラー出力は変えずに global tool log の stack 付き例外フォーマッタを使います。

--- a/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.FullScan.cs
@@ -19,6 +19,9 @@ public static partial class IndexCommandRunner
     internal static string FormatPerFileErrorLine(string label, string path, Exception ex, string message) =>
         $"  [{label}] {CollapseLineBreaks(path)}: {CollapseLineBreaks(message)}";
 
+    internal static void LogIndexFileFailure(string eventName, string path, Exception ex) =>
+        GlobalToolLog.Error($"{eventName} path={CollapseLineBreaks(path)}", ex);
+
     internal static string FormatIndexFileException(Exception ex) =>
         ex switch
         {
@@ -1926,7 +1929,7 @@ public static partial class IndexCommandRunner
                     }
                     catch (Exception ex)
                     {
-                        GlobalToolLog.Error($"index_file_failed path={CollapseLineBreaks(item.FilePath)}\n{GlobalToolLog.FormatExceptionChain(ex)}");
+                        LogIndexFileFailure("index_file_failed", item.FilePath, ex);
                         errors++;
                         var errorMessage = FormatIndexFileException(ex);
                         errorList.Add(new CliJsonMessage(item.FilePath, errorMessage));

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -1027,7 +1027,7 @@ public static partial class IndexCommandRunner
                     DemoteReadinessOnce();
                     if (fileBatchMarked)
                         writer.ClearBatchInProgress();
-                    GlobalToolLog.Error($"index_update_file_failed path={CollapseLineBreaks(relPath)}\n{GlobalToolLog.FormatExceptionChain(ex)}");
+                    LogIndexFileFailure("index_update_file_failed", relPath, ex);
 
                     errors++;
                     var errorMessage = FormatIndexFileException(ex);

--- a/tests/CodeIndex.Tests/GlobalToolLogTests.cs
+++ b/tests/CodeIndex.Tests/GlobalToolLogTests.cs
@@ -631,6 +631,51 @@ public class GlobalToolLogTests
     }
 
     [Fact]
+    public void LogIndexFileFailure_WritesSanitizedStackTraceToPersistentLog()
+    {
+        var logRoot = Path.Combine(Path.GetTempPath(), $"cdidx_global_log_index_failure_{Guid.NewGuid():N}");
+        try
+        {
+            using var env = EnvironmentVariableScope.Capture(
+                "CDIDX_FORCE_GLOBAL_TOOL_LOG",
+                "CDIDX_DISABLE_PERSISTENT_LOG",
+                "CDIDX_GLOBAL_TOOL_LOG_DIR");
+            env.Set("CDIDX_FORCE_GLOBAL_TOOL_LOG", "1");
+            env.Set("CDIDX_DISABLE_PERSISTENT_LOG", null);
+            env.Set("CDIDX_GLOBAL_TOOL_LOG_DIR", logRoot);
+
+            using (GlobalToolLog.TryStartForTesting(["index", "."], "test"))
+            {
+                try
+                {
+                    ThrowForIndexFileFailureLogTest();
+                }
+                catch (Exception ex)
+                {
+                    IndexCommandRunner.LogIndexFileFailure("index_file_failed", "src/bad\nfile.js", ex);
+                }
+            }
+
+            var logPath = Assert.Single(Directory.GetFiles(logRoot, "stderr-*.log"));
+            var log = File.ReadAllText(logPath);
+            Assert.Contains("index_file_failed path=src/bad file.js", log);
+            Assert.Contains("exception[0] type=System.ArgumentException message=\"argument_error\"", log);
+            Assert.Contains("  stack: ", log);
+            Assert.Contains(nameof(ThrowForIndexFileFailureLogTest), log);
+            Assert.DoesNotContain("secret-token", log);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(logRoot);
+        }
+    }
+
+    private static void ThrowForIndexFileFailureLogTest()
+    {
+        throw new ArgumentException("secret-token");
+    }
+
+    [Fact]
     public void TryStart_ErrorMirrorIgnoresDisposedOriginalConsoleWriter()
     {
         var logRoot = Path.Combine(Path.GetTempPath(), $"cdidx_global_log_disposed_{Guid.NewGuid():N}");


### PR DESCRIPTION
## Summary

- Route per-file index failure logs through the global tool log exception formatter so persistent logs include sanitized stack traces.
- Keep stderr and JSON per-file error output unchanged, so MCP/stdout consumers still receive the short safe message.
- Add regression coverage for index file failure log stack traces and a bilingual changelog fragment.

## Root Cause

The full-scan and update per-file exception paths manually formatted `GlobalToolLog.FormatExceptionChain(ex)` without `includeStacks`, so persistent logs only had the exception type/category and not the stack needed to identify the failing extractor path.

## Validation

- `dotnet build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~GlobalToolLogTests|FullyQualifiedName~FormatPerFileErrorLine"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`