### PR TITLE
Fix changed-between stale file purge

### DIFF
--- a/changelog.d/unreleased/4056.fixed.md
+++ b/changelog.d/unreleased/4056.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 4056
+affected:
+  - src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+  - src/CodeIndex/Database/DbWriter.cs
+  - tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+---
+
+## English
+
+- **`index --changed-between` now purges stale missing rows after branch refreshes (#4056)** — changed-between updates now remove indexed files that are absent from the current worktree even when the stale row came from the previously indexed branch rather than the provided diff range.
+
+## 日本語
+
+- **`index --changed-between` がブランチ更新後の stale な missing 行を削除するようになりました (#4056)** — changed-between 更新は、stale 行が指定された diff 範囲ではなく以前に index したブランチ由来の場合でも、現在の worktree に存在しない indexed file を削除します。

--- a/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
+++ b/src/CodeIndex/Cli/IndexCommandRunner.Update.cs
@@ -1048,6 +1048,31 @@ public static partial class IndexCommandRunner
             StopIndexJsonPhaseHeartbeat(updateHeartbeat);
         }
 
+        if (options.ChangedBetweenSpecified)
+        {
+            ThrowIfUpdateCancelled();
+
+            var skipWorktreePaths = GitHelper.TryGetSkipWorktreePaths(projectRoot, cancellationToken);
+            if (skipWorktreePaths != null)
+            {
+                var purgedMissing = writer.PurgeStaleFiles(
+                    projectRoot,
+                    beforeCommit: () =>
+                    {
+                        DemoteReadinessOnce();
+                        WriteProjectRootOnce();
+                        RequireTypeScriptAugmentationRefresh();
+                    },
+                    preservedMissingPaths: skipWorktreePaths);
+                if (purgedMissing > 0)
+                {
+                    removed += purgedMissing;
+                    ftsMutated = true;
+                    WriteUpdateVerboseStatus($"  [DEL ] purged {purgedMissing:N0} missing indexed path(s) after --changed-between");
+                }
+            }
+        }
+
         ThrowIfUpdateCancelled();
         PauseUpdateSpinnerForConsoleWrite();
 

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -2166,8 +2166,15 @@ public class DbWriter
     /// ディスク上に存在しなくなったファイルをDBから削除する（ブランチ切り替え対応）。
     /// </summary>
     /// <param name="projectRoot">Absolute path to project root / プロジェクトルートの絶対パス</param>
+    /// <param name="preservedMissingPaths">
+    /// Relative DB paths that are intentionally absent from disk /
+    /// ディスク上に意図的に存在しないDB相対パス
+    /// </param>
     /// <returns>Number of stale files removed / 削除された古いファイル数</returns>
-    public int PurgeStaleFiles(string projectRoot, Action? beforeCommit = null)
+    public int PurgeStaleFiles(
+        string projectRoot,
+        Action? beforeCommit = null,
+        IReadOnlySet<string>? preservedMissingPaths = null)
     {
         // Collect all paths currently in DB / DB内の全パスを収集
         var dbPaths = LoadCurrentFilePaths();
@@ -2181,7 +2188,8 @@ public class DbWriter
             // paths (>= 248 chars) are not silently classified as stale and DELETED from the DB.
             // Without this wrap, the FileIndexer walker can index a long path successfully and
             // the next index run will purge it. See LongPath.cs and #1547.
-            if (!File.Exists(LongPath.EnsureWindowsPrefix(absolutePath)))
+            if (!File.Exists(LongPath.EnsureWindowsPrefix(absolutePath))
+                && (preservedMissingPaths == null || !preservedMissingPaths.Contains(relativePath)))
                 staleIds.Add(id);
         }
 

--- a/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexCommandRunnerTests.cs
@@ -8771,6 +8771,73 @@ public sealed class Caller
     }
 
     [Fact]
+    public void Run_UpdateMode_WithChangedBetween_PurgesMissingIndexedPathOutsideDiff_4056()
+    {
+        var projectRoot = CreateTempProject();
+        try
+        {
+            RunGit(projectRoot, "init");
+            var sourcePath = Path.Combine(projectRoot, "app.cs");
+            File.WriteAllText(sourcePath, "public class App { }\n");
+            RunGit(projectRoot, "add", ".");
+            RunGit(projectRoot, "commit", "-m", "initial");
+            RunGit(projectRoot, "branch", "before-main");
+
+            RunGit(projectRoot, "checkout", "-b", "stale-index");
+            var changelogDir = Path.Combine(projectRoot, "changelog.d", "unreleased");
+            Directory.CreateDirectory(changelogDir);
+            var stalePath = Path.Combine(changelogDir, "+changelog-empty-release-guard.fixed.md");
+            File.WriteAllText(
+                stalePath,
+                """
+                ---
+                category: fixed
+                ---
+
+                ## English
+
+                - Placeholder.
+
+                ## 日本語
+
+                - プレースホルダー。
+                """);
+            RunGit(projectRoot, "add", ".");
+            RunGit(projectRoot, "commit", "-m", "add stale branch fragment");
+
+            var initialExitCode = IndexCommandRunner.Run([projectRoot, "--json"], _jsonOptions);
+            Assert.Equal(CommandExitCodes.Success, initialExitCode);
+            var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+            Assert.Contains("changelog.d/unreleased/+changelog-empty-release-guard.fixed.md", ReadIndexedPaths(dbPath));
+
+            RunGit(projectRoot, "checkout", "-b", "main-update", "before-main");
+            File.WriteAllText(sourcePath, "public class App { public void Run() { } }\n");
+            RunGit(projectRoot, "add", "app.cs");
+            RunGit(projectRoot, "commit", "-m", "update app");
+            RunGit(projectRoot, "branch", "after-main");
+
+            var (exitCode, json) = RunAndCaptureJson([projectRoot, "--changed-between", "before-main", "after-main", "--json"]);
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal("success", json.GetProperty("status").GetString());
+            Assert.Equal(1, json.GetProperty("summary").GetProperty("updated").GetInt32());
+            Assert.Equal(1, json.GetProperty("summary").GetProperty("removed").GetInt32());
+
+            var indexedPaths = ReadIndexedPaths(dbPath);
+            Assert.DoesNotContain("changelog.d/unreleased/+changelog-empty-release-guard.fixed.md", indexedPaths);
+            Assert.Contains("app.cs", indexedPaths);
+
+            var (statusExitCode, statusJson) = RunStatusAndCaptureJson(["--db", dbPath, "--check", "--json"]);
+            Assert.Equal(CommandExitCodes.Success, statusExitCode);
+            Assert.True(statusJson.GetProperty("workspace_check").GetProperty("matches_workspace").GetBoolean());
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void Run_UpdateMode_WithChangedBetween_FallsBackToFullScanWhenIgnoreFilesChange()
     {
         var projectRoot = CreateTempProject();


### PR DESCRIPTION
## Summary

- Purge missing indexed files after `index --changed-between` finishes applying the requested diff so stale rows from the previously indexed branch do not keep `status --check` stale.
- Preserve skip-worktree paths during that post-pass so sparse checkout entries are not treated as deleted.
- Add regression coverage for a branch-only stale changelog fragment that is outside the provided diff range.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Run_UpdateMode_WithChangedBetween_PurgesMissingIndexedPathOutsideDiff_4056"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ChangedBetween"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Attempted `dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false --no-build`; it was interrupted after a long run while still running, with no failure output before interruption.

## Documentation and Changelog

- Added `changelog.d/unreleased/4056.fixed.md`.
- No README or guide updates were needed because the change restores the documented `--changed-between` refresh behavior.

## Review

- Adversarial review: No blocking/actionable issues found.
- A nested `codex exec` reviewer was attempted, but its local command execution failed before it could read the local diff, so the review was completed locally against `origin/main..HEAD`.

Fixes #4056

## Follow-up Candidates

- None.