### PR TITLE
[codex] Fix watch JSON contract consistency

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -242,9 +242,10 @@ CLI JSON output must be machine-clean: redirected stdout is written as UTF-8 wit
 
 JSON serialization sites are split by contract domain. Public CLI JSON uses
 `ProgramRunner.CreateDefaultJsonOptions()` and `CliJsonSerializerContext`: field
-names are snake_case, nulls are omitted, top-level event/result DTOs carry
-`api_version`, and DOM-built `JsonObject` payloads may add only sanitized,
-bounded fields. MCP JSON-RPC uses `McpServer`'s camelCase options for the
+names are snake_case, nulls are omitted, audited public top-level event/result
+DTOs carry `api_version`, and DOM-built `JsonObject` payloads may add only
+sanitized, bounded fields. Add `api_version` when introducing or auditing a
+public top-level CLI JSON DTO. MCP JSON-RPC uses `McpServer`'s camelCase options for the
 protocol envelope while tool structured content keeps its documented
 machine-readable keys; sanitize/redact values before mutating `JsonObject` /
 `JsonNode` instances. LSP, quickfix, and SARIF outputs follow their external
@@ -2566,8 +2567,9 @@ invariant を継承できるようにしてください。
 
 JSON serialization site は contract domain ごとに分けます。公開 CLI JSON は
 `ProgramRunner.CreateDefaultJsonOptions()` と `CliJsonSerializerContext` を使います。field name は
-snake_case、null は省略、top-level event/result DTO は `api_version` を持ち、DOM で組み立てる
-`JsonObject` payload は sanitized / bounded 済み field だけを追加します。MCP JSON-RPC は
+snake_case、null は省略、audit 済みの公開 top-level event/result DTO は `api_version` を持ち、
+DOM で組み立てる `JsonObject` payload は sanitized / bounded 済み field だけを追加します。
+公開 top-level CLI JSON DTO を追加または audit するときは `api_version` を追加してください。MCP JSON-RPC は
 protocol envelope に `McpServer` の camelCase option を使い、tool structured content は文書化済みの
 machine-readable key を保ちます。`JsonObject` / `JsonNode` を mutate する前に値を sanitize /
 redact してください。LSP、quickfix、SARIF 出力は CLI snake_case contract ではなく外部 schema に

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -240,6 +240,21 @@ When an error code is available, the first line is `Error [<code>]: <message>`. 
 
 CLI JSON output must be machine-clean: redirected stdout is written as UTF-8 without a BOM, and JSON-mode commands must not emit ANSI escape sequences even when `--color=always` or `CLICOLOR_FORCE=1` would color human output. Keep JSON-safe styling suppression close to shared formatting helpers such as `ConsoleUi.ColorizeKind` so future query output paths inherit the invariant.
 
+JSON serialization sites are split by contract domain. Public CLI JSON uses
+`ProgramRunner.CreateDefaultJsonOptions()` and `CliJsonSerializerContext`: field
+names are snake_case, nulls are omitted, top-level event/result DTOs carry
+`api_version`, and DOM-built `JsonObject` payloads may add only sanitized,
+bounded fields. MCP JSON-RPC uses `McpServer`'s camelCase options for the
+protocol envelope while tool structured content keeps its documented
+machine-readable keys; sanitize/redact values before mutating `JsonObject` /
+`JsonNode` instances. LSP, quickfix, and SARIF outputs follow their external
+schemas rather than the CLI snake_case contract. GitHub/report helpers and
+worker/private storage paths use their own bounded serializers because they are
+either API clients, persisted local state, or process-internal protocols. The
+`LocalJsonlJsonWriterOptions` relaxed encoder is intentionally limited to
+private append-only JSONL diagnostics and must not be reused for public CLI,
+MCP, LSP, HTTP, or embeddable JSON.
+
 `cdidx export ctags --json` follows the same contract: stdout contains only a
 single JSON summary or structured error, while the tag file itself remains the
 artifact. The summary includes resolved output/database paths, tag/emitted/
@@ -2548,6 +2563,18 @@ CLI JSON output は機械処理向けにきれいでなければなりません�
 場合でも ANSI escape sequence を出してはいけません。JSON-safe styling suppression は
 `ConsoleUi.ColorizeKind` など共有 formatter の近くに置き、将来の query output path も同じ
 invariant を継承できるようにしてください。
+
+JSON serialization site は contract domain ごとに分けます。公開 CLI JSON は
+`ProgramRunner.CreateDefaultJsonOptions()` と `CliJsonSerializerContext` を使います。field name は
+snake_case、null は省略、top-level event/result DTO は `api_version` を持ち、DOM で組み立てる
+`JsonObject` payload は sanitized / bounded 済み field だけを追加します。MCP JSON-RPC は
+protocol envelope に `McpServer` の camelCase option を使い、tool structured content は文書化済みの
+machine-readable key を保ちます。`JsonObject` / `JsonNode` を mutate する前に値を sanitize /
+redact してください。LSP、quickfix、SARIF 出力は CLI snake_case contract ではなく外部 schema に
+従います。GitHub/report helper と worker/private storage path は API client、永続化ローカル状態、
+process-internal protocol のいずれかなので、それぞれの bounded serializer を使います。
+`LocalJsonlJsonWriterOptions` の relaxed encoder は private append-only JSONL diagnostic 専用であり、
+公開 CLI、MCP、LSP、HTTP、埋め込み可能な JSON に再利用してはいけません。
 
 `cdidx export ctags --json` も同じ contract に従います。stdout は単一の JSON summary または
 structured error だけを含み、tags file 自体は artifact として残します。summary には解決済みの

--- a/changelog.d/unreleased/4077.fixed.md
+++ b/changelog.d/unreleased/4077.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 4077
+affected:
+  - src/CodeIndex/Cli/IndexWatchRunner.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Watch JSON events now follow the shared CLI JSON contract (#4077)** — `index --watch --json` lifecycle events include `api_version`, honor the caller's JSON serializer options such as `--pretty`, and the developer guide now classifies CLI, MCP, LSP, GitHub/report, worker, and local JSONL contract domains.
+
+## 日本語
+
+- **watch JSON event が共有 CLI JSON contract に従うようになりました (#4077)** — `index --watch --json` の lifecycle event に `api_version` を追加し、`--pretty` など呼び出し元の JSON serializer option を尊重するようにしました。また developer guide で CLI、MCP、LSP、GitHub/report、worker、local JSONL の contract domain を分類しました。

--- a/src/CodeIndex/Cli/IndexWatchRunner.cs
+++ b/src/CodeIndex/Cli/IndexWatchRunner.cs
@@ -147,7 +147,7 @@ internal static class IndexWatchRunner
 
             watcher.EnableRaisingEvents = true;
 
-            EmitWatchStarted(baseOptions, projectRoot, resolvedDbPath, debounce, maxPendingPaths);
+            EmitWatchStarted(baseOptions, jsonOptions, projectRoot, resolvedDbPath, debounce, maxPendingPaths);
 
             while (!cancellationToken.IsCancellationRequested)
             {
@@ -165,7 +165,7 @@ internal static class IndexWatchRunner
 
                 if (fullRescan)
                 {
-                    EmitWatchOverflow(baseOptions, overflowReason, resolvedDbPath);
+                    EmitWatchOverflow(baseOptions, jsonOptions, overflowReason, resolvedDbPath);
                     RecordSubRunExitCode(ref watchExitCode, RunFullRescan(baseOptions, jsonOptions, resolvedDbPath));
                     continue;
                 }
@@ -185,7 +185,7 @@ internal static class IndexWatchRunner
             }
         }
 
-        EmitWatchStopped(baseOptions);
+        EmitWatchStopped(baseOptions, jsonOptions);
         return watchExitCode;
     }
 
@@ -694,6 +694,7 @@ internal static class IndexWatchRunner
 
     private static void EmitWatchStarted(
         IndexCommandOptions baseOptions,
+        JsonSerializerOptions jsonOptions,
         string projectRoot,
         string resolvedDbPath,
         TimeSpan debounce,
@@ -701,10 +702,6 @@ internal static class IndexWatchRunner
     {
         if (baseOptions.Json)
         {
-            var jsonOpts = new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
-            };
             Console.Out.WriteLine(JsonSerializer.Serialize(new IndexWatchEventJsonResult
             {
                 Status = "watching",
@@ -713,7 +710,7 @@ internal static class IndexWatchRunner
                 Db = "[redacted]",
                 DebounceMs = (int)debounce.TotalMilliseconds,
                 WatchPendingPathLimit = maxPendingPaths,
-            }, CliJsonSerializerContextFactory.Create(jsonOpts).IndexWatchEventJsonResult));
+            }, CliJsonSerializerContextFactory.Create(jsonOptions).IndexWatchEventJsonResult));
         }
         else
         {
@@ -722,15 +719,15 @@ internal static class IndexWatchRunner
         }
     }
 
-    private static void EmitWatchOverflow(IndexCommandOptions baseOptions, string? reason, string resolvedDbPath)
+    private static void EmitWatchOverflow(
+        IndexCommandOptions baseOptions,
+        JsonSerializerOptions jsonOptions,
+        string? reason,
+        string resolvedDbPath)
     {
         var safeReason = FormatWatchDiagnosticText(reason);
         if (baseOptions.Json)
         {
-            var jsonOpts = new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
-            };
             Console.Out.WriteLine(JsonSerializer.Serialize(new IndexWatchEventJsonResult
             {
                 Status = "overflow",
@@ -739,7 +736,7 @@ internal static class IndexWatchRunner
                 OverflowReason = safeReason,
                 WatchPendingPathLimit = baseOptions.WatchPendingPathLimit,
                 RecoveryCommand = BuildOverflowRecoveryCommand(baseOptions, resolvedDbPath, redactPaths: true),
-            }, CliJsonSerializerContextFactory.Create(jsonOpts).IndexWatchEventJsonResult));
+            }, CliJsonSerializerContextFactory.Create(jsonOptions).IndexWatchEventJsonResult));
         }
         else
         {
@@ -748,18 +745,14 @@ internal static class IndexWatchRunner
         }
     }
 
-    private static void EmitWatchStopped(IndexCommandOptions baseOptions)
+    private static void EmitWatchStopped(IndexCommandOptions baseOptions, JsonSerializerOptions jsonOptions)
     {
         if (baseOptions.Json)
         {
-            var jsonOpts = new JsonSerializerOptions
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
-            };
             Console.Out.WriteLine(JsonSerializer.Serialize(new IndexWatchEventJsonResult
             {
                 Status = "stopped",
-            }, CliJsonSerializerContextFactory.Create(jsonOpts).IndexWatchEventJsonResult));
+            }, CliJsonSerializerContextFactory.Create(jsonOptions).IndexWatchEventJsonResult));
         }
         else
         {

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -450,6 +450,7 @@ internal sealed class IndexDryRunJsonResult
 
 internal sealed class IndexWatchEventJsonResult
 {
+    public string ApiVersion { get; init; } = JsonOutputContract.ApiVersion;
     public string Status { get; init; } = string.Empty;
     public string? Phase { get; init; }
     public string? ProjectRoot { get; init; }

--- a/tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
@@ -493,7 +493,7 @@ public class IndexWatchRunnerTests
             Console.SetOut(stdout);
             try
             {
-                method.Invoke(null, [options, "buffer full", resolvedDbPath]);
+                method.Invoke(null, [options, _jsonOptions, "buffer full", resolvedDbPath]);
             }
             finally
             {
@@ -503,6 +503,7 @@ public class IndexWatchRunnerTests
         }
 
         using var doc = JsonDocument.Parse(capturedOut);
+        Assert.Equal(JsonOutputContract.ApiVersion, doc.RootElement.GetProperty("api_version").GetString());
         Assert.Equal("overflow", doc.RootElement.GetProperty("status").GetString());
         Assert.Equal("incremental", doc.RootElement.GetProperty("phase").GetString());
         Assert.Equal("buffer full", doc.RootElement.GetProperty("overflow_reason").GetString());
@@ -660,9 +661,80 @@ public class IndexWatchRunnerTests
             Assert.DoesNotContain(projectRoot, watchingLine);
             Assert.DoesNotContain(dbPath, watchingLine);
             using var watchStarted = JsonDocument.Parse(watchingLine);
+            Assert.Equal(JsonOutputContract.ApiVersion, watchStarted.RootElement.GetProperty("api_version").GetString());
             Assert.Equal("[redacted]", watchStarted.RootElement.GetProperty("project_root").GetString());
             Assert.Equal("[redacted]", watchStarted.RootElement.GetProperty("db").GetString());
             Assert.Equal(123, watchStarted.RootElement.GetProperty("watch_pending_path_limit").GetInt32());
+        }
+        finally
+        {
+            DeleteDirectory(projectRoot);
+            SqliteConnection.ClearAllPools();
+            if (File.Exists(dbPath))
+                File.Delete(dbPath);
+        }
+    }
+
+    [Fact]
+    public void RunCore_JsonLifecycleEventsHonorIndentedJsonOptions()
+    {
+        var projectRoot = CreateTempProject();
+        var dbPath = Path.Combine(projectRoot, ".cdidx", "codeindex.db");
+        try
+        {
+            File.WriteAllText(Path.Combine(projectRoot, "hello.py"), "print('hi')\n");
+            var prebuildJson = RunIndexAndCapture([projectRoot, "--db", dbPath, "--json"], out var prebuildExit);
+            Assert.Equal(CommandExitCodes.Success, prebuildExit);
+
+            var options = new IndexCommandOptions
+            {
+                ProjectPath = projectRoot,
+                DbPath = dbPath,
+                Json = true,
+                Watch = true,
+                WatchDebounceMs = 50,
+            };
+            var indentedOptions = new JsonSerializerOptions(_jsonOptions)
+            {
+                WriteIndented = true,
+            };
+
+            using var cts = new CancellationTokenSource();
+            string capturedOut;
+            int exitCode;
+
+            lock (TestConsoleLock.Gate)
+            {
+                var originalOut = Console.Out;
+                using var stdout = new SignalingStringWriter(
+                    line => line.Contains("\"status\": \"watching\"", StringComparison.Ordinal));
+                Task<int>? loopTask = null;
+                Console.SetOut(stdout);
+                try
+                {
+                    loopTask = StartWatchLoop(options, projectRoot, dbPath, cts.Token, indentedOptions);
+                    var started = stdout.WaitForSignal(TimeSpan.FromSeconds(10));
+                    cts.Cancel();
+                    Assert.True(started,
+                        "Watch loop did not emit the indented watching event before cancellation / 取り消し前に indented watching イベントが出力されなかった");
+#pragma warning disable xUnit1031
+                    Assert.True(loopTask.Wait(TimeSpan.FromSeconds(10)));
+                    exitCode = loopTask.Result;
+#pragma warning restore xUnit1031
+                }
+                finally
+                {
+                    CancelAndDrainWatchLoop(cts, loopTask);
+                    Console.SetOut(originalOut);
+                }
+                capturedOut = stdout.ToString();
+            }
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            var normalized = capturedOut.Replace("\r\n", "\n", StringComparison.Ordinal);
+            Assert.Contains("{\n  \"api_version\": \"" + JsonOutputContract.ApiVersion + "\"", normalized, StringComparison.Ordinal);
+            Assert.Contains("\n  \"status\": \"watching\"", normalized, StringComparison.Ordinal);
+            Assert.Contains("\n  \"status\": \"stopped\"", normalized, StringComparison.Ordinal);
         }
         finally
         {
@@ -780,12 +852,13 @@ public class IndexWatchRunnerTests
         IndexCommandOptions options,
         string projectRoot,
         string dbPath,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        JsonSerializerOptions? jsonOptions = null)
     {
         // Run the watcher on a dedicated thread so this cancellation test does not depend on
         // ThreadPool availability during the full test suite.
         return Task.Factory.StartNew(
-            () => IndexWatchRunner.RunCore(options, _jsonOptions, projectRoot, dbPath, cancellationToken),
+            () => IndexWatchRunner.RunCore(options, jsonOptions ?? _jsonOptions, projectRoot, dbPath, cancellationToken),
             CancellationToken.None,
             TaskCreationOptions.LongRunning,
             TaskScheduler.Default);


### PR DESCRIPTION
## Summary

- Add `api_version` to `index --watch --json` lifecycle events.
- Route watch lifecycle JSON through the caller-provided CLI serializer options so `--pretty` and shared source-generated options are honored consistently.
- Document the JSON contract domains for CLI, MCP, LSP, GitHub/report helpers, worker/private storage, and local JSONL diagnostics.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~IndexWatchRunnerTests -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --no-build --filter FullyQualifiedName~IndexWatchRunnerTests`
- `dotnet build -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Docs and Changelog

- Updated `DEVELOPER_GUIDE.md` in both English and Japanese sections.
- Added `changelog.d/unreleased/4077.fixed.md`.

## Review

Adversarial review found an over-broad developer-guide statement about `api_version` coverage. The wording was tightened to audited public top-level CLI JSON DTOs before opening this PR. No remaining blocking/actionable issues found.

Fixes #4077