### PR TITLE
Classify environment variable inventory

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1791,6 +1791,8 @@ Precedence is **CLI flag > environment variable > config file > built-in default
 
 Secrets are intentionally **not** loadable from the file: `CDIDX_GITHUB_TOKEN`, `CDIDX_MCP_AUTH_TOKEN`, and `CDIDX_MCP_HTTP_TOKEN` are env-only so tokens never get checked into version control.
 
+Run `cdidx doctor --env-inventory` (or `cdidx doctor --json`) to audit the full environment-variable contract. Each inventory row reports a stable `domain` (`display`, `config`, `auth_secret`, `trust_boundary`, `subprocess`, `update_logging`, or `indexing_query`), sensitivity, config-file support, and `invalid_value_behavior`. Secret-bearing variables such as `CDIDX_GITHUB_TOKEN`, `CDIDX_MCP_AUTH_TOKEN`, and `CDIDX_MCP_HTTP_TOKEN` are marked `auth_secret` and are redacted from doctor/config diagnostics; trust-boundary variables such as MCP tool filters, workspace plugin trust, hook directories, and GitHub proxy credential opt-ins document whether invalid values fail closed, warn, or leave the feature disabled.
+
 Supported schema (top-level keys are snake_case; nested indexing kind keys keep the CLI issue spelling; every key is optional):
 
 ```jsonc
@@ -4429,6 +4431,8 @@ MCP のレスポンスサイズ上限は、環境変数 override で guard が�
 優先順位は **CLI フラグ > 環境変数 > 設定ファイル > 組み込み既定値** です。設定ファイル由来の値は、対応する環境変数がプロセスで未設定の場合にのみ適用されるため、シェルや CI で既に export されている値が常に優先されます。設定 JSON はスキーマ検証前に 64 KiB と保守的なネスト深度の上限で検査されます。不正なファイル（無効な JSON、未知のキー、型違い、過度なネスト）は hard error として扱われ、cdidx はファイルパスと検出できた該当フィールドすべてを示して終了コード `1` で終了します。完全にバイパスしたい場合は `CDIDX_DISABLE_CONFIG_FILE=1` を設定してください。
 
 シークレットは意図的に**ファイルから読み込めません**。`CDIDX_GITHUB_TOKEN` / `CDIDX_MCP_AUTH_TOKEN` / `CDIDX_MCP_HTTP_TOKEN` は環境変数専用としており、トークンがバージョン管理に混入するのを防ぎます。
+
+`cdidx doctor --env-inventory`（または `cdidx doctor --json`）で環境変数契約全体を監査できます。各 inventory 行は安定した `domain`（`display`、`config`、`auth_secret`、`trust_boundary`、`subprocess`、`update_logging`、`indexing_query`）、sensitivity、設定ファイル対応、`invalid_value_behavior` を出力します。`CDIDX_GITHUB_TOKEN` / `CDIDX_MCP_AUTH_TOKEN` / `CDIDX_MCP_HTTP_TOKEN` のような secret 変数は `auth_secret` として扱われ、doctor / config 診断では redact されます。MCP tool filter、workspace plugin trust、hook directory、GitHub proxy credential opt-in のような trust-boundary 変数は、不正値が fail closed になるのか、警告されるのか、機能を無効のままにするのかを inventory に明示します。
 
 対応スキーマ（top-level key は snake_case、ネストした indexing の kind key は CLI issue の表記を維持、すべて任意）:
 

--- a/changelog.d/unreleased/4073.changed.md
+++ b/changelog.d/unreleased/4073.changed.md
@@ -1,0 +1,18 @@
+---
+category: changed
+issues:
+  - 4073
+affected:
+  - src/CodeIndex/Cli/EnvironmentVariableInventory.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - tests/CodeIndex.Tests/ProgramRunnerTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Environment-variable inventory now reports domains and invalid-value behavior (#4073)** — `cdidx doctor --env-inventory` and doctor JSON classify environment-variable controls by display, config, auth secret, trust-boundary, subprocess, update/logging, and indexing/query domains and document how invalid values are handled.
+
+## 日本語
+
+- **環境変数 inventory が domain と不正値の扱いを報告するようになりました (#4073)** — `cdidx doctor --env-inventory` と doctor JSON は、環境変数制御を display、config、auth secret、trust-boundary、subprocess、update/logging、indexing/query の domain で分類し、不正値がどう扱われるかを示します。

--- a/src/CodeIndex/Cli/EnvironmentVariableInventory.cs
+++ b/src/CodeIndex/Cli/EnvironmentVariableInventory.cs
@@ -9,6 +9,14 @@ namespace CodeIndex.Cli;
 
 internal static class EnvironmentVariableInventory
 {
+    internal const string DomainDisplay = "display";
+    internal const string DomainConfig = "config";
+    internal const string DomainAuthSecret = "auth_secret";
+    internal const string DomainTrustBoundary = "trust_boundary";
+    internal const string DomainSubprocess = "subprocess";
+    internal const string DomainUpdateLogging = "update_logging";
+    internal const string DomainIndexingQuery = "indexing_query";
+
     internal const string SensitivityPublic = "public_config";
     internal const string SensitivitySecret = "secret";
 
@@ -43,8 +51,11 @@ internal static class EnvironmentVariableInventory
         Item(GlobalToolLog.LogMaxSizeMbEnvironmentVariable, "logging", SensitivityPublic, "io", "50", "yes", "Persistent stderr log rotation size cap in MiB.", Location("src/CodeIndex/Cli/GlobalToolLog.cs", 19, "GlobalToolLog")),
         Item(GlobalToolLog.GlobalToolLogMaxBytesEnvironmentVariable, "logging", SensitivityPublic, "io", "internal cap", "no", "Maximum persistent stderr log bytes.", Location("src/CodeIndex/Cli/GlobalToolLog.cs", 20, "GlobalToolLog")),
         Item("CDIDX_GLOBAL_TOOL_LOG_DIR", "logging", SensitivityPublic, "io", "platform log directory", "yes", "Persistent stderr log directory.", Location("src/CodeIndex/Cli/GlobalToolLog.cs", 736, "GlobalToolLog")),
+        Item(UpdateChecker.DisableEnvVar, "update", SensitivityPublic, "diagnostic", "automatic update checks enabled", "no", "Disable automatic release update checks.", Location("src/CodeIndex/Cli/UpdateChecker.cs", 9, "UpdateChecker")),
+        Item(UpdateChecker.DiagnosticsEnvVar, "update", SensitivityPublic, "diagnostic", "cache diagnostics disabled", "no", "Emit bounded update-check cache diagnostics.", Location("src/CodeIndex/Cli/UpdateChecker.cs", 10, "UpdateChecker")),
 
         Item(SearchAuditRecipes.RecipePathsEnvironmentVariable, "search", SensitivityPublic, "io", "built-in recipes only", "no", "Additional search recipe files.", Location("src/CodeIndex/Cli/SearchAuditRecipes.cs", 13, "SearchAuditRecipes")),
+        Item(global::CodeIndex.SubprocessEnvironmentPolicy.TestEnvironmentPrefix + "*", "subprocess", SensitivityPublic, "test_only", "not forwarded outside isolated workers", "no", "Test-only environment prefix forwarded only to isolated worker subprocesses.", Location("src/CodeIndex/SubprocessEnvironmentPolicy.cs", 10, "SubprocessEnvironmentPolicy")),
 
         Item(McpToolFilter.AllowEnvVarName, "mcp", SensitivityPublic, "security", "all known tools enabled", "yes", "Allowlist visible/callable MCP tools.", Location("src/CodeIndex/Mcp/McpToolFilter.cs", 23, "McpToolFilter")),
         Item(McpToolFilter.DenyEnvVarName, "mcp", SensitivityPublic, "security", "no denied tools", "yes", "Denylist MCP tools from the default enabled set.", Location("src/CodeIndex/Mcp/McpToolFilter.cs", 24, "McpToolFilter")),
@@ -98,19 +109,97 @@ internal static class EnvironmentVariableInventory
         string configFileSupported,
         string description,
         params EnvironmentVariableInventoryLocation[] locations) =>
-        new(name, category, sensitivity, policy, defaultBehavior, configFileSupported, description, locations);
+        new(
+            name,
+            ResolveDomain(name, category, sensitivity, policy),
+            category,
+            sensitivity,
+            policy,
+            defaultBehavior,
+            configFileSupported,
+            ResolveInvalidValueBehavior(name, category, sensitivity, policy),
+            description,
+            locations);
 
     private static EnvironmentVariableInventoryLocation Location(string path, int line, string member)
         => new(path, line, member);
+
+    private static string ResolveDomain(string name, string category, string sensitivity, string policy)
+    {
+        if (sensitivity == SensitivitySecret)
+            return DomainAuthSecret;
+
+        if (name == global::CodeIndex.SubprocessEnvironmentPolicy.TestEnvironmentPrefix + "*")
+            return DomainSubprocess;
+
+        return category switch
+        {
+            "terminal" or "locale" or "output" => DomainDisplay,
+            _ when policy == "display" => DomainDisplay,
+            "config" or "workspace" or "path" => DomainConfig,
+            "plugins" => DomainTrustBoundary,
+            "mcp" when policy == "security" => DomainTrustBoundary,
+            "github" when policy == "security" => DomainTrustBoundary,
+            "logging" or "telemetry" or "debug" or "status" or "update" => DomainUpdateLogging,
+            "indexing" or "query" or "search" or "sqlite" => DomainIndexingQuery,
+            _ => DomainConfig,
+        };
+    }
+
+    private static string ResolveInvalidValueBehavior(string name, string category, string sensitivity, string policy)
+    {
+        if (name == "CDIDX_GITHUB_TOKEN")
+            return "empty or whitespace values disable GitHub submission; non-empty values are sent as bearer tokens and authentication failures are reported by GitHub";
+
+        if (sensitivity == SensitivitySecret)
+            return "empty values disable the feature; whitespace/control-token values are rejected before use";
+
+        if (name == McpToolFilter.AllowEnvVarName || name == McpToolFilter.DenyEnvVarName)
+            return "invalid CSV bounds fail closed; unknown names warn and are ignored";
+
+        if (name == CdidxConfigFile.DisableEnvVar)
+            return "only value 1 disables config discovery; other values leave discovery enabled";
+
+        if (name == UpdateChecker.DisableEnvVar)
+            return "only values 1 or true disable update checks; other values leave checks enabled";
+
+        if (name == UpdateChecker.DiagnosticsEnvVar)
+            return "only values 1, true, or yes enable diagnostics; other values leave diagnostics disabled";
+
+        if (name == global::CodeIndex.SubprocessEnvironmentPolicy.TestEnvironmentPrefix + "*")
+            return "only non-empty variables with the exact prefix are copied into isolated worker subprocesses";
+
+        return category switch
+        {
+            "terminal" or "locale" or "output" =>
+                "unsupported values fall back to automatic display behavior unless the owning option documents a warning",
+            "plugins" =>
+                "unsafe or invalid paths/options are rejected or ignored with bounded diagnostics",
+            "mcp" when policy == "security" =>
+                "invalid security gates fail closed or keep the feature disabled with a warning",
+            "github" when policy == "security" =>
+                "non-opt-in values keep the trust boundary disabled",
+            "logging" or "telemetry" or "update" =>
+                "invalid paths or values disable the auxiliary output/check and keep the main command running",
+            "indexing" or "query" or "search" or "sqlite" =>
+                "non-numeric, out-of-range, or overflowing values fall back, clamp, warn, or reject as documented by the owning command",
+            "config" or "workspace" or "path" =>
+                "missing values use the default; invalid paths are rejected by the owning resolver",
+            _ =>
+                "missing values use the default; invalid values follow the owning command contract",
+        };
+    }
 }
 
 internal sealed record EnvironmentVariableInventoryItem(
     [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("domain")] string Domain,
     [property: JsonPropertyName("category")] string Category,
     [property: JsonPropertyName("sensitivity")] string Sensitivity,
     [property: JsonPropertyName("policy")] string Policy,
     [property: JsonPropertyName("default_behavior")] string DefaultBehavior,
     [property: JsonPropertyName("config_file_supported")] string ConfigFileSupported,
+    [property: JsonPropertyName("invalid_value_behavior")] string InvalidValueBehavior,
     [property: JsonPropertyName("description")] string Description,
     [property: JsonPropertyName("locations")] IReadOnlyList<EnvironmentVariableInventoryLocation> Locations);
 

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -741,11 +741,13 @@ internal static partial class ProgramRunner
                 ? "<unknown>"
                 : $"{firstLocation.Path}:{firstLocation.Line}";
             Console.WriteLine($"  {item.Name}");
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("domain", item.Domain, indent: "    "));
             Console.WriteLine(ConsoleUi.FormatSummaryLine("category", item.Category, indent: "    "));
             Console.WriteLine(ConsoleUi.FormatSummaryLine("sensitivity", item.Sensitivity, indent: "    "));
             Console.WriteLine(ConsoleUi.FormatSummaryLine("policy", item.Policy, indent: "    "));
             Console.WriteLine(ConsoleUi.FormatSummaryLine("default", item.DefaultBehavior, indent: "    "));
             Console.WriteLine(ConsoleUi.FormatSummaryLine("config", item.ConfigFileSupported, indent: "    "));
+            Console.WriteLine(ConsoleUi.FormatSummaryLine("invalid", item.InvalidValueBehavior, indent: "    "));
             Console.WriteLine(ConsoleUi.FormatSummaryLine("location", location, indent: "    "));
             Console.WriteLine(ConsoleUi.FormatSummaryLine("description", item.Description, indent: "    "));
         }

--- a/tests/CodeIndex.Tests/ProgramRunnerTests.cs
+++ b/tests/CodeIndex.Tests/ProgramRunnerTests.cs
@@ -530,15 +530,61 @@ public class ProgramRunnerTests
         var byName = EnvironmentVariableInventory.Items.ToDictionary(item => item.Name, StringComparer.Ordinal);
 
         var githubToken = Assert.Contains("CDIDX_GITHUB_TOKEN", byName);
+        Assert.Equal(EnvironmentVariableInventory.DomainAuthSecret, githubToken.Domain);
         Assert.Equal(EnvironmentVariableInventory.SensitivitySecret, githubToken.Sensitivity);
         Assert.Equal("security", githubToken.Policy);
         Assert.Equal("no", githubToken.ConfigFileSupported);
+        Assert.Contains("GitHub submission", githubToken.InvalidValueBehavior, StringComparison.Ordinal);
         Assert.Contains(githubToken.Locations, location => location.Path.EndsWith("GitHubIssueReporter.cs", StringComparison.Ordinal));
 
+        var mcpAuthToken = Assert.Contains(McpAuthenticatorFactory.AuthTokenEnvVar, byName);
+        Assert.Equal(EnvironmentVariableInventory.DomainAuthSecret, mcpAuthToken.Domain);
+        Assert.Contains("whitespace/control-token", mcpAuthToken.InvalidValueBehavior, StringComparison.Ordinal);
+
         var maxLineWidth = Assert.Contains(QueryCommandRunner.DefaultMaxLineWidthEnvironmentVariable, byName);
+        Assert.Equal(EnvironmentVariableInventory.DomainDisplay, maxLineWidth.Domain);
         Assert.Equal(EnvironmentVariableInventory.SensitivityPublic, maxLineWidth.Sensitivity);
         Assert.Equal("display", maxLineWidth.Policy);
         Assert.Equal("yes", maxLineWidth.ConfigFileSupported);
+        Assert.NotEmpty(maxLineWidth.InvalidValueBehavior);
+
+        var defaultLimit = Assert.Contains(QueryCommandRunner.DefaultLimitEnvironmentVariable, byName);
+        Assert.Equal(EnvironmentVariableInventory.DomainIndexingQuery, defaultLimit.Domain);
+
+        var toolAllowlist = Assert.Contains(McpToolFilter.AllowEnvVarName, byName);
+        Assert.Equal(EnvironmentVariableInventory.DomainTrustBoundary, toolAllowlist.Domain);
+        Assert.Contains("fail closed", toolAllowlist.InvalidValueBehavior, StringComparison.OrdinalIgnoreCase);
+
+        var updateDisable = Assert.Contains(UpdateChecker.DisableEnvVar, byName);
+        Assert.Equal(EnvironmentVariableInventory.DomainUpdateLogging, updateDisable.Domain);
+        Assert.Contains("1 or true", updateDisable.InvalidValueBehavior, StringComparison.Ordinal);
+
+        var isolatedWorkerPrefix = Assert.Contains(global::CodeIndex.SubprocessEnvironmentPolicy.TestEnvironmentPrefix + "*", byName);
+        Assert.Equal(EnvironmentVariableInventory.DomainSubprocess, isolatedWorkerPrefix.Domain);
+        Assert.Contains("isolated worker subprocesses", isolatedWorkerPrefix.InvalidValueBehavior, StringComparison.Ordinal);
+
+        Assert.All(EnvironmentVariableInventory.Items, item =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(item.Domain));
+            Assert.False(string.IsNullOrWhiteSpace(item.InvalidValueBehavior));
+        });
+    }
+
+    [Theory]
+    [InlineData("1", true)]
+    [InlineData("true", true)]
+    [InlineData("TRUE", true)]
+    [InlineData("0", false)]
+    [InlineData("false", false)]
+    [InlineData("yes", false)]
+    [InlineData("garbage", false)]
+    [InlineData("", false)]
+    public void UpdateChecker_IsDisabled_OnlyRecognizesExplicitTrueValues(string value, bool expected)
+    {
+        using var env = EnvironmentVariableScope.Capture(UpdateChecker.DisableEnvVar);
+        env.Set(UpdateChecker.DisableEnvVar, value);
+
+        Assert.Equal(expected, UpdateChecker.IsDisabled());
     }
 
     [Fact]
@@ -552,7 +598,9 @@ public class ProgramRunnerTests
         Assert.Empty(stderr);
         Assert.Contains("environment_inventory:", stdout);
         Assert.Contains("CDIDX_GITHUB_TOKEN", stdout);
+        Assert.Contains("domain   : auth_secret", stdout);
         Assert.Contains("sensitivity: secret", stdout);
+        Assert.Contains("invalid", stdout);
         Assert.Contains("CDIDX_MCP_RATE_LIMIT_RPS", stdout);
         Assert.Contains("policy   : performance", stdout);
     }
@@ -593,12 +641,22 @@ public class ProgramRunnerTests
         Assert.Equal(visiblePath, envByName["CDIDX_VISIBLE_PATH"].GetProperty("value").GetString());
         Assert.False(envByName["CDIDX_VISIBLE_PATH"].GetProperty("sensitive").GetBoolean());
 
-        var inventoryNames = root.GetProperty("environment_inventory")
+        var inventoryByName = root.GetProperty("environment_inventory")
             .EnumerateArray()
-            .Select(element => element.GetProperty("name").GetString())
-            .ToHashSet(StringComparer.Ordinal);
-        Assert.Contains("CDIDX_GITHUB_TOKEN", inventoryNames);
-        Assert.Contains(QueryCommandRunner.DefaultMaxLineWidthEnvironmentVariable, inventoryNames);
+            .ToDictionary(
+                element => element.GetProperty("name").GetString()!,
+                element => element,
+                StringComparer.Ordinal);
+        Assert.Equal(
+            EnvironmentVariableInventory.DomainAuthSecret,
+            inventoryByName["CDIDX_GITHUB_TOKEN"].GetProperty("domain").GetString());
+        Assert.Contains(
+            "GitHub submission",
+            inventoryByName["CDIDX_GITHUB_TOKEN"].GetProperty("invalid_value_behavior").GetString(),
+            StringComparison.Ordinal);
+        Assert.Equal(
+            EnvironmentVariableInventory.DomainDisplay,
+            inventoryByName[QueryCommandRunner.DefaultMaxLineWidthEnvironmentVariable].GetProperty("domain").GetString());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Add stable `domain` and `invalid_value_behavior` fields to the environment-variable inventory emitted by `doctor --env-inventory` and `doctor --json`.
- Add inventory coverage for update-check variables and the isolated-worker subprocess test prefix.
- Document the environment-variable inventory contract in both English and Japanese user-guide sections.

## Documentation and changelog

- Updated `USER_GUIDE.md` in both English and Japanese.
- Added `changelog.d/unreleased/4073.changed.md`.

## Validation

- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 -p:UseSharedCompilation=false -p:BuildInParallel=false -m:1 --no-restore`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-build --filter "FullyQualifiedName~ProgramRunnerTests"`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net9.0 -p:UseSharedCompilation=false -p:BuildInParallel=false -m:1 --no-restore`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net9.0 --no-build --filter "FullyQualifiedName~ProgramRunnerTests"`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll doctor --env-inventory`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll doctor --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `git diff --check`
- `git diff --cached --check`
- Codex adversarial review found one actionable issue in the secret-token invalid-value text; the issue was fixed. A second Codex review attempt was blocked by the Codex usage limit, so the follow-up verification is covered by the tests and smoke checks above.

`dotnet format CodeIndex.sln --verify-no-changes --no-restore` and the same command with `--include` were attempted but did not complete under the current machine's concurrent dotnet workload. A full solution build was also cancelled after the CLI project built because the test project compile step stalled under the same load; targeted net8/net9 builds and tests passed.

Fixes #4073
