### PR TITLE
Replace AddWithValue in symbol lookups

### DIFF
--- a/changelog.d/unreleased/4057.fixed.md
+++ b/changelog.d/unreleased/4057.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 4057
+affected:
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+---
+
+## English
+
+- **Symbol line lookups now use explicit SQLite parameter binding (#4057)** — `AnalyzeFileLine` no longer relies on `AddWithValue` inside symbol lookup queries, so the dotnet risk audit stays aligned with the repository SQLite command policy.
+
+## 日本語
+
+- **シンボル行 lookup が明示的な SQLite parameter binding を使うようになりました (#4057)** — `AnalyzeFileLine` のシンボル lookup query 内で `AddWithValue` に依存しなくなり、dotnet risk audit がリポジトリの SQLite command policy と揃うようになりました。

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -1821,13 +1821,13 @@ public partial class DbReader
             LIMIT @limit";
 
         cmd.CommandText = sql;
-        cmd.Parameters.AddWithValue("@path", path);
-        cmd.Parameters.AddWithValue("@line", line);
-        cmd.Parameters.AddWithValue("@limit", limit);
+        SqliteCommandPolicy.Add(cmd, "@path", path);
+        SqliteCommandPolicy.Add(cmd, "@line", line);
+        SqliteCommandPolicy.Add(cmd, "@limit", limit);
         if (kind != null)
-            cmd.Parameters.AddWithValue("@kind", kind);
+            SqliteCommandPolicy.Add(cmd, "@kind", kind);
         if (lang != null)
-            cmd.Parameters.AddWithValue("@lang", lang);
+            SqliteCommandPolicy.Add(cmd, "@lang", lang);
 
         var results = new List<SymbolResult>();
         using var reader = cmd.ExecuteTrackedReader();

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -2571,6 +2571,36 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void AnalyzeFileLine_WithKindAndLanguageFilters_ReturnsSymbolAtLine_Issue4057()
+    {
+        InsertIndexedFile(
+            "src/issue4057/LineLookup.cs",
+            "csharp",
+            """
+            public class LineLookup
+            {
+                public void Outside() { }
+                public void Target()
+                {
+                }
+            }
+            """);
+
+        var analysis = _reader.AnalyzeFileLine(
+            "src/issue4057/LineLookup.cs",
+            line: 5,
+            limit: 5,
+            lang: "csharp",
+            kind: "function");
+
+        var definition = Assert.Single(analysis.Definitions);
+        Assert.Equal("Target", definition.Name);
+        Assert.Equal("function", definition.Kind);
+        Assert.Equal("csharp", definition.Lang);
+        Assert.Equal("src/issue4057/LineLookup.cs", definition.Path);
+    }
+
+    [Fact]
     public void SearchSymbols_CSharpOperatorsConversionsAndIndexersUseNavigableNames()
     {
         InsertIndexedFile("src/csharp_special_names.cs", "csharp",


### PR DESCRIPTION
## Summary

- Replaced the remaining `GetSymbolsAtLine` `AddWithValue` calls with `SqliteCommandPolicy.Add` typed parameter binding.
- Added `AnalyzeFileLine` coverage for line lookup with `kind` and `lang` filters.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~AnalyzeFileLine_WithKindAndLanguageFilters_ReturnsSymbolAtLine_Issue4057"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll audit dotnet-risk-patterns --path src/ --json` (`sqlite-addwithvalue` count: 0)
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes --include src/CodeIndex/Database/DbSymbolReader.cs tests/CodeIndex.Tests/DbReaderTests.cs --no-restore`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~Extract_JavaScriptLargeExportedObjectLiteralProperties_CompletesWithinPracticalBudget" -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

Full-suite note: `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --settings tests/CodeIndex.Tests/CodeIndex.Tests.runsettings --blame-crash --blame-hang --blame-hang-timeout 5m -p:UseSharedCompilation=false` was attempted under concurrent local indexer load and hit an unrelated practical-budget timeout in `Extract_JavaScriptLargeExportedObjectLiteralProperties_CompletesWithinPracticalBudget`; the same test passed/skipped as expected when rerun directly.

## Documentation / Changelog

- Added changelog fragment: `changelog.d/unreleased/4057.fixed.md`.
- No guide or user documentation changes were needed for this internal binding-policy fix.

## Follow-up Candidates

None.

Fixes #4057
