### PR TITLE
Fix bounded dependency cycle detection

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1527,6 +1527,7 @@ same source location.
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | Filter to files modified since this ISO 8601 timestamp. Offsetless values (e.g. `2024-01-01T00:00:00`) are treated as UTC so the same flag resolves to the same instant in every timezone; append `Z` or an explicit offset (`+09:00`) to be explicit. |
 | `--no-dedup` | `search` | Disable overlapping-chunk deduplication and return every raw chunk hit; useful for debugging chunk boundaries or measuring raw match density |
 | `--reverse` | `deps` | Reverse lookup: show files that depend ON the matched path |
+| `--cycles` | `deps` | Return dependency cycles from a bounded candidate-edge scan. `--limit` controls displayed cycles; cycle detection examines up to `max(--limit, 50)` candidate rows and JSON reports `truncated`, `termination_reason`, `truncated_reason`, `candidate_edge_count`, `candidate_edge_limit`, and `cycle_detection_mode` when results are partial. |
 | `--strict-not-found` | Query commands | Return exit code `2` when a valid query produces zero rows. Without this flag, zero-result queries exit `0` and keep their normal empty/zero-result output. |
 | `--top <n>` | Query commands | Alias for `--limit` |
 | `--max-results <n>` | `search` | Alias for `--limit` |
@@ -4166,6 +4167,7 @@ raw match density を正確に測る、といった理由で全 raw chunk hit �
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | 指定タイムスタンプ以降に変更されたファイルのみ（ISO 8601）。オフセットなしの値（例: `2024-01-01T00:00:00`）は UTC として解釈されるため、どのタイムゾーンから呼び出しても同じ UTC 時点になります。明示したい場合は末尾に `Z` または `+09:00` 等のオフセットを付与してください。 |
 | `--no-dedup` | `search` | overlap chunk の重複排除を無効化し、全 raw chunk hit を返す。chunk 境界の debug や raw match density 計測向け |
 | `--reverse` | `deps` | 逆引き: 指定パスに依存しているファイルを表示 |
+| `--cycles` | `deps` | 上限付きの候補 edge scan から依存 cycle を返す。`--limit` は表示する cycle 数を制御し、cycle 検出は最大 `max(--limit, 50)` 件の候補行を調べる。結果が部分的な場合、JSON は `truncated`、`termination_reason`、`truncated_reason`、`candidate_edge_count`、`candidate_edge_limit`、`cycle_detection_mode` を返す。 |
 | `--workspace-db <path>` | `deps` | file dependency query に別の CodeIndex DB を追加する。最大 7 個の distinct な追加 DB（`--db` を含め合計 8 個）まで繰り返し指定でき、JSON edge には同じ相対パスを区別できるよう `source_db` / `target_db` が含まれる。 |
 | `--top <n>` | クエリ系 | `--limit` のエイリアス |
 | `--max-results <n>` | `search` | `--limit` のエイリアス |

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1527,7 +1527,7 @@ same source location.
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | Filter to files modified since this ISO 8601 timestamp. Offsetless values (e.g. `2024-01-01T00:00:00`) are treated as UTC so the same flag resolves to the same instant in every timezone; append `Z` or an explicit offset (`+09:00`) to be explicit. |
 | `--no-dedup` | `search` | Disable overlapping-chunk deduplication and return every raw chunk hit; useful for debugging chunk boundaries or measuring raw match density |
 | `--reverse` | `deps` | Reverse lookup: show files that depend ON the matched path |
-| `--cycles` | `deps` | Return dependency cycles from a bounded candidate-edge scan. `--limit` controls displayed cycles; cycle detection examines up to `max(--limit, 50)` candidate rows and JSON reports `truncated`, `termination_reason`, `truncated_reason`, `candidate_edge_count`, `candidate_edge_limit`, and `cycle_detection_mode` when results are partial. |
+| `--cycles` | `deps` | Return dependency cycles from a bounded approximate candidate-edge scan. `--limit` controls displayed cycles; cycle detection examines up to `max(--limit, 50)` lightweight candidate edges and JSON reports `truncated`, `termination_reason`, `truncated_reason`, `candidate_edge_count`, `candidate_edge_limit`, and `cycle_detection_mode` when results are partial. |
 | `--strict-not-found` | Query commands | Return exit code `2` when a valid query produces zero rows. Without this flag, zero-result queries exit `0` and keep their normal empty/zero-result output. |
 | `--top <n>` | Query commands | Alias for `--limit` |
 | `--max-results <n>` | `search` | Alias for `--limit` |
@@ -4167,7 +4167,7 @@ raw match density を正確に測る、といった理由で全 raw chunk hit �
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | 指定タイムスタンプ以降に変更されたファイルのみ（ISO 8601）。オフセットなしの値（例: `2024-01-01T00:00:00`）は UTC として解釈されるため、どのタイムゾーンから呼び出しても同じ UTC 時点になります。明示したい場合は末尾に `Z` または `+09:00` 等のオフセットを付与してください。 |
 | `--no-dedup` | `search` | overlap chunk の重複排除を無効化し、全 raw chunk hit を返す。chunk 境界の debug や raw match density 計測向け |
 | `--reverse` | `deps` | 逆引き: 指定パスに依存しているファイルを表示 |
-| `--cycles` | `deps` | 上限付きの候補 edge scan から依存 cycle を返す。`--limit` は表示する cycle 数を制御し、cycle 検出は最大 `max(--limit, 50)` 件の候補行を調べる。結果が部分的な場合、JSON は `truncated`、`termination_reason`、`truncated_reason`、`candidate_edge_count`、`candidate_edge_limit`、`cycle_detection_mode` を返す。 |
+| `--cycles` | `deps` | 上限付きの近似候補 edge scan から依存 cycle を返す。`--limit` は表示する cycle 数を制御し、cycle 検出は最大 `max(--limit, 50)` 件の軽量候補 edge を調べる。結果が部分的な場合、JSON は `truncated`、`termination_reason`、`truncated_reason`、`candidate_edge_count`、`candidate_edge_limit`、`cycle_detection_mode` を返す。 |
 | `--workspace-db <path>` | `deps` | file dependency query に別の CodeIndex DB を追加する。最大 7 個の distinct な追加 DB（`--db` を含め合計 8 個）まで繰り返し指定でき、JSON edge には同じ相対パスを区別できるよう `source_db` / `target_db` が含まれる。 |
 | `--top <n>` | クエリ系 | `--limit` のエイリアス |
 | `--max-results <n>` | `search` | `--limit` のエイリアス |

--- a/changelog.d/unreleased/4065.fixed.md
+++ b/changelog.d/unreleased/4065.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 4065
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Database/DbReader.Dependencies.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **`deps --cycles` now uses a bounded candidate scan (#4065)** - cycle detection avoids the full dependency-edge aggregation path, can be interrupted through the CLI cancellation token, and reports partial results with truncation metadata when the candidate edge budget is reached.
+
+## 日本語
+
+- **`deps --cycles` が上限付きの候補 scan を使うようになりました (#4065)** - cycle 検出は依存 edge の全量集計経路を避け、CLI の cancellation token で中断でき、候補 edge budget に達した場合は truncation metadata 付きで部分結果を報告します。

--- a/changelog.d/unreleased/4065.fixed.md
+++ b/changelog.d/unreleased/4065.fixed.md
@@ -11,8 +11,8 @@ affected:
 
 ## English
 
-- **`deps --cycles` now uses a bounded candidate scan (#4065)** - cycle detection avoids the full dependency-edge aggregation path, can be interrupted through the CLI cancellation token, and reports partial results with truncation metadata when the candidate edge budget is reached.
+- **`deps --cycles` now uses a bounded approximate candidate scan (#4065)** - cycle detection avoids the full dependency-edge aggregation path, can be interrupted through the CLI cancellation token, and reports partial results with truncation metadata when the candidate edge budget is reached.
 
 ## 日本語
 
-- **`deps --cycles` が上限付きの候補 scan を使うようになりました (#4065)** - cycle 検出は依存 edge の全量集計経路を避け、CLI の cancellation token で中断でき、候補 edge budget に達した場合は truncation metadata 付きで部分結果を報告します。
+- **`deps --cycles` が上限付きの近似候補 scan を使うようになりました (#4065)** - cycle 検出は依存 edge の全量集計経路を避け、CLI の cancellation token で中断でき、候補 edge budget に達した場合は truncation metadata 付きで部分結果を報告します。

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -282,7 +282,7 @@ internal static class CliFlagSchema
             new() { Name = "--min-entrypoint-confidence", ValuePlaceholder = "<0.0..1.0>", Description = "Map: omit entrypoint candidates below this confidence", Commands = Set(EntrypointConfidenceCommands) },
             new() { Name = "--sections", ValuePlaceholder = "<tree,languages,hotspots,metrics>", Description = "Map: comma-separated response sections to include", Commands = Set(MapSectionCommands) },
             new() { Name = "--summary-only", Description = "Map/Diff: return only aggregate summary fields", Commands = Set(SummaryOnlyCommands) },
-            new() { Name = "--cycles", Description = "Deps: return dependency cycles instead of edge rows", Commands = Set(DependencyCycleCommands) },
+            new() { Name = "--cycles", Description = "Deps: return dependency cycles from a bounded candidate-edge scan", Commands = Set(DependencyCycleCommands) },
             new() { Name = "--suppress-noise", Description = "Deps: suppress generic framework/noise symbols in edge symbol samples", Commands = Set("deps") },
             new() { Name = "--symbol", ValuePlaceholder = "<name>", Description = "Deps: keep only edges with an exact sampled symbol name", Commands = Set("deps") },
             new() { Name = "--symbol-family", ValuePlaceholder = "<prefix>", Description = "Deps: keep only edges with a sampled symbol prefix/family", Commands = Set("deps") },

--- a/src/CodeIndex/Cli/CliFlagSchema.cs
+++ b/src/CodeIndex/Cli/CliFlagSchema.cs
@@ -282,7 +282,7 @@ internal static class CliFlagSchema
             new() { Name = "--min-entrypoint-confidence", ValuePlaceholder = "<0.0..1.0>", Description = "Map: omit entrypoint candidates below this confidence", Commands = Set(EntrypointConfidenceCommands) },
             new() { Name = "--sections", ValuePlaceholder = "<tree,languages,hotspots,metrics>", Description = "Map: comma-separated response sections to include", Commands = Set(MapSectionCommands) },
             new() { Name = "--summary-only", Description = "Map/Diff: return only aggregate summary fields", Commands = Set(SummaryOnlyCommands) },
-            new() { Name = "--cycles", Description = "Deps: return dependency cycles from a bounded candidate-edge scan", Commands = Set(DependencyCycleCommands) },
+            new() { Name = "--cycles", Description = "Deps: return dependency cycles from a bounded approximate candidate-edge scan", Commands = Set(DependencyCycleCommands) },
             new() { Name = "--suppress-noise", Description = "Deps: suppress generic framework/noise symbols in edge symbol samples", Commands = Set("deps") },
             new() { Name = "--symbol", ValuePlaceholder = "<name>", Description = "Deps: keep only edges with an exact sampled symbol name", Commands = Set("deps") },
             new() { Name = "--symbol-family", ValuePlaceholder = "<prefix>", Description = "Deps: keep only edges with a sampled symbol prefix/family", Commands = Set("deps") },

--- a/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.Dispatch.cs
@@ -312,7 +312,7 @@ internal static partial class ProgramRunner
             "validate" => a => QueryCommandRunner.RunValidate(a, context.JsonOptions),
             "languages" => a => QueryCommandRunner.RunLanguages(a, context.JsonOptions),
             "impact" => a => QueryCommandRunner.RunImpact(a, context.JsonOptions),
-            "deps" => a => QueryCommandRunner.RunDeps(a, context.JsonOptions),
+            "deps" => a => QueryCommandRunner.RunDeps(a, context.JsonOptions, context.CancellationToken),
             "unused" => a => QueryCommandRunner.RunUnused(a, context.JsonOptions),
             "hotspots" => a => QueryCommandRunner.RunHotspots(a, context.JsonOptions),
             "batch" => a => QueryCommandRunner.RunBatch(a, context.JsonOptions),

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -8165,6 +8165,9 @@ public static partial class QueryCommandRunner
     }
 
     public static int RunDeps(string[] cmdArgs, JsonSerializerOptions jsonOptions)
+        => RunDeps(cmdArgs, jsonOptions, CancellationToken.None);
+
+    public static int RunDeps(string[] cmdArgs, JsonSerializerOptions jsonOptions, CancellationToken cancellationToken)
     {
         var previewOptionError = ValidatePreviewOptions("deps", cmdArgs, allowMaxLineWidth: false, allowFocusOptions: false);
         if (previewOptionError != null)
@@ -8194,14 +8197,32 @@ public static partial class QueryCommandRunner
 
         return WithDb(options, jsonOptions, reader =>
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (TryWriteInvalidWorkspaceDependencyDatabaseError(options, out var workspaceDbExitCode))
                 return workspaceDbExitCode;
 
             var reverse = cmdArgs.Any(a => a == "--reverse");
-            var results = GetWorkspaceFileDependencies(reader, options, reverse, options.Limit);
-            var cycleCandidates = options.DependencyCycles
-                ? GetWorkspaceFileDependencies(reader, options, reverse, GetDependencyCycleGraphLimit(options.Limit))
-                : results;
+            List<FileDependencyResult> results;
+            List<FileDependencyResult> cycleCandidates;
+            var cycleCandidateRowCount = 0;
+            var cycleCandidateLimit = GetDependencyCycleGraphLimit(options.Limit);
+            if (options.DependencyCycles)
+            {
+                cycleCandidates = GetWorkspaceFileDependencyCycleCandidates(
+                    reader,
+                    options,
+                    reverse,
+                    checked(cycleCandidateLimit + 1),
+                    out cycleCandidateRowCount,
+                    cancellationToken);
+                results = cycleCandidates.Take(cycleCandidateLimit).ToList();
+                cycleCandidates = results;
+            }
+            else
+            {
+                results = GetWorkspaceFileDependencies(reader, options, reverse, options.Limit);
+                cycleCandidates = results;
+            }
             var baseSqlGraphSignal = reader.GetSqlGraphContractSignal(options.Lang, options.PathPatterns, options.ExcludePaths, options.ExcludeTests);
             if (results.Count == 0)
             {
@@ -8228,11 +8249,19 @@ public static partial class QueryCommandRunner
             List<List<string>> cycles = [];
             List<FileDependencyResult> outputEdges;
             DependencySymbolFilterResult symbolFilter;
+            DependencyCycleAnalysis? dependencyCycleAnalysis = null;
             if (options.DependencyCycles)
             {
                 symbolFilter = ApplyDependencySymbolFilters(cycleCandidates, options);
-                outputEdges = FilterCycleEdges(symbolFilter.Edges, out cycles).Take(options.Limit).ToList();
-                cycles = cycles.Take(options.Limit).ToList();
+                var analysis = AnalyzeDependencyCycles(
+                    symbolFilter.Edges,
+                    cycleCandidateLimit,
+                    cycleCandidateRowCount,
+                    options.Limit,
+                    cancellationToken);
+                outputEdges = analysis.Edges;
+                cycles = analysis.Cycles;
+                dependencyCycleAnalysis = analysis;
             }
             else
             {
@@ -8278,6 +8307,8 @@ public static partial class QueryCommandRunner
                 if (options.Json)
                 {
                     var payload = new JsonObject { ["count"] = 0, ["cycles"] = new JsonArray() };
+                    if (dependencyCycleAnalysis != null)
+                        AddDependencyCycleAnalysisJsonFields(payload, dependencyCycleAnalysis);
                     AddDependencySchemaJsonFields(payload, options, jsonOptions, sqlGraphSignal, symbolFilter.Summary);
                     AddFreshnessHint(payload, reader);
                     Console.WriteLine(payload.ToJsonString(jsonOptions));
@@ -8285,6 +8316,8 @@ public static partial class QueryCommandRunner
                 else
                 {
                     CommandErrorWriter.WriteStderr(BuildZeroResultLine("No dependency cycles found", options));
+                    if (dependencyCycleAnalysis is { Truncated: true })
+                        CommandErrorWriter.WriteStderr(BuildDependencyCycleTruncationWarning(dependencyCycleAnalysis));
                     WriteSqlGraphContractWarningIfNeeded(json: false, sqlGraphSignal, reader, options);
                 }
                 return ZeroResultExitCode(options);
@@ -8292,7 +8325,17 @@ public static partial class QueryCommandRunner
 
             if (depsFormat is OutputFormatDot or OutputFormatGraphMl or OutputFormatJsonGraph)
             {
-                WriteDependencyGraph(outputEdges, depsFormat, jsonOptions, reader, options, sqlGraphSignal, symbolFilter.Summary);
+                WriteDependencyGraph(
+                    outputEdges,
+                    depsFormat,
+                    jsonOptions,
+                    reader,
+                    options,
+                    sqlGraphSignal,
+                    symbolFilter.Summary,
+                    dependencyCycleAnalysis == null ? null : payload => AddDependencyCycleAnalysisJsonFields(payload, dependencyCycleAnalysis));
+                if ((depsFormat is OutputFormatDot or OutputFormatGraphMl) && dependencyCycleAnalysis is { Truncated: true })
+                    CommandErrorWriter.WriteStderr(BuildDependencyCycleTruncationWarning(dependencyCycleAnalysis));
                 return CommandExitCodes.Success;
             }
 
@@ -8303,7 +8346,11 @@ public static partial class QueryCommandRunner
                     ["count"] = options.DependencyCycles ? cycles.Count : outputEdges.Count,
                 };
                 if (options.DependencyCycles)
+                {
                     payload["cycles"] = BuildDependencyCyclesJson(cycles);
+                    if (dependencyCycleAnalysis != null)
+                        AddDependencyCycleAnalysisJsonFields(payload, dependencyCycleAnalysis);
+                }
                 else
                     payload["edges"] = JsonSerializer.SerializeToNode(outputEdges, CliJsonSerializerContextFactory.Create(jsonOptions).ListFileDependencyResult);
                 AddDependencySchemaJsonFields(payload, options, jsonOptions, sqlGraphSignal, symbolFilter.Summary);
@@ -8316,7 +8363,10 @@ public static partial class QueryCommandRunner
                 {
                     foreach (var cycle in cycles)
                         Console.WriteLine(string.Join(" -> ", cycle.Concat([cycle[0]])));
-                    CommandErrorWriter.WriteStderr($"({cycles.Count} dependency cycles)");
+                    var truncationNote = dependencyCycleAnalysis is { Truncated: true }
+                        ? $"; {BuildDependencyCycleTruncationSummary(dependencyCycleAnalysis)}"
+                        : string.Empty;
+                    CommandErrorWriter.WriteStderr($"({cycles.Count} dependency cycles{truncationNote})");
                     WriteSqlGraphContractWarningIfNeeded(json: false, sqlGraphSignal, reader, options);
                     return CommandExitCodes.Success;
                 }
@@ -8330,7 +8380,7 @@ public static partial class QueryCommandRunner
                 WriteSqlGraphContractWarningIfNeeded(json: false, sqlGraphSignal, reader, options);
             }
             return CommandExitCodes.Success;
-        });
+        }, cancellationToken: cancellationToken);
     }
 
     private static bool TryExtractDepsFormat(string[] args, out string format, out string[] parseArgs, out string? error)
@@ -8395,8 +8445,11 @@ public static partial class QueryCommandRunner
     }
 
     internal static List<FileDependencyResult> FilterCycleEdges(List<FileDependencyResult> results, out List<List<string>> cycles)
+        => FilterCycleEdges(results, out cycles, CancellationToken.None);
+
+    private static List<FileDependencyResult> FilterCycleEdges(IReadOnlyList<FileDependencyResult> results, out List<List<string>> cycles, CancellationToken cancellationToken)
     {
-        cycles = FindDependencyCycles(results);
+        cycles = FindDependencyCycles(results, cancellationToken);
         if (cycles.Count == 0)
             return [];
         var cycleNodes = cycles.SelectMany(cycle => cycle).ToHashSet(StringComparer.Ordinal);
@@ -8406,10 +8459,15 @@ public static partial class QueryCommandRunner
     }
 
     internal static List<List<string>> FindDependencyCycles(IReadOnlyList<FileDependencyResult> edges)
+        => FindDependencyCycles(edges, CancellationToken.None);
+
+    private static List<List<string>> FindDependencyCycles(IReadOnlyList<FileDependencyResult> edges, CancellationToken cancellationToken)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var adjacency = new Dictionary<string, List<string>>(StringComparer.Ordinal);
         foreach (var edge in edges)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!adjacency.TryGetValue(edge.SourcePath, out var targets))
                 adjacency[edge.SourcePath] = targets = [];
             targets.Add(edge.TargetPath);
@@ -8425,6 +8483,7 @@ public static partial class QueryCommandRunner
 
         void Visit(string node)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             indexes[node] = index;
             lowLinks[node] = index;
             index++;
@@ -8433,6 +8492,7 @@ public static partial class QueryCommandRunner
 
             foreach (var target in adjacency[node])
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 if (!indexes.ContainsKey(target))
                 {
                     Visit(target);
@@ -8462,8 +8522,11 @@ public static partial class QueryCommandRunner
         }
 
         foreach (var node in adjacency.Keys.OrderBy(path => path, StringComparer.Ordinal).ToList())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
             if (!indexes.ContainsKey(node))
                 Visit(node);
+        }
 
         return cycles;
     }
@@ -8481,6 +8544,75 @@ public static partial class QueryCommandRunner
         }
         return array;
     }
+
+    private sealed record DependencyCycleAnalysis(
+        List<FileDependencyResult> Edges,
+        List<List<string>> Cycles,
+        bool Truncated,
+        string TerminationReason,
+        string? TruncatedReason,
+        int CandidateEdgeCount,
+        int CandidateEdgeLimit,
+        string DetectionMode);
+
+    private static DependencyCycleAnalysis AnalyzeDependencyCycles(
+        IReadOnlyList<FileDependencyResult> candidateEdges,
+        int candidateEdgeLimit,
+        int candidateRowCount,
+        int displayLimit,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var edges = FilterCycleEdges(candidateEdges, out var allCycles, cancellationToken);
+        var cyclesTruncated = allCycles.Count > displayLimit;
+        var candidateTruncated = candidateRowCount > candidateEdgeLimit;
+        var cycles = allCycles.Take(displayLimit).ToList();
+        var cycleNodes = cycles.SelectMany(static cycle => cycle).ToHashSet(StringComparer.Ordinal);
+        var outputEdges = edges
+            .Where(edge => cycleNodes.Count == 0 || (cycleNodes.Contains(edge.SourcePath) && cycleNodes.Contains(edge.TargetPath)))
+            .Take(displayLimit)
+            .ToList();
+        var truncatedReason = candidateTruncated
+            ? "candidate_edge_limit"
+            : cyclesTruncated
+                ? "display_limit"
+                : null;
+        var terminationReason = truncatedReason switch
+        {
+            "candidate_edge_limit" => "candidate_limit_reached",
+            "display_limit" => "display_limit_reached",
+            _ => "completed",
+        };
+
+        return new DependencyCycleAnalysis(
+            outputEdges,
+            cycles,
+            candidateTruncated || cyclesTruncated,
+            terminationReason,
+            truncatedReason,
+            Math.Min(candidateRowCount, candidateEdgeLimit),
+            candidateEdgeLimit,
+            "bounded_candidate_edges");
+    }
+
+    private static void AddDependencyCycleAnalysisJsonFields(JsonObject payload, DependencyCycleAnalysis analysis)
+    {
+        payload["truncated"] = analysis.Truncated;
+        payload["termination_reason"] = analysis.TerminationReason;
+        if (analysis.TruncatedReason != null)
+            payload["truncated_reason"] = analysis.TruncatedReason;
+        payload["candidate_edge_count"] = analysis.CandidateEdgeCount;
+        payload["candidate_edge_limit"] = analysis.CandidateEdgeLimit;
+        payload["cycle_detection_mode"] = analysis.DetectionMode;
+    }
+
+    private static string BuildDependencyCycleTruncationSummary(DependencyCycleAnalysis analysis)
+        => analysis.TruncatedReason == "display_limit"
+            ? $"partial: showing first {analysis.Cycles.Count} cycles"
+            : $"partial: candidate edge limit reached after {analysis.CandidateEdgeCount} candidate edges";
+
+    private static string BuildDependencyCycleTruncationWarning(DependencyCycleAnalysis analysis)
+        => $"Warning: dependency cycle detection returned partial results ({BuildDependencyCycleTruncationSummary(analysis)}).";
 
     private static DependencySymbolFilterResult ApplyDependencySymbolFilters(IReadOnlyList<FileDependencyResult> edges, QueryCommandOptions options)
     {
@@ -8615,7 +8747,8 @@ public static partial class QueryCommandRunner
         DbReader reader,
         QueryCommandOptions options,
         SqlGraphContractSignal sqlGraphSignal,
-        DependencySymbolFilterSummary symbolFilter)
+        DependencySymbolFilterSummary symbolFilter,
+        Action<JsonObject>? addExtraJsonFields = null)
     {
         switch (format)
         {
@@ -8635,7 +8768,7 @@ public static partial class QueryCommandRunner
                 Console.WriteLine("</graph></graphml>");
                 break;
             case OutputFormatJsonGraph:
-                WriteDependencyJsonGraph(edges, jsonOptions, reader, options, sqlGraphSignal, symbolFilter);
+                WriteDependencyJsonGraph(edges, jsonOptions, reader, options, sqlGraphSignal, symbolFilter, addExtraJsonFields);
                 break;
         }
     }
@@ -8646,7 +8779,8 @@ public static partial class QueryCommandRunner
         DbReader reader,
         QueryCommandOptions options,
         SqlGraphContractSignal sqlGraphSignal,
-        DependencySymbolFilterSummary symbolFilter)
+        DependencySymbolFilterSummary symbolFilter,
+        Action<JsonObject>? addExtraJsonFields = null)
     {
         var seenNodes = new HashSet<string>(StringComparer.Ordinal);
         var nodes = new List<string>();
@@ -8669,6 +8803,7 @@ public static partial class QueryCommandRunner
                 ["symbols"] = BuildDependencySymbolsJson(edge.Symbols),
             }).ToArray()),
         };
+        addExtraJsonFields?.Invoke(payload);
         AddDependencySchemaJsonFields(payload, options, jsonOptions, sqlGraphSignal, symbolFilter);
         AddFreshnessHint(payload, reader);
         Console.WriteLine(payload.ToJsonString(jsonOptions));
@@ -8719,6 +8854,71 @@ public static partial class QueryCommandRunner
             .ThenBy(result => result.TargetPath, StringComparer.Ordinal)
             .Take(limit)
             .ToList();
+    }
+
+    private static List<FileDependencyResult> GetWorkspaceFileDependencyCycleCandidates(
+        DbReader primaryReader,
+        QueryCommandOptions options,
+        bool reverse,
+        int limit,
+        out int candidateRowCount,
+        CancellationToken cancellationToken)
+    {
+        candidateRowCount = 0;
+        var results = primaryReader.GetFileDependencyCycleCandidates(
+            limit,
+            out var primaryCandidateRows,
+            options.Lang,
+            options.PathPatterns,
+            options.ExcludePaths,
+            options.ExcludeTests,
+            reverse,
+            cancellationToken);
+        candidateRowCount += primaryCandidateRows;
+        if (options.WorkspaceDbPaths.Count == 0)
+            return results.Take(limit).ToList();
+
+        var memberDbs = BuildWorkspaceDependencyDatabaseList(options);
+        var primaryDb = memberDbs[0];
+        TagFileDependencyResults(results, primaryDb);
+        if (results.Count >= limit)
+            return results.Take(limit).ToList();
+        foreach (var normalizedDbPath in memberDbs.Skip(1))
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using var db = new DbContext(normalizedDbPath, cancellationToken);
+            db.TryMigrateForRead();
+            var reader = new DbReader(db) { IncludeGenerated = primaryReader.IncludeGenerated };
+            var memberResults = reader.GetFileDependencyCycleCandidates(
+                limit,
+                out var memberCandidateRows,
+                options.Lang,
+                options.PathPatterns,
+                options.ExcludePaths,
+                options.ExcludeTests,
+                reverse,
+                cancellationToken);
+            candidateRowCount += memberCandidateRows;
+            TagFileDependencyResults(memberResults, normalizedDbPath);
+            results.AddRange(memberResults);
+            if (results.Count >= limit)
+                return results.Take(limit).ToList();
+        }
+
+        foreach (var sourceDb in memberDbs)
+            foreach (var targetDb in memberDbs)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (string.Equals(sourceDb, targetDb, StringComparison.Ordinal))
+                    continue;
+                var crossDbResults = GetCrossDatabaseFileDependencies(sourceDb, targetDb, options, reverse, limit);
+                candidateRowCount += crossDbResults.Count;
+                results.AddRange(crossDbResults);
+                if (results.Count >= limit)
+                    return results.Take(limit).ToList();
+            }
+
+        return results.Take(limit).ToList();
     }
 
     internal static List<string> BuildWorkspaceDependencyDatabaseList(QueryCommandOptions options)

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -8592,7 +8592,7 @@ public static partial class QueryCommandRunner
             truncatedReason,
             Math.Min(candidateRowCount, candidateEdgeLimit),
             candidateEdgeLimit,
-            "bounded_candidate_edges");
+            "bounded_approximate_candidate_edges");
     }
 
     private static void AddDependencyCycleAnalysisJsonFields(JsonObject payload, DependencyCycleAnalysis analysis)

--- a/src/CodeIndex/Database/DbReader.Dependencies.cs
+++ b/src/CodeIndex/Database/DbReader.Dependencies.cs
@@ -560,6 +560,110 @@ public partial class DbReader
         return results;
     }
 
+    public List<FileDependencyResult> GetFileDependencyCycleCandidates(
+        int limit,
+        out int candidateRowCount,
+        string? lang = null,
+        IReadOnlyList<string>? pathPatterns = null,
+        IReadOnlyList<string>? excludePathPatterns = null,
+        bool excludeTests = false,
+        bool reverse = false,
+        CancellationToken cancellationToken = default)
+    {
+        candidateRowCount = 0;
+        lang = NormalizeQueryLanguage(lang);
+        if (!_hasReferencesTable || limit <= 0)
+            return [];
+
+        cancellationToken.ThrowIfCancellationRequested();
+        using var cmd = _conn.CreateCommand();
+        var constrainedAlias = reverse ? "dst" : "src";
+        var sql = @"
+            SELECT DISTINCT src.path AS source_path,
+                            dst.path AS target_path,
+                            r.symbol_name
+            FROM symbol_references r
+            JOIN files src ON r.file_id = src.id
+            JOIN symbols s ON s.name = r.symbol_name
+            JOIN files dst ON s.file_id = dst.id
+            WHERE src.path != dst.path
+              AND src.lang = dst.lang";
+        sql += $" AND {BuildGraphSupportedLanguagePredicate(cmd, "src", "depsCycleSourceLang")}";
+        sql += $" AND {BuildGraphSupportedLanguagePredicate(cmd, "dst", "depsCycleTargetLang")}";
+        AppendDependencyGeneratedFilter(ref sql, "src");
+        AppendDependencyGeneratedFilter(ref sql, "dst");
+        if (lang != null)
+            sql += " AND src.lang = @lang AND dst.lang = @lang";
+        if (pathPatterns is { Count: > 0 })
+        {
+            var ors = new List<string>(pathPatterns.Count);
+            for (int i = 0; i < pathPatterns.Count; i++)
+                ors.Add($"{constrainedAlias}.path LIKE @pathPattern{i} ESCAPE '\\'");
+            sql += " AND (" + string.Join(" OR ", ors) + ")";
+        }
+        if (excludePathPatterns is { Count: > 0 })
+        {
+            for (int i = 0; i < excludePathPatterns.Count; i++)
+                sql += $" AND {constrainedAlias}.path NOT LIKE @excludePath{i} ESCAPE '\\'";
+        }
+        if (excludeTests)
+        {
+            sql += $" AND NOT {DependencyTestPathCondition("src.path")}";
+            sql += $" AND NOT {DependencyTestPathCondition("dst.path")}";
+        }
+        sql += " LIMIT @limit";
+
+        cmd.CommandText = sql;
+        if (lang != null)
+            SqliteCommandPolicy.Add(cmd, "@lang", lang);
+        if (pathPatterns is { Count: > 0 })
+        {
+            for (int i = 0; i < pathPatterns.Count; i++)
+                SqliteCommandPolicy.Add(cmd, $"@pathPattern{i}", BuildPathLikePattern(pathPatterns[i]));
+        }
+        if (excludePathPatterns is { Count: > 0 })
+        {
+            for (int i = 0; i < excludePathPatterns.Count; i++)
+                SqliteCommandPolicy.Add(cmd, $"@excludePath{i}", BuildPathLikePattern(excludePathPatterns[i]));
+        }
+        SqliteCommandPolicy.Add(cmd, "@limit", limit);
+
+        var results = new List<FileDependencyResult>();
+        var resultIndexes = new Dictionary<(string SourcePath, string TargetPath), int>();
+        var symbolsByEdge = new Dictionary<(string SourcePath, string TargetPath), SortedSet<string>>();
+        using var reader = cmd.ExecuteTrackedReader();
+        while (reader.TrackedRead())
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            candidateRowCount++;
+            var sourcePath = reader.GetString(0);
+            var targetPath = reader.GetString(1);
+            var key = (sourcePath, targetPath);
+            if (!resultIndexes.ContainsKey(key))
+            {
+                resultIndexes[key] = results.Count;
+                results.Add(new FileDependencyResult
+                {
+                    SourcePath = sourcePath,
+                    TargetPath = targetPath,
+                    ReferenceCount = 1,
+                    Symbols = string.Empty,
+                });
+            }
+
+            if (!symbolsByEdge.TryGetValue(key, out var symbols))
+                symbolsByEdge[key] = symbols = new SortedSet<string>(StringComparer.Ordinal);
+            symbols.Add(reader.GetString(2));
+        }
+
+        foreach (var (key, index) in resultIndexes)
+        {
+            if (symbolsByEdge.TryGetValue(key, out var symbols))
+                results[index].Symbols = string.Join(",", symbols.Take(DependencySymbolSampleLimit));
+        }
+        return results;
+    }
+
     private static string DependencyTestPathCondition(string pathSql)
         => "(" + TestPathCondition.Replace("f.path", pathSql) + $" OR lower({pathSql}) LIKE '%.test%/%')";
 

--- a/src/CodeIndex/Database/DbReader.Dependencies.cs
+++ b/src/CodeIndex/Database/DbReader.Dependencies.cs
@@ -579,9 +579,9 @@ public partial class DbReader
         using var cmd = _conn.CreateCommand();
         var constrainedAlias = reverse ? "dst" : "src";
         var sql = @"
-            SELECT DISTINCT src.path AS source_path,
-                            dst.path AS target_path,
-                            r.symbol_name
+            WITH candidate_edges AS (
+                SELECT DISTINCT src.path AS source_path,
+                                dst.path AS target_path
             FROM symbol_references r
             JOIN files src ON r.file_id = src.id
             JOIN symbols s ON s.name = r.symbol_name
@@ -611,7 +611,42 @@ public partial class DbReader
             sql += $" AND NOT {DependencyTestPathCondition("src.path")}";
             sql += $" AND NOT {DependencyTestPathCondition("dst.path")}";
         }
-        sql += " LIMIT @limit";
+        sql += @"
+                LIMIT @limit
+            ),
+            candidate_symbols AS (
+                SELECT candidate_edges.source_path,
+                       candidate_edges.target_path,
+                       r.symbol_name
+                FROM candidate_edges
+                JOIN files src ON src.path = candidate_edges.source_path
+                JOIN symbol_references r ON r.file_id = src.id
+                JOIN symbols s ON s.name = r.symbol_name
+                JOIN files dst ON s.file_id = dst.id
+                 AND dst.path = candidate_edges.target_path
+                WHERE src.path != dst.path
+                  AND src.lang = dst.lang
+            ),
+            distinct_edge_symbols AS (
+                SELECT DISTINCT source_path,
+                                target_path,
+                                symbol_name
+                FROM candidate_symbols
+            ),
+            ranked_edge_symbols AS (
+                SELECT source_path,
+                       target_path,
+                       symbol_name,
+                       ROW_NUMBER() OVER (PARTITION BY source_path, target_path ORDER BY symbol_name) AS symbol_rank
+                FROM distinct_edge_symbols
+            )
+            SELECT source_path,
+                   target_path,
+                   COUNT(*) AS reference_count,
+                   COALESCE(GROUP_CONCAT(CASE WHEN symbol_rank <= @symbolSampleLimit THEN symbol_name END), '') AS symbols
+            FROM ranked_edge_symbols
+            GROUP BY source_path, target_path
+            ORDER BY source_path, target_path";
 
         cmd.CommandText = sql;
         if (lang != null)
@@ -627,39 +662,21 @@ public partial class DbReader
                 SqliteCommandPolicy.Add(cmd, $"@excludePath{i}", BuildPathLikePattern(excludePathPatterns[i]));
         }
         SqliteCommandPolicy.Add(cmd, "@limit", limit);
+        SqliteCommandPolicy.Add(cmd, "@symbolSampleLimit", DependencySymbolSampleLimit);
 
         var results = new List<FileDependencyResult>();
-        var resultIndexes = new Dictionary<(string SourcePath, string TargetPath), int>();
-        var symbolsByEdge = new Dictionary<(string SourcePath, string TargetPath), SortedSet<string>>();
         using var reader = cmd.ExecuteTrackedReader();
         while (reader.TrackedRead())
         {
             cancellationToken.ThrowIfCancellationRequested();
             candidateRowCount++;
-            var sourcePath = reader.GetString(0);
-            var targetPath = reader.GetString(1);
-            var key = (sourcePath, targetPath);
-            if (!resultIndexes.ContainsKey(key))
+            results.Add(new FileDependencyResult
             {
-                resultIndexes[key] = results.Count;
-                results.Add(new FileDependencyResult
-                {
-                    SourcePath = sourcePath,
-                    TargetPath = targetPath,
-                    ReferenceCount = 1,
-                    Symbols = string.Empty,
-                });
-            }
-
-            if (!symbolsByEdge.TryGetValue(key, out var symbols))
-                symbolsByEdge[key] = symbols = new SortedSet<string>(StringComparer.Ordinal);
-            symbols.Add(reader.GetString(2));
-        }
-
-        foreach (var (key, index) in resultIndexes)
-        {
-            if (symbolsByEdge.TryGetValue(key, out var symbols))
-                results[index].Symbols = string.Join(",", symbols.Take(DependencySymbolSampleLimit));
+                SourcePath = reader.GetString(0),
+                TargetPath = reader.GetString(1),
+                ReferenceCount = reader.GetInt32(2),
+                Symbols = reader.GetString(3),
+            });
         }
         return results;
     }

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -4839,15 +4839,34 @@ public partial class McpServer
 
         return WithDbReader(id, args, reader =>
         {
-            var results = reader.GetFileDependencies(limit, lang, pathPatterns, excludePaths, excludeTests, reverse);
-            var cycleCandidates = cyclesOnly
-                ? reader.GetFileDependencies(QueryCommandRunner.GetDependencyCycleGraphLimit(limit), lang, pathPatterns, excludePaths, excludeTests, reverse)
-                : results;
+            var cycleCandidateLimit = QueryCommandRunner.GetDependencyCycleGraphLimit(limit);
+            var cycleCandidateRowCount = 0;
+            var results = cyclesOnly
+                ? reader.GetFileDependencyCycleCandidates(
+                    checked(cycleCandidateLimit + 1),
+                    out cycleCandidateRowCount,
+                    lang,
+                    pathPatterns,
+                    excludePaths,
+                    excludeTests,
+                    reverse)
+                : reader.GetFileDependencies(limit, lang, pathPatterns, excludePaths, excludeTests, reverse);
+            var cycleCandidateRowsRead = cyclesOnly ? cycleCandidateRowCount : 0;
+            var cycleCandidates = cyclesOnly ? results.Take(cycleCandidateLimit).ToList() : results;
             var baseSqlGraphSignal = reader.GetSqlGraphContractSignal(lang, pathPatterns, excludePaths, excludeTests);
             List<List<string>> cycles = [];
-            var outputEdges = cyclesOnly ? QueryCommandRunner.FilterCycleEdges(cycleCandidates, out cycles).Take(limit).ToList() : results;
+            var outputEdges = cyclesOnly ? QueryCommandRunner.FilterCycleEdges(cycleCandidates, out cycles) : results;
+            var cycleCandidateTruncated = cyclesOnly && cycleCandidateRowsRead > cycleCandidateLimit;
+            var cycleDisplayTruncated = cyclesOnly && cycles.Count > limit;
             if (cyclesOnly)
+            {
                 cycles = cycles.Take(limit).ToList();
+                var cycleNodes = cycles.SelectMany(static cycle => cycle).ToHashSet(StringComparer.Ordinal);
+                outputEdges = outputEdges
+                    .Where(edge => cycleNodes.Count == 0 || (cycleNodes.Contains(edge.SourcePath) && cycleNodes.Contains(edge.TargetPath)))
+                    .Take(limit)
+                    .ToList();
+            }
             var sqlGraphSignalPaths = cyclesOnly
                 ? cycles.Count > 0
                     ? cycles.SelectMany(static cycle => cycle)
@@ -4867,6 +4886,26 @@ public partial class McpServer
                 payload["graph"] = BuildJsonGraphPayload(outputEdges);
             else
                 payload["edges"] = JsonSerializer.SerializeToNode(outputEdges, _jsonOptions);
+            if (cyclesOnly)
+            {
+                payload["truncated"] = cycleCandidateTruncated || cycleDisplayTruncated;
+                var truncatedReason = cycleCandidateTruncated
+                    ? "candidate_edge_limit"
+                    : cycleDisplayTruncated
+                        ? "display_limit"
+                        : null;
+                payload["termination_reason"] = truncatedReason switch
+                {
+                    "candidate_edge_limit" => "candidate_limit_reached",
+                    "display_limit" => "display_limit_reached",
+                    _ => "completed",
+                };
+                if (truncatedReason != null)
+                    payload["truncated_reason"] = truncatedReason;
+                payload["candidate_edge_count"] = Math.Min(cycleCandidateRowsRead, cycleCandidateLimit);
+                payload["candidate_edge_limit"] = cycleCandidateLimit;
+                payload["cycle_detection_mode"] = "bounded_candidate_edges";
+            }
             payload["format"] = format;
             payload["includeGenerated"] = includeGenerated;
             payload["generated_code_filter_supported"] = true;
@@ -4874,7 +4913,7 @@ public partial class McpServer
             AddSqlGraphContractSignal(payload, sqlGraphSignal);
             var summary = payload["count"]!.GetValue<int>() > 0
                 ? cyclesOnly ? $"Found {ConsoleUi.Counted(cycles.Count, "dependency cycle")}." : $"Found {ConsoleUi.Counted(results.Count, "dependency edge")}."
-                : "No file dependencies found.";
+                : cyclesOnly ? "No dependency cycles found." : "No file dependencies found.";
             if (results.Count == 0)
                 AddFreshnessHint(payload, reader);
             adjustments.ApplyTo(payload);

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -4904,7 +4904,7 @@ public partial class McpServer
                     payload["truncated_reason"] = truncatedReason;
                 payload["candidate_edge_count"] = Math.Min(cycleCandidateRowsRead, cycleCandidateLimit);
                 payload["candidate_edge_limit"] = cycleCandidateLimit;
-                payload["cycle_detection_mode"] = "bounded_candidate_edges";
+                payload["cycle_detection_mode"] = "bounded_approximate_candidate_edges";
             }
             payload["format"] = format;
             payload["includeGenerated"] = includeGenerated;

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -4213,6 +4213,54 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunDeps_CyclesJsonReportsCandidateLimitTruncation_Issue4065()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_deps_cycle_candidate_limit");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            for (var i = 0; i < 60; i++)
+            {
+                var symbolName = $"Target{i}";
+                InsertFileWithSymbol(dbPath, $"src/Target{i}.cs", symbolName);
+                InsertFileWithReferences(dbPath, $"src/Source{i}.cs", [symbolName]);
+            }
+            MarkDependencyGraphReady(dbPath);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunDeps(
+                ["--db", dbPath, "--json", "--cycles", "--limit", "1", "--lang", "csharp"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(0, json.GetProperty("count").GetInt32());
+            Assert.Empty(json.GetProperty("cycles").EnumerateArray());
+            Assert.True(json.GetProperty("truncated").GetBoolean());
+            Assert.Equal("candidate_limit_reached", json.GetProperty("termination_reason").GetString());
+            Assert.Equal("candidate_edge_limit", json.GetProperty("truncated_reason").GetString());
+            Assert.Equal(QueryCommandRunner.DefaultDependencyCycleGraphLimit, json.GetProperty("candidate_edge_count").GetInt32());
+            Assert.Equal(QueryCommandRunner.DefaultDependencyCycleGraphLimit, json.GetProperty("candidate_edge_limit").GetInt32());
+            Assert.Equal("bounded_candidate_edges", json.GetProperty("cycle_detection_mode").GetString());
+
+            var (textExitCode, textStdout, textStderr) = CaptureConsole(() => QueryCommandRunner.RunDeps(
+                ["--db", dbPath, "--cycles", "--limit", "1", "--lang", "csharp"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, textExitCode);
+            Assert.Equal(string.Empty, textStdout);
+            Assert.Contains("No dependency cycles found", textStderr, StringComparison.Ordinal);
+            Assert.Contains("Warning: dependency cycle detection returned partial results", textStderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunDeps_ExcludeTestsFiltersSourceAndTargetEdges_Issue3895()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_deps_exclude_tests_targets");

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -4243,7 +4243,7 @@ public partial class QueryCommandRunnerTests
             Assert.Equal("candidate_edge_limit", json.GetProperty("truncated_reason").GetString());
             Assert.Equal(QueryCommandRunner.DefaultDependencyCycleGraphLimit, json.GetProperty("candidate_edge_count").GetInt32());
             Assert.Equal(QueryCommandRunner.DefaultDependencyCycleGraphLimit, json.GetProperty("candidate_edge_limit").GetInt32());
-            Assert.Equal("bounded_candidate_edges", json.GetProperty("cycle_detection_mode").GetString());
+            Assert.Equal("bounded_approximate_candidate_edges", json.GetProperty("cycle_detection_mode").GetString());
 
             var (textExitCode, textStdout, textStderr) = CaptureConsole(() => QueryCommandRunner.RunDeps(
                 ["--db", dbPath, "--cycles", "--limit", "1", "--lang", "csharp"],
@@ -4253,6 +4253,46 @@ public partial class QueryCommandRunnerTests
             Assert.Equal(string.Empty, textStdout);
             Assert.Contains("No dependency cycles found", textStderr, StringComparison.Ordinal);
             Assert.Contains("Warning: dependency cycle detection returned partial results", textStderr, StringComparison.Ordinal);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunDeps_CyclesCandidateBudgetCountsDistinctEdges_Issue4065()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_deps_cycle_candidate_edges");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            var noiseSymbols = Enumerable.Range(0, 80)
+                .Select(index => $"Noise{index:D2}")
+                .ToArray();
+            InsertFileWithSymbols(dbPath, "src/NoiseTarget.cs", noiseSymbols);
+            InsertFileWithReferences(dbPath, "src/NoiseCaller.cs", noiseSymbols);
+            InsertFileWithSymbolsAndReferences(dbPath, "src/CycleA.cs", ["CycleA"], ["CycleB"]);
+            InsertFileWithSymbolsAndReferences(dbPath, "src/CycleB.cs", ["CycleB"], ["CycleA"]);
+            MarkDependencyGraphReady(dbPath);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunDeps(
+                ["--db", dbPath, "--json", "--cycles", "--limit", "1", "--lang", "csharp"],
+                _jsonOptions));
+
+            using var document = ParseJsonOutput(stdout);
+            var json = document.RootElement;
+            var cycle = Assert.Single(json.GetProperty("cycles").EnumerateArray());
+            var nodes = cycle.GetProperty("nodes").EnumerateArray().Select(node => node.GetString()).ToArray();
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(1, json.GetProperty("count").GetInt32());
+            Assert.False(json.GetProperty("truncated").GetBoolean());
+            Assert.Equal("completed", json.GetProperty("termination_reason").GetString());
+            Assert.Equal(3, json.GetProperty("candidate_edge_count").GetInt32());
+            Assert.Contains("src/CycleA.cs", nodes);
+            Assert.Contains("src/CycleB.cs", nodes);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- Make `deps --cycles` use a bounded approximate candidate-edge scan instead of the full dependency aggregation path.
- Add truncation metadata for CLI JSON/graph output and MCP dependency cycle responses.
- Document the new bounded approximate behavior and add a changelog fragment.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~RunDeps_Cycles"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~RunDeps_"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll deps --cycles --path src/ --exclude-tests --limit 10 --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll deps --cycles --path src/ --exclude-tests --limit 10`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~RunDeps_"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Review
- External Codex adversarial review found a High issue in the first implementation; fixed with distinct candidate-edge limiting and approximate-mode documentation.
- Follow-up `codex exec` review was blocked by usage limits, so the final `origin/main..HEAD` diff was reviewed locally with the same workflow.

Fixes #4065