### PR TITLE
Fix path case policy for map and impact

### DIFF
--- a/changelog.d/unreleased/4071.fixed.md
+++ b/changelog.d/unreleased/4071.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 4071
+affected:
+  - src/CodeIndex/Database/DbReader.FilesStatus.cs
+  - src/CodeIndex/Database/DbReader.GraphQueries.cs
+  - src/CodeIndex/Database/RepoMapBuilder.cs
+  - tests/CodeIndex.Tests/DbReaderTests.cs
+  - docs/path-comparison-audit.md
+---
+
+## English
+
+- **Path-sensitive `map` and `impact` results now honor indexed filesystem case policy (#4071)** — case-sensitive workspaces keep case-variant indexed paths distinct for entrypoint fallback and impact definition-file ambiguity, while legacy and case-insensitive indexes keep the previous collapsed behavior. The audit classification for path comparison and normalization domains is documented in `docs/path-comparison-audit.md`.
+
+## 日本語
+
+- **path-sensitive な `map` と `impact` の結果が indexed filesystem の大小区別ポリシーを尊重するようになりました (#4071)** — case-sensitive な workspace では entrypoint fallback と impact の definition file 曖昧性判定で case variant の indexed path を別物として扱い、legacy / case-insensitive な index では従来どおり畳み込む挙動を維持します。パス比較と正規化 domain の監査分類は `docs/path-comparison-audit.md` に記録しました。

--- a/docs/path-comparison-audit.md
+++ b/docs/path-comparison-audit.md
@@ -1,0 +1,60 @@
+# Path Comparison And Normalization Audit
+
+> **[日本語版はこちら / Japanese version](#パス比較と正規化の監査)**
+
+This note records the issue #4071 audit classification for high-count
+`OrdinalIgnoreCase` and `Path.GetFullPath` hits. It distinguishes path equality
+from intentionally case-insensitive protocol, option, schema, and language
+domains.
+
+## English
+
+### Domain Classification
+
+| Domain | Representative files | Policy |
+|---|---|---|
+| Indexed path equality and path sets | `DbReader.GraphQueries`, `RepoMapBuilder` | Use the persisted `workspace_path_case_sensitive` / `path_case_sensitive` stamp. Case-sensitive indexes keep `Foo.cs` and `foo.cs` distinct; legacy or case-insensitive indexes preserve the historical case-insensitive behavior. |
+| Workspace and cleanup boundaries | `PathCasing`, `FileSystemBoundary`, `DbPathResolver`, `DataDirectorySecurity`, `McpPathBoundary`, `LspServer` | Normalize with `Path.GetFullPath`, then compare through `PathCasing` / `FileSystemBoundary` so containment follows the probed filesystem case policy. Cleanup targets also reject symlink, reparse-point, and device targets where deletion could cross a boundary. |
+| URI and SQLite sidecar paths | `FileUriPolicy`, `PathUriNormalizer`, `DbPathResolver`, `ExportImportCommandRunner`, `SqliteConnectionPolicy` | Reject encoded URI path-boundary characters before normalization. SQLite DB sidecar overlap checks use both the live filesystem comparison and the stored DB path-case stamp when available. |
+| Extension and filename conventions | `FileIndexer`, `FileIndexer.FileNameLanguages`, `FileIndexer.DefaultExclusions`, `SymbolExtractor.TypeScriptPathAliases` | Keep case-insensitive matching because these are language, extension, generated-file, and cross-platform convention domains, not file identity comparisons. |
+| Language and schema identifiers | `ReferenceExtractor`, `LanguageReferenceExtractionSupport`, `SqlReferenceExtractor`, `DbSearchReader`, `DbSymbolReader`, `DbSchemaCache`, `RepoMapBuilder` name hints | Keep case-insensitive comparison where the language, SQL schema, SQLite schema, search-token, or entrypoint-name contract is case-insensitive. |
+| CLI, MCP, labels, headers, and recipes | `QueryCommandRunner`, `ProgramRunner`, `McpToolHandlers`, `HttpMcpTransport`, `IssueDuplicatePreflight`, `GitHubIssueReporter`, `SearchAuditRecipes` | Keep case-insensitive matching for protocol tokens, option values, JSON formats, labels, HTTP headers, recipe names, and GitHub metadata. |
+| Plugin, hook, and configured extractor paths | `ExtractorPluginRegistry`, `PostExtractionHooks`, `LanguageMapOverrides` | Normalize discovered paths, apply explicit trust-boundary checks, and reject unsafe symlink/reparse overrides where applicable. Registry-local duplicate suppression is not a workspace path-equality decision; new user-visible path identity checks should use `PathCasing` / `FileSystemBoundary`. |
+
+### Changes From This Audit
+
+- `map` entrypoint fallback de-duplication now uses the indexed workspace path
+  case policy instead of always using `OrdinalIgnoreCase`.
+- `impact` definition-file ambiguity now uses the same indexed workspace path
+  case policy instead of collapsing case-variant paths unconditionally.
+- Regression tests cover both case-sensitive and case-insensitive indexed
+  workspace behavior for these path sets.
+
+---
+
+<a id="パス比較と正規化の監査"></a>
+# パス比較と正規化の監査
+
+このメモは issue #4071 の監査分類を記録します。高頻度の
+`OrdinalIgnoreCase` と `Path.GetFullPath` の検出結果について、パス同一性の判定と、
+プロトコル、オプション、スキーマ、言語など意図的に case-insensitive な領域を分けます。
+
+## 日本語
+
+### 領域分類
+
+| 領域 | 代表ファイル | 方針 |
+|---|---|---|
+| indexed path の同一性と path set | `DbReader.GraphQueries`, `RepoMapBuilder` | 永続化された `workspace_path_case_sensitive` / `path_case_sensitive` stamp を使う。case-sensitive な index では `Foo.cs` と `foo.cs` を別 path として扱い、legacy または case-insensitive な index では従来どおり case-insensitive に扱う。 |
+| workspace と cleanup boundary | `PathCasing`, `FileSystemBoundary`, `DbPathResolver`, `DataDirectorySecurity`, `McpPathBoundary`, `LspServer` | `Path.GetFullPath` で正規化したあと、`PathCasing` / `FileSystemBoundary` 経由で比較し、containment を実 FS の大小区別ポリシーに合わせる。削除系 target は boundary を越え得る symlink、reparse point、device も拒否する。 |
+| URI と SQLite sidecar path | `FileUriPolicy`, `PathUriNormalizer`, `DbPathResolver`, `ExportImportCommandRunner`, `SqliteConnectionPolicy` | 正規化前に encoded URI path boundary 文字を拒否する。SQLite DB sidecar の重なり判定は、利用可能なら live filesystem comparison と保存済み DB path-case stamp の両方を使う。 |
+| 拡張子とファイル名の慣習 | `FileIndexer`, `FileIndexer.FileNameLanguages`, `FileIndexer.DefaultExclusions`, `SymbolExtractor.TypeScriptPathAliases` | ここは file identity ではなく、言語、拡張子、generated file、cross-platform convention の領域なので case-insensitive のままにする。 |
+| 言語・schema identifier | `ReferenceExtractor`, `LanguageReferenceExtractionSupport`, `SqlReferenceExtractor`, `DbSearchReader`, `DbSymbolReader`, `DbSchemaCache`, `RepoMapBuilder` name hints | 言語、SQL schema、SQLite schema、search token、entrypoint name の契約が case-insensitive な箇所は case-insensitive のままにする。 |
+| CLI、MCP、label、header、recipe | `QueryCommandRunner`, `ProgramRunner`, `McpToolHandlers`, `HttpMcpTransport`, `IssueDuplicatePreflight`, `GitHubIssueReporter`, `SearchAuditRecipes` | protocol token、option value、JSON format、label、HTTP header、recipe name、GitHub metadata は case-insensitive matching を維持する。 |
+| plugin、hook、configured extractor path | `ExtractorPluginRegistry`, `PostExtractionHooks`, `LanguageMapOverrides` | discovery path を正規化し、明示的な trust-boundary check を適用する。該当する override では unsafe な symlink / reparse point を拒否する。registry 内部の duplicate suppression は workspace path equality ではないため、新しいユーザー可視の path identity 判定では `PathCasing` / `FileSystemBoundary` を使う。 |
+
+### この監査での変更
+
+- `map` の entrypoint fallback 重複排除は、常に `OrdinalIgnoreCase` を使うのではなく、indexed workspace の path case policy を使うようになった。
+- `impact` の definition file 曖昧性判定も同じ indexed workspace path case policy を使い、case variant path を無条件に畳み込まないようになった。
+- これらの path set について、case-sensitive / case-insensitive 両方の indexed workspace 挙動を regression test で固定した。

--- a/src/CodeIndex/Database/DbReader.FilesStatus.cs
+++ b/src/CodeIndex/Database/DbReader.FilesStatus.cs
@@ -929,7 +929,7 @@ public partial class DbReader
     /// </summary>
     public RepoMapResult GetRepoMap(int limit = 10, string? lang = null, IReadOnlyList<string>? pathPatterns = null, IReadOnlyList<string>? excludePathPatterns = null, bool excludeTests = false, double minEntrypointConfidence = 0)
     {
-        var builder = new RepoMapBuilder(_conn, _fileColumns, _hasReferencesTable);
+        var builder = new RepoMapBuilder(_conn, _fileColumns, _hasReferencesTable, GetIndexedPathComparer);
         return builder.Build(limit, lang, pathPatterns, excludePathPatterns, excludeTests, minEntrypointConfidence, GetWorkspaceFreshness);
     }
 
@@ -1120,6 +1120,14 @@ public partial class DbReader
             ExecuteNullableDateTime(_fileColumns.Contains("indexed_at") ? "SELECT MAX(indexed_at) FROM files" : null),
             ExecuteNullableDateTime(_fileColumns.Contains("modified") ? "SELECT MAX(modified) FROM files" : null)
         );
+    }
+
+    private StringComparer GetIndexedPathComparer()
+    {
+        var pathCaseSensitive = ParseMetaBool(TryGetMetaStringInternal(DbContext.WorkspacePathCaseSensitiveMetaKey));
+        return pathCaseSensitive == true
+            ? StringComparer.Ordinal
+            : StringComparer.OrdinalIgnoreCase;
     }
 
     private DateTime? ExecuteNullableDateTime(string? sql)

--- a/src/CodeIndex/Database/DbReader.GraphQueries.cs
+++ b/src/CodeIndex/Database/DbReader.GraphQueries.cs
@@ -1769,9 +1769,10 @@ public partial class DbReader
         lang = NormalizeQueryLanguage(lang);
         var resolvedName = ResolveSymbolName(symbolName, lang);
         var definitions = ResolveImpactDefinitions(resolvedName, lang, pathPatterns, excludePathPatterns, excludeTests);
+        var indexedPathComparer = GetIndexedPathComparer();
         var definitionPaths = definitions
             .Select(d => d.Path)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Distinct(indexedPathComparer)
             .ToList();
         var hasMultipleDefinitions = definitions.Count > 1;
         var fallbackDefinitions = definitions
@@ -1779,7 +1780,7 @@ public partial class DbReader
             .ToList();
         var fallbackDefinitionPaths = fallbackDefinitions
             .Select(d => d.Path)
-            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Distinct(indexedPathComparer)
             .ToList();
         var hasMultipleFallbackDefinitions = fallbackDefinitions.Count > 1;
         var hasMultipleFallbackDefinitionFiles = fallbackDefinitionPaths.Count > 1;

--- a/src/CodeIndex/Database/RepoMapBuilder.cs
+++ b/src/CodeIndex/Database/RepoMapBuilder.cs
@@ -12,6 +12,7 @@ internal sealed class RepoMapBuilder
 {
     private readonly SqliteConnection _conn;
     private readonly HashSet<string> _fileColumns;
+    private readonly Func<StringComparer> _getIndexedPathComparer;
 
     private static readonly Dictionary<string, string[]> EntrypointNameHints = new(StringComparer.OrdinalIgnoreCase)
     {
@@ -64,11 +65,12 @@ internal sealed class RepoMapBuilder
 
     private readonly bool _hasReferencesTable;
 
-    public RepoMapBuilder(SqliteConnection connection, HashSet<string> fileColumns, bool hasReferencesTable)
+    public RepoMapBuilder(SqliteConnection connection, HashSet<string> fileColumns, bool hasReferencesTable, Func<StringComparer> getIndexedPathComparer)
     {
         _conn = connection;
         _fileColumns = fileColumns;
         _hasReferencesTable = hasReferencesTable;
+        _getIndexedPathComparer = getIndexedPathComparer;
     }
 
     /// <summary>
@@ -96,6 +98,7 @@ internal sealed class RepoMapBuilder
         // file stats / workspace freshness / entrypoint 取得が同じ WAL snapshot から返る
         // ようにする。
         using var txn = _conn.BeginTransaction(deferred: true);
+        var indexedPathComparer = _getIndexedPathComparer();
         var javaModuleDescriptors = LoadJavaModuleDescriptors();
         var aggregate = BuildAggregate(
             EnumerateFileStats(lang, pathPatterns, excludePathPatterns, excludeTests),
@@ -118,7 +121,7 @@ internal sealed class RepoMapBuilder
             LargestFiles = BuildLargestFileResults(aggregate.LargestFiles),
             SymbolRichFiles = BuildSymbolRichFileResults(aggregate.SymbolRichFiles),
             ReferenceRichFiles = BuildReferenceRichFileResults(aggregate.ReferenceRichFiles),
-            Entrypoints = GetEntrypoints(aggregate.EntrypointFallbacks, limit, lang, pathPatterns, excludePathPatterns, excludeTests, minEntrypointConfidence),
+            Entrypoints = GetEntrypoints(aggregate.EntrypointFallbacks, limit, lang, pathPatterns, excludePathPatterns, excludeTests, minEntrypointConfidence, indexedPathComparer),
             GraphTableAvailable = _hasReferencesTable,
         };
         txn.Commit();
@@ -408,7 +411,7 @@ internal sealed class RepoMapBuilder
 
     private List<RepoEntrypointResult> GetEntrypoints(IReadOnlyList<RepoEntrypointResult> fallbackEntrypoints, int limit,
         string? lang, IReadOnlyList<string>? pathPatterns, IReadOnlyList<string>? excludePathPatterns, bool excludeTests,
-        double minConfidence)
+        double minConfidence, StringComparer indexedPathComparer)
     {
         using var cmd = _conn.CreateCommand();
         var sql = @"
@@ -458,7 +461,7 @@ internal sealed class RepoMapBuilder
         // シンボル抽出がエントリポイントを捉えられない場合、既知のエントリファイルにフォールバック
         var filesWithEntrypoints = results
             .Select(result => result.Path)
-            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+            .ToHashSet(indexedPathComparer);
 
         foreach (var fallback in fallbackEntrypoints)
         {

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -619,6 +619,9 @@ public class DbReaderTests : IDisposable
         _writer.InsertReferences(ReferenceExtractor.Extract(fileId, lang, normalized, symbols));
     }
 
+    private void StampWorkspacePathCaseSensitive(bool pathCaseSensitive)
+        => _writer.SetMeta(DbContext.WorkspacePathCaseSensitiveMetaKey, pathCaseSensitive.ToString());
+
     private string ExplainQueryPlan(string sql)
     {
         using var cmd = _db.Connection.CreateCommand();
@@ -12667,6 +12670,58 @@ public class DbReaderTests : IDisposable
     }
 
     [Fact]
+    public void AnalyzeImpact_CaseSensitiveWorkspaceTreatsCaseVariantDefinitionFilesAsDistinct()
+    {
+        StampWorkspacePathCaseSensitive(true);
+        InsertIndexedFile("src/CaseVariantTarget.cs", "csharp",
+            """
+            public class CaseVariantTarget
+            {
+                public void Start() { }
+            }
+            """);
+        InsertIndexedFile("src/casevarianttarget.cs", "csharp",
+            """
+            public class CaseVariantTarget
+            {
+                public void Stop() { }
+            }
+            """);
+
+        var analysis = _reader.AnalyzeImpact("CaseVariantTarget", maxDepth: 3, limit: 10);
+
+        Assert.Equal("none", analysis.ImpactMode);
+        Assert.True(analysis.HasMultipleDefinitions);
+        Assert.True(analysis.HasMultipleDefinitionFiles);
+        Assert.Equal("multiple_definition_files", analysis.ZeroResultReason);
+    }
+
+    [Fact]
+    public void AnalyzeImpact_CaseInsensitiveWorkspaceCollapsesCaseVariantDefinitionFiles()
+    {
+        StampWorkspacePathCaseSensitive(false);
+        InsertIndexedFile("src/CaseVariantTarget.cs", "csharp",
+            """
+            public class CaseVariantTarget
+            {
+                public void Start() { }
+            }
+            """);
+        InsertIndexedFile("src/casevarianttarget.cs", "csharp",
+            """
+            public class CaseVariantTarget
+            {
+                public void Stop() { }
+            }
+            """);
+
+        var analysis = _reader.AnalyzeImpact("CaseVariantTarget", maxDepth: 3, limit: 10);
+
+        Assert.True(analysis.HasMultipleDefinitions);
+        Assert.False(analysis.HasMultipleDefinitionFiles);
+    }
+
+    [Fact]
     public void AnalyzeImpact_FoldEquivalentClassDefinitions_ReportAmbiguity()
     {
         InsertIndexedFile("src/FooService.cs", "csharp",
@@ -13670,6 +13725,44 @@ public class DbReaderTests : IDisposable
         Assert.Equal("path", entrypoint.MatchType);
         Assert.True(entrypoint.Confidence >= 0.4);
         Assert.Equal(1, entrypoint.HintRank);
+    }
+
+    [Fact]
+    public void GetRepoMap_CaseSensitiveWorkspaceKeepsCaseVariantEntrypointFallbackPath()
+    {
+        StampWorkspacePathCaseSensitive(true);
+        InsertIndexedFile("src/Program.cs", "csharp",
+            """
+            public class Program
+            {
+                public static void Main() { }
+            }
+            """);
+        InsertIndexedFile("src/program.cs", "csharp", "Console.WriteLine(\"fallback\");\n");
+
+        var map = _reader.GetRepoMap(limit: 10, lang: "csharp", pathPatterns: new[] { "src/" });
+
+        Assert.Contains(map.Entrypoints, item => item.Name == "Main" && item.Path == "src/Program.cs");
+        Assert.Contains(map.Entrypoints, item => item.Kind == "file" && item.Name == "program.cs" && item.Path == "src/program.cs");
+    }
+
+    [Fact]
+    public void GetRepoMap_CaseInsensitiveWorkspaceCollapsesCaseVariantEntrypointFallbackPath()
+    {
+        StampWorkspacePathCaseSensitive(false);
+        InsertIndexedFile("src/Program.cs", "csharp",
+            """
+            public class Program
+            {
+                public static void Main() { }
+            }
+            """);
+        InsertIndexedFile("src/program.cs", "csharp", "Console.WriteLine(\"fallback\");\n");
+
+        var map = _reader.GetRepoMap(limit: 10, lang: "csharp", pathPatterns: new[] { "src/" });
+
+        Assert.Contains(map.Entrypoints, item => item.Name == "Main" && item.Path == "src/Program.cs");
+        Assert.DoesNotContain(map.Entrypoints, item => item.Kind == "file" && item.Path == "src/program.cs");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Make `map` entrypoint fallback de-duplication use the indexed workspace path case policy.
- Make `impact` definition-file ambiguity use the same indexed path policy, so case-sensitive indexes keep case-variant paths distinct.
- Add a bilingual path comparison/normalization audit classification document.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:UseSharedCompilation=false --filter "FullyQualifiedName~CaseVariant"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~DbReaderTests.GetRepoMap"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~DbReaderTests.AnalyzeImpact_"`
- `dotnet build src/CodeIndex/CodeIndex.csproj -c Release -p:UseSharedCompilation=false --no-restore`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and changelog
- Added `docs/path-comparison-audit.md`.
- Added changelog fragment `changelog.d/unreleased/4071.fixed.md`.
- `CHANGELOG.md` was not edited.

## Notes
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore` and the same command with `--include` were attempted, but both stayed silent for several minutes in this environment and were interrupted.

## Follow-up candidates
- None.

Fixes #4071