### PR TITLE
[codex] Centralize process launch policy for workers

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -236,6 +236,14 @@ Usage: <command shape>
 
 When an error code is available, the first line is `Error [<code>]: <message>`. Use `CommandErrorWriter` for new CLI parse, validation, and filesystem preflight errors so `ProgramRunner`, `IndexCommandRunner`, and query runners keep the same format. JSON error payloads continue to use `CommandErrorJsonResult`.
 
+### Process launch policy
+
+All production subprocess launch sites must use `ProcessStartInfo.ArgumentList` and must leave `UseShellExecute` disabled. Start-info construction belongs in `ProcessLaunchPolicy` or a nearby purpose-specific helper that calls it, so git, isolated workers, hook callbacks, installer dispatch, and other subprocesses share the same argument, encoding, and no-shell defaults.
+
+Environment inheritance is opt-in. Use `SubprocessEnvironmentPolicy` for allowlisted subprocess environments: git keeps only base/proxy/certificate/git knobs and disables terminal prompts, isolated workers keep only base/.NET runtime values plus `CDIDX_TEST_` variables for tests, and installer handoff keeps only the documented installer/proxy/certificate variables. Do not add broad `CDIDX_*`, token, credential, or shell environment forwarding without documenting the trust boundary and adding tests.
+
+Every subprocess wait must have an explicit cancellation or timeout path. Captured stdout/stderr must be bounded before user-visible diagnostics, and diagnostics should be sanitized through the existing safe-formatting helpers.
+
 ### CLI output encoding and terminal controls
 
 CLI JSON output must be machine-clean: redirected stdout is written as UTF-8 without a BOM, and JSON-mode commands must not emit ANSI escape sequences even when `--color=always` or `CLICOLOR_FORCE=1` would color human output. Keep JSON-safe styling suppression close to shared formatting helpers such as `ConsoleUi.ColorizeKind` so future query output paths inherit the invariant.
@@ -2540,6 +2548,14 @@ error code がある場合、先頭行は `Error [<code>]: <message>` です。�
 validation、filesystem preflight error は `CommandErrorWriter` を使い、`ProgramRunner`、
 `IndexCommandRunner`、query runner の形式を揃えてください。JSON error payload は
 `CommandErrorJsonResult` を使い続けます。
+
+### プロセス起動ポリシー
+
+本番の subprocess 起動箇所はすべて `ProcessStartInfo.ArgumentList` を使い、`UseShellExecute` を無効のままにしてください。start-info の構築は `ProcessLaunchPolicy` またはそれを呼ぶ用途別 helper に置き、git、isolated worker、hook callback、installer dispatch、その他の subprocess が同じ argument、encoding、no-shell default を共有できるようにします。
+
+environment 継承は opt-in です。subprocess environment には `SubprocessEnvironmentPolicy` の allowlist を使ってください。git は base / proxy / certificate / git knob だけを残し terminal prompt を無効化します。isolated worker は base / .NET runtime 値と test 用の `CDIDX_TEST_` 変数だけを残します。installer handoff は文書化済みの installer / proxy / certificate 変数だけを残します。trust boundary の文書化とテストなしに、広い `CDIDX_*`、token、credential、shell environment forwarding を追加してはいけません。
+
+すべての subprocess wait には明示的な cancellation または timeout 経路が必要です。capture した stdout / stderr は user-visible diagnostic に出す前に bounded にし、diagnostic は既存の safe-formatting helper で sanitize してください。
 
 ### CLI 出力エンコーディングと端末制御
 

--- a/changelog.d/unreleased/4075.security.md
+++ b/changelog.d/unreleased/4075.security.md
@@ -1,0 +1,18 @@
+---
+category: security
+issues:
+  - 4075
+affected:
+  - src/CodeIndex/ProcessLaunchPolicy.cs
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
+  - src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Process launch construction now has a documented shared policy (#4075)** — isolated symbol and hook workers now share the same worker command/protocol argument helper, and the developer guide records the no-shell, allowlisted-environment, timeout/cancellation, and bounded-capture expectations for production subprocess launches.
+
+## 日本語
+
+- **プロセス起動構築を共有ポリシーとして文書化しました (#4075)** — isolated symbol worker と hook worker が同じ worker command / protocol argument helper を共有し、開発者ガイドに本番 subprocess 起動の no-shell、allowlisted environment、timeout / cancellation、bounded capture の期待値を記録しました。

--- a/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
+++ b/src/CodeIndex/Indexer/Hooks/PostExtractionHookCallbackWorker.cs
@@ -372,7 +372,6 @@ internal static class PostExtractionHookCallbackWorker
 {
     internal const string CommandName = "__cdidx-post-extraction-hook-callback";
     internal const int WorkerKillWaitMilliseconds = 5000;
-    private const string ProtocolMaxLineBytesOption = "--protocol-max-line-bytes";
     private const int CapturedConsoleMaxChars = 32 * 1024;
     internal static readonly JsonSerializerOptions JsonOptions =
         WorkerProtocolJsonValidator.CreateSerializerOptions(PostExtractionHookCallbackWorkerJsonContext.Default.Options);
@@ -454,10 +453,12 @@ internal static class PostExtractionHookCallbackWorker
                 typeof(PostExtractionHookCallbackWorker).Assembly))
         {
             startInfo.FileName = currentProcessPath!;
-            startInfo.ArgumentList.Add(CommandName);
-            startInfo.ArgumentList.Add(hook.AssemblyPath);
-            startInfo.ArgumentList.Add(hook.TypeName);
-            CodeIndex.ProcessLaunchPolicy.AddInvariantIntArgument(startInfo, ProtocolMaxLineBytesOption, maxProtocolLineBytes);
+            CodeIndex.ProcessLaunchPolicy.AddWorkerCommandArguments(
+                startInfo,
+                CommandName,
+                maxProtocolLineBytes,
+                hook.AssemblyPath,
+                hook.TypeName);
             error = string.Empty;
             return true;
         }
@@ -475,10 +476,12 @@ internal static class PostExtractionHookCallbackWorker
             return false;
         }
 
-        startInfo.ArgumentList.Add(CommandName);
-        startInfo.ArgumentList.Add(hook.AssemblyPath);
-        startInfo.ArgumentList.Add(hook.TypeName);
-        CodeIndex.ProcessLaunchPolicy.AddInvariantIntArgument(startInfo, ProtocolMaxLineBytesOption, maxProtocolLineBytes);
+        CodeIndex.ProcessLaunchPolicy.AddWorkerCommandArguments(
+            startInfo,
+            CommandName,
+            maxProtocolLineBytes,
+            hook.AssemblyPath,
+            hook.TypeName);
 
         error = string.Empty;
         return true;
@@ -665,7 +668,7 @@ internal static class PostExtractionHookCallbackWorker
             return true;
 
         if (args.Length == 5
-            && StringComparer.Ordinal.Equals(args[3], ProtocolMaxLineBytesOption)
+            && StringComparer.Ordinal.Equals(args[3], CodeIndex.ProcessLaunchPolicy.WorkerProtocolMaxLineBytesOption)
             && int.TryParse(args[4], NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
             && parsed > 0)
         {
@@ -674,7 +677,7 @@ internal static class PostExtractionHookCallbackWorker
             return true;
         }
 
-        error = $"post-extraction hook callback worker requires assembly path, type name, and optional `{ProtocolMaxLineBytesOption} <bytes>`.";
+        error = $"post-extraction hook callback worker requires assembly path, type name, and optional `{CodeIndex.ProcessLaunchPolicy.WorkerProtocolMaxLineBytesOption} <bytes>`.";
         return false;
     }
 

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractionWorker.cs
@@ -382,7 +382,6 @@ internal static class SymbolExtractionWorker
     internal const string CommandName = "__cdidx-symbol-extraction";
     internal const int WorkerKillWaitMilliseconds = 5000;
     internal const int MaxDelayMillisecondsForTesting = 5000;
-    private const string ProtocolMaxLineBytesOption = "--protocol-max-line-bytes";
     private const string TestDelayMillisecondsOption = "--test-delay-ms";
     private const string TestConsoleStdoutOption = "--test-console-stdout";
     private const int CapturedConsoleMaxChars = 32 * 1024;
@@ -457,8 +456,7 @@ internal static class SymbolExtractionWorker
                 typeof(SymbolExtractionWorker).Assembly))
         {
             startInfo.FileName = currentProcessPath!;
-            startInfo.ArgumentList.Add(CommandName);
-            CodeIndex.ProcessLaunchPolicy.AddInvariantIntArgument(startInfo, ProtocolMaxLineBytesOption, maxProtocolLineBytes);
+            CodeIndex.ProcessLaunchPolicy.AddWorkerCommandArguments(startInfo, CommandName, maxProtocolLineBytes);
             AddTestingArguments(startInfo);
             error = string.Empty;
             return true;
@@ -477,8 +475,7 @@ internal static class SymbolExtractionWorker
             return false;
         }
 
-        startInfo.ArgumentList.Add(CommandName);
-        CodeIndex.ProcessLaunchPolicy.AddInvariantIntArgument(startInfo, ProtocolMaxLineBytesOption, maxProtocolLineBytes);
+        CodeIndex.ProcessLaunchPolicy.AddWorkerCommandArguments(startInfo, CommandName, maxProtocolLineBytes);
         AddTestingArguments(startInfo);
 
         error = string.Empty;
@@ -697,7 +694,7 @@ internal static class SymbolExtractionWorker
             }
 
             var value = args[++index];
-            if (StringComparer.Ordinal.Equals(option, ProtocolMaxLineBytesOption)
+            if (StringComparer.Ordinal.Equals(option, CodeIndex.ProcessLaunchPolicy.WorkerProtocolMaxLineBytesOption)
                 && int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var protocolBytes)
                 && protocolBytes > 0)
             {
@@ -734,7 +731,7 @@ internal static class SymbolExtractionWorker
 
     private static string BuildWorkerOptionError()
         => "symbol extraction worker accepts only "
-            + $"`{ProtocolMaxLineBytesOption} <bytes>`, "
+            + $"`{CodeIndex.ProcessLaunchPolicy.WorkerProtocolMaxLineBytesOption} <bytes>`, "
             + $"`{TestDelayMillisecondsOption} <milliseconds>`, or "
             + $"`{TestConsoleStdoutOption} <text>`.";
 

--- a/src/CodeIndex/ProcessLaunchPolicy.cs
+++ b/src/CodeIndex/ProcessLaunchPolicy.cs
@@ -6,6 +6,8 @@ namespace CodeIndex;
 
 internal static class ProcessLaunchPolicy
 {
+    internal const string WorkerProtocolMaxLineBytesOption = "--protocol-max-line-bytes";
+
     internal static ProcessStartInfo CreateNoShellStartInfo(
         string? fileName = null,
         string? workingDirectory = null,
@@ -53,5 +55,16 @@ internal static class ProcessLaunchPolicy
     {
         startInfo.ArgumentList.Add(optionName);
         startInfo.ArgumentList.Add(value.ToString(CultureInfo.InvariantCulture));
+    }
+
+    internal static void AddWorkerCommandArguments(
+        ProcessStartInfo startInfo,
+        string commandName,
+        int maxProtocolLineBytes,
+        params string[] commandArguments)
+    {
+        startInfo.ArgumentList.Add(commandName);
+        AddArguments(startInfo, commandArguments);
+        AddInvariantIntArgument(startInfo, WorkerProtocolMaxLineBytesOption, maxProtocolLineBytes);
     }
 }

--- a/tests/CodeIndex.Tests/ProcessLaunchPolicyTests.cs
+++ b/tests/CodeIndex.Tests/ProcessLaunchPolicyTests.cs
@@ -36,6 +36,30 @@ public class ProcessLaunchPolicyTests
     }
 
     [Fact]
+    public void AddWorkerCommandArguments_AppendsCommandPayloadAndProtocolLimit_Issue4075()
+    {
+        var startInfo = ProcessLaunchPolicy.CreateNoShellStartInfo();
+
+        ProcessLaunchPolicy.AddWorkerCommandArguments(
+            startInfo,
+            "__cdidx-worker",
+            16384,
+            "/tmp/hook.dll",
+            "Demo.Hook");
+
+        Assert.Equal(
+            [
+                "__cdidx-worker",
+                "/tmp/hook.dll",
+                "Demo.Hook",
+                ProcessLaunchPolicy.WorkerProtocolMaxLineBytesOption,
+                "16384",
+            ],
+            startInfo.ArgumentList.ToArray());
+        Assert.Equal(string.Empty, startInfo.Arguments);
+    }
+
+    [Fact]
     public void CreateUtf8RedirectedWorkerStartInfo_DisablesShellAndUsesUtf8NoBom_Issue3991()
     {
         var startInfo = ProcessLaunchPolicy.CreateUtf8RedirectedWorkerStartInfo();


### PR DESCRIPTION
## Summary

- Centralizes isolated worker command/protocol argument construction in `ProcessLaunchPolicy`.
- Keeps symbol and post-extraction hook worker launch argument ordering unchanged while sharing the protocol option constant.
- Documents the production subprocess launch policy in both English and Japanese developer-guide sections.

## Launch-Site Classification

- Git: `GitHelper` uses trusted git resolution, no shell, git-specific environment allowlist, bounded capture, and timeout/cancellation.
- Program dispatch / installer handoff: `ProgramRunner` uses trusted bash resolution, no shell, installer environment allowlist, timeout/cancellation, and bounded suppressed output capture.
- Symbol worker: `SymbolExtractionWorker` uses isolated worker defaults and shared worker command/protocol arguments.
- Hook callback worker: `PostExtractionHookCallbackWorker` uses isolated worker defaults, hook assembly/type arguments, and shared worker command/protocol arguments.
- Isolated worker launcher: `IsolatedWorkerProcessLauncher` centralizes worker stdio/UTF-8/no-shell defaults and dotnet host preparation.
- Subprocess environment policy: `SubprocessEnvironmentPolicy` owns git, installer, and isolated-worker environment allowlists.
- Shared launch policy: `ProcessLaunchPolicy` owns no-shell start-info defaults and worker protocol argument construction.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~ProcessLaunchPolicyTests|FullyQualifiedName~SymbolExtractionWorker_StartInfo|FullyQualifiedName~PostExtractionHookCallbackWorker_StartInfo|FullyQualifiedName~IsolatedWorkers_StartInfo"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore`
- `dotnet build`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search --recipe risky-code/process-start-info --path src/ --exclude-tests --count-by file --limit 80`

## Documentation and Changelog

- Updated `DEVELOPER_GUIDE.md` in English and Japanese.
- Added `changelog.d/unreleased/4075.security.md`.

## Review

- Adversarial review: No blocking/actionable issues found.

## Follow-up Candidates

- None.

Fixes #4075