### PR TITLE
Downrank generic symbol audit noise

### DIFF
--- a/changelog.d/unreleased/4066.fixed.md
+++ b/changelog.d/unreleased/4066.fixed.md
@@ -1,0 +1,18 @@
+---
+category: fixed
+issues:
+  - 4066
+affected:
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Models/QueryResults.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSymbolTests.cs
+---
+
+## English
+
+- **Symbol audit ranking now downranks ambiguous generic names (#4066)** — `symbols --sort references`, `--sort hotspot`, and `--sort complexity` now use generic-name penalties, duplicate-definition dilution, structural member penalties, and structural size caps so one-line `Path`, `File`, `Equal`, or partial-class rows no longer dominate top-N audit output.
+
+## 日本語
+
+- **シンボル監査ランキングで曖昧な汎用名を下げるようになりました (#4066)** — `symbols --sort references`、`--sort hotspot`、`--sort complexity` は汎用名ペナルティ、重複定義の希釈、構造的なメンバーへのペナルティ、構造的サイズの上限を使うようになり、1 行の `Path`、`File`、`Equal` や部分クラス行が上位 N 件の監査出力を占有しにくくなりました。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -5318,6 +5318,16 @@ public static partial class QueryCommandRunner
             parts.Add($"refs={result.ReferenceCount.Value}");
         if (result.HotspotScore.HasValue)
             parts.Add($"hotspot={result.HotspotScore.Value.ToString("0.###", CultureInfo.InvariantCulture)}");
+        if (result.RankingReferenceScore.HasValue)
+            parts.Add($"rank_refs={result.RankingReferenceScore.Value.ToString("0.###", CultureInfo.InvariantCulture)}");
+        if (result.RankingHotspotScore.HasValue)
+            parts.Add($"rank_hotspot={result.RankingHotspotScore.Value.ToString("0.###", CultureInfo.InvariantCulture)}");
+        if (result.GenericNamePenalty is < 1.0)
+            parts.Add($"name_penalty={result.GenericNamePenalty.Value.ToString("0.###", CultureInfo.InvariantCulture)}");
+        if (result.StructuralRankPenalty is < 1.0)
+            parts.Add($"struct_penalty={result.StructuralRankPenalty.Value.ToString("0.###", CultureInfo.InvariantCulture)}");
+        if (result.DefinitionSites is > 1)
+            parts.Add($"defs={result.DefinitionSites.Value}");
         if (result.SizeLines.HasValue)
             parts.Add($"size={result.SizeLines.Value}");
         if (result.ComplexityScore.HasValue)

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -20,6 +20,8 @@ public partial class DbReader
     private const double GenericHotspotNamePenalty = 0.35;
     private const string GenericHotspotNamePenaltySqlLiteral = "0.35";
     private const string GenericHotspotNamesSql = "('add','append','build','call','combine','convert','create','execute','get','getstring','getvalue','getvalues','handle','invoke','load','parse','process','read','resolve','run','set','start','stop','tolist','tostring','tryparse','update','write')";
+    private const string GenericSymbolRankNamePenaltySqlLiteral = "0.01";
+    private const string GenericSymbolRankNamesSql = "('add','append','build','call','combine','contains','convert','count','create','equal','equals','execute','file','files','get','getstring','getvalue','getvalues','handle','id','invoke','key','kind','length','line','load','name','parse','path','process','read','resolve','run','set','start','stop','text','tolist','tostring','tryparse','type','update','value','values','write')";
 
     private const string UnusedBucketLikelyPrivate = "likely_unused_private";
     private const string UnusedBucketMaybeNonPublic = "maybe_unused_nonpublic";
@@ -823,14 +825,31 @@ public partial class DbReader
                 GROUP BY rf.lang, sr.symbol_name
             ) symbol_rank
               ON symbol_rank.lang = f.lang
-             AND symbol_rank.symbol_name = s.name COLLATE NOCASE"
+             AND symbol_rank.symbol_name = s.name COLLATE NOCASE
+            LEFT JOIN (
+                SELECT df.lang AS lang,
+                       ds.name AS symbol_name,
+                       COUNT(*) AS definition_sites
+                FROM symbols ds
+                JOIN files df ON df.id = ds.file_id
+                WHERE ds.name IS NOT NULL
+                  AND ds.name <> ''
+                GROUP BY df.lang, ds.name
+            ) symbol_defs
+              ON symbol_defs.lang = f.lang
+             AND symbol_defs.symbol_name = s.name COLLATE NOCASE"
             : string.Empty;
         var referenceCountSql = includeRankSignals ? "COALESCE(symbol_rank.reference_count, 0)" : "CAST(0 AS INTEGER)";
         var hotspotScoreSql = includeRankSignals ? "COALESCE(symbol_rank.hotspot_score, 0.0)" : "CAST(0.0 AS REAL)";
-        var genericNamePenaltySql = includeRankSignals ? GetGenericHotspotNamePenaltySql("s.name") : "1.0";
-        var rankingReferenceCountSql = includeRankSignals ? $"(({referenceCountSql}) * ({genericNamePenaltySql}))" : referenceCountSql;
-        var rankingHotspotScoreSql = includeRankSignals ? $"(({hotspotScoreSql}) * ({genericNamePenaltySql}))" : hotspotScoreSql;
-        var complexityScoreSql = $@"(({sizeLinesSql}) + ({rankingReferenceCountSql} * 4.0) + ({rankingHotspotScoreSql} * 2.0) + CASE
+        var genericNamePenaltySql = includeRankSignals ? GetGenericSymbolRankNamePenaltySql("s.name") : "1.0";
+        var definitionSitesSql = includeRankSignals ? "COALESCE(symbol_defs.definition_sites, 1)" : "CAST(1 AS INTEGER)";
+        var definitionDilutionSql = $"CASE WHEN ({definitionSitesSql}) > 1 THEN CAST(({definitionSitesSql}) * ({definitionSitesSql}) AS REAL) ELSE 1.0 END";
+        var structuralRankPenaltySql = includeRankSignals ? $"CASE WHEN s.kind IN ('property', 'enum') AND ({sizeLinesSql}) <= 1 THEN 0.1 ELSE 1.0 END" : "1.0";
+        var rankingReferenceScoreSql = includeRankSignals ? $"(({referenceCountSql}) * ({genericNamePenaltySql}) * ({structuralRankPenaltySql}) / ({definitionDilutionSql}))" : referenceCountSql;
+        var rankingHotspotScoreSql = includeRankSignals ? $"(({hotspotScoreSql}) * ({genericNamePenaltySql}) * ({structuralRankPenaltySql}) / ({definitionDilutionSql}))" : hotspotScoreSql;
+        var cappedRankingReferenceScoreSql = $"CASE WHEN ({rankingReferenceScoreSql}) > 100.0 THEN 100.0 ELSE ({rankingReferenceScoreSql}) END";
+        var cappedRankingHotspotScoreSql = $"CASE WHEN ({rankingHotspotScoreSql}) > 150.0 THEN 150.0 ELSE ({rankingHotspotScoreSql}) END";
+        var complexityScoreSql = $@"(({sizeLinesSql} * 16.0) + ({cappedRankingReferenceScoreSql} * 0.75) + ({cappedRankingHotspotScoreSql} * 0.35) + CASE
                        WHEN {visibilitySql} IN ('public', 'pub', 'open', 'export') THEN 8.0
                        WHEN {visibilitySql} IN ('protected', 'internal', 'protected internal') THEN 4.0
                        ELSE 0.0
@@ -849,6 +868,11 @@ public partial class DbReader
                    {returnTypeSql} AS return_type,
                    {referenceCountSql} AS reference_count,
                    {hotspotScoreSql} AS hotspot_score,
+                   {rankingReferenceScoreSql} AS ranking_reference_score,
+                   {rankingHotspotScoreSql} AS ranking_hotspot_score,
+                   {genericNamePenaltySql} AS generic_name_penalty,
+                   {structuralRankPenaltySql} AS structural_rank_penalty,
+                   {definitionSitesSql} AS definition_sites,
                    {sizeLinesSql} AS size_lines,
                    {complexityScoreSql} AS complexity_score
             FROM symbols s
@@ -916,7 +940,7 @@ public partial class DbReader
             "WHEN @preferCaseInsensitiveNormalizedSqlMatch = 1 AND f.lang = 'sql' AND sql_segment_count(s.name) = @rawQuerySegmentCount AND sql_normalize_name_folded(s.name) = @rawQueryNormalizedFolded THEN 3 " +
             "WHEN @preferCaseInsensitiveSqlLeafMatch = 1 AND f.lang = 'sql' AND sql_leaf_name_folded(s.name) = @rawQueryLeafFolded THEN 4 " +
             "ELSE 5 END";
-        sql += BuildSymbolSortOrderBy(sortMode, exactNameOrderSql, referenceCountSql, rankingHotspotScoreSql, sizeLinesSql, complexityScoreSql, startColumnSql);
+        sql += BuildSymbolSortOrderBy(sortMode, exactNameOrderSql, referenceCountSql, hotspotScoreSql, rankingReferenceScoreSql, rankingHotspotScoreSql, sizeLinesSql, complexityScoreSql, startColumnSql);
         sql += " LIMIT @limit";
 
         cmd.CommandText = sql;
@@ -1007,8 +1031,13 @@ public partial class DbReader
                 SortMode = includeRankingMetadata ? sortModeName : null,
                 ReferenceCount = includeRankingMetadata ? Convert.ToInt32(reader.GetInt64(15)) : null,
                 HotspotScore = includeRankingMetadata ? Math.Round(reader.GetDouble(16), 3) : null,
-                SizeLines = includeRankingMetadata ? Convert.ToInt32(reader.GetInt64(17)) : null,
-                ComplexityScore = includeRankingMetadata ? Math.Round(reader.GetDouble(18), 3) : null,
+                RankingReferenceScore = includeRankingMetadata ? Math.Round(reader.GetDouble(17), 3) : null,
+                RankingHotspotScore = includeRankingMetadata ? Math.Round(reader.GetDouble(18), 3) : null,
+                GenericNamePenalty = includeRankingMetadata ? Math.Round(reader.GetDouble(19), 3) : null,
+                StructuralRankPenalty = includeRankingMetadata ? Math.Round(reader.GetDouble(20), 3) : null,
+                DefinitionSites = includeRankingMetadata ? Convert.ToInt32(reader.GetInt64(21)) : null,
+                SizeLines = includeRankingMetadata ? Convert.ToInt32(reader.GetInt64(22)) : null,
+                ComplexityScore = includeRankingMetadata ? Math.Round(reader.GetDouble(23), 3) : null,
             });
         }
         return results;
@@ -1017,11 +1046,16 @@ public partial class DbReader
     private static string GetGenericHotspotNamePenaltySql(string nameSql)
         => $"CASE WHEN lower({nameSql}) IN {GenericHotspotNamesSql} THEN {GenericHotspotNamePenaltySqlLiteral} ELSE 1.0 END";
 
+    private static string GetGenericSymbolRankNamePenaltySql(string nameSql)
+        => $"CASE WHEN lower({nameSql}) IN {GenericSymbolRankNamesSql} THEN {GenericSymbolRankNamePenaltySqlLiteral} ELSE 1.0 END";
+
     private string BuildSymbolSortOrderBy(
         SymbolSortMode sortMode,
         string exactNameOrderSql,
         string referenceCountSql,
-        string hotspotScoreSql,
+        string rawHotspotScoreSql,
+        string rankingReferenceScoreSql,
+        string rankingHotspotScoreSql,
         string sizeLinesSql,
         string complexityScoreSql,
         string startColumnSql)
@@ -1029,10 +1063,10 @@ public partial class DbReader
         var stableTieBreakers = $"{PathBucketOrder}, {VisibilityOrder}, s.name, f.path, s.line, {startColumnSql} ASC, s.id ASC";
         return sortMode switch
         {
-            SymbolSortMode.Hotspot => $" ORDER BY {hotspotScoreSql} DESC, {referenceCountSql} DESC, {sizeLinesSql} DESC, {stableTieBreakers}",
-            SymbolSortMode.References => $" ORDER BY {referenceCountSql} DESC, {hotspotScoreSql} DESC, {sizeLinesSql} DESC, {stableTieBreakers}",
-            SymbolSortMode.Size => $" ORDER BY {sizeLinesSql} DESC, {referenceCountSql} DESC, {hotspotScoreSql} DESC, {stableTieBreakers}",
-            SymbolSortMode.Complexity => $" ORDER BY {complexityScoreSql} DESC, {hotspotScoreSql} DESC, {referenceCountSql} DESC, {sizeLinesSql} DESC, {stableTieBreakers}",
+            SymbolSortMode.Hotspot => $" ORDER BY {rankingHotspotScoreSql} DESC, {rankingReferenceScoreSql} DESC, {rawHotspotScoreSql} DESC, {referenceCountSql} DESC, {sizeLinesSql} DESC, {stableTieBreakers}",
+            SymbolSortMode.References => $" ORDER BY {rankingReferenceScoreSql} DESC, {rankingHotspotScoreSql} DESC, {referenceCountSql} DESC, {rawHotspotScoreSql} DESC, {sizeLinesSql} DESC, {stableTieBreakers}",
+            SymbolSortMode.Size => $" ORDER BY {sizeLinesSql} DESC, {rankingReferenceScoreSql} DESC, {rankingHotspotScoreSql} DESC, {referenceCountSql} DESC, {stableTieBreakers}",
+            SymbolSortMode.Complexity => $" ORDER BY {complexityScoreSql} DESC, {rankingHotspotScoreSql} DESC, {rankingReferenceScoreSql} DESC, {referenceCountSql} DESC, {sizeLinesSql} DESC, {stableTieBreakers}",
             SymbolSortMode.Path => $" ORDER BY f.path, s.line, {startColumnSql} ASC, s.name, s.id ASC",
             _ => $" ORDER BY {exactNameOrderSql}, {stableTieBreakers}",
         };

--- a/src/CodeIndex/Models/QueryResults.cs
+++ b/src/CodeIndex/Models/QueryResults.cs
@@ -231,6 +231,16 @@ public class SymbolResult
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public double? HotspotScore { get; set; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? RankingReferenceScore { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? RankingHotspotScore { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? GenericNamePenalty { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public double? StructuralRankPenalty { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? DefinitionSites { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public int? SizeLines { get; set; }
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public double? ComplexityScore { get; set; }

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSymbolTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSymbolTests.cs
@@ -275,6 +275,11 @@ public partial class QueryCommandRunnerTests
             Assert.Equal(sortMode, rows[0].GetProperty("sort_mode").GetString());
             Assert.True(rows[0].GetProperty("reference_count").GetInt32() >= 2);
             Assert.True(rows[0].GetProperty("hotspot_score").GetDouble() > 0);
+            Assert.True(rows[0].GetProperty("ranking_reference_score").GetDouble() > 0);
+            Assert.True(rows[0].GetProperty("ranking_hotspot_score").GetDouble() > 0);
+            Assert.True(rows[0].GetProperty("generic_name_penalty").GetDouble() > 0);
+            Assert.True(rows[0].GetProperty("structural_rank_penalty").GetDouble() > 0);
+            Assert.True(rows[0].GetProperty("definition_sites").GetInt32() > 0);
             Assert.True(rows[0].GetProperty("size_lines").GetInt32() > 0);
             Assert.True(rows[0].GetProperty("complexity_score").GetDouble() > 0);
         }
@@ -314,6 +319,65 @@ public partial class QueryCommandRunnerTests
             Assert.Equal(string.Empty, pathStderr);
             Assert.Equal("src/Alpha.cs", pathRow.GetProperty("path").GetString());
             Assert.Equal("path", pathRow.GetProperty("sort_mode").GetString());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunSymbols_SortReferencesAndComplexityDemoteGenericNameNoise_Issue4066()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_symbols_generic_rank_noise_4066");
+        try
+        {
+            var dbPath = CreateSymbolGenericRankNoiseFixtureDb(projectRoot);
+
+            var (refsExitCode, refsStdout, refsStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["--db", dbPath, "--json=array", "--kind", "function", "--lang", "csharp", "--sort", "references", "--limit", "3"],
+                _jsonOptions));
+            var (complexityExitCode, complexityStdout, complexityStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["--db", dbPath, "--json=array", "--kind", "function", "--lang", "csharp", "--sort", "complexity", "--limit", "1"],
+                _jsonOptions));
+            var (pathExitCode, pathStdout, pathStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["Path", "--db", dbPath, "--json=array", "--exact-name", "--lang", "csharp", "--sort", "references", "--limit", "1"],
+                _jsonOptions));
+            var (humanExitCode, humanStdout, humanStderr) = CaptureConsole(() => QueryCommandRunner.RunSymbols(
+                ["Path", "--db", dbPath, "--exact-name", "--lang", "csharp", "--sort", "references", "--limit", "1"],
+                _jsonOptions));
+
+            using var refsDocument = ParseJsonOutput(refsStdout);
+            var refsRows = refsDocument.RootElement.EnumerateArray().ToList();
+            using var complexityDocument = ParseJsonOutput(complexityStdout);
+            var complexityRow = Assert.Single(complexityDocument.RootElement.EnumerateArray().ToList());
+            using var pathDocument = ParseJsonOutput(pathStdout);
+            var pathRow = Assert.Single(pathDocument.RootElement.EnumerateArray().ToList());
+
+            Assert.Equal(CommandExitCodes.Success, refsExitCode);
+            Assert.Equal(CommandExitCodes.Success, complexityExitCode);
+            Assert.Equal(CommandExitCodes.Success, pathExitCode);
+            Assert.Equal(CommandExitCodes.Success, humanExitCode);
+            Assert.Equal(string.Empty, refsStderr);
+            Assert.Equal(string.Empty, complexityStderr);
+            Assert.Equal(string.Empty, pathStderr);
+            Assert.Contains("sort=references", humanStderr);
+
+            Assert.Equal("DeepAuditTarget", refsRows[0].GetProperty("name").GetString());
+            Assert.Equal("DeepAuditTarget", complexityRow.GetProperty("name").GetString());
+            Assert.DoesNotContain(refsRows, row => row.GetProperty("name").GetString() is "Path" or "Equal");
+
+            Assert.Equal("Path", pathRow.GetProperty("name").GetString());
+            Assert.True(pathRow.GetProperty("reference_count").GetInt32() >= 500);
+            Assert.True(pathRow.GetProperty("generic_name_penalty").GetDouble() < 1.0);
+            Assert.True(pathRow.GetProperty("structural_rank_penalty").GetDouble() < 1.0);
+            Assert.True(pathRow.GetProperty("definition_sites").GetInt32() > 1);
+            Assert.True(pathRow.GetProperty("ranking_reference_score").GetDouble() < pathRow.GetProperty("reference_count").GetInt32());
+            Assert.Contains("rank_refs=", humanStdout);
+            Assert.Contains("rank_hotspot=", humanStdout);
+            Assert.Contains("name_penalty=", humanStdout);
+            Assert.Contains("struct_penalty=", humanStdout);
+            Assert.Contains("defs=", humanStdout);
         }
         finally
         {
@@ -405,6 +469,125 @@ public partial class QueryCommandRunnerTests
         var writer = new DbWriter(db.Connection);
         writer.MarkGraphReady();
         return dbPath;
+    }
+
+    private static string CreateSymbolGenericRankNoiseFixtureDb(string projectRoot)
+    {
+        var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+        TestProjectHelper.InsertIndexedFile(
+            dbPath,
+            "src/GenericA.cs",
+            "csharp",
+            """
+            public class GenericA
+            {
+                public string Path { get; }
+                public bool Equal { get; }
+                public string File { get; }
+            }
+            """);
+        TestProjectHelper.InsertIndexedFile(
+            dbPath,
+            "src/GenericB.cs",
+            "csharp",
+            """
+            public class GenericB
+            {
+                public string Path { get; }
+                public string File { get; }
+            }
+            """);
+        TestProjectHelper.InsertIndexedFile(
+            dbPath,
+            "src/GenericC.cs",
+            "csharp",
+            """
+            public class GenericC
+            {
+                public string Path { get; }
+            }
+            """);
+        TestProjectHelper.InsertIndexedFile(
+            dbPath,
+            "src/Worker.cs",
+            "csharp",
+            """
+            public class Worker
+            {
+                public void DeepAuditTarget()
+                {
+                    var total = 0;
+                    total += 1;
+                    total += 2;
+                    total += 3;
+                    total += 4;
+                    total += 5;
+                    total += 6;
+                    total += 7;
+                    total += 8;
+                    total += 9;
+                    total += 10;
+                }
+
+                public void SmallUsefulCaller()
+                {
+                    DeepAuditTarget();
+                }
+            }
+            """);
+        TestProjectHelper.InsertIndexedFile(
+            dbPath,
+            "src/Refs.cs",
+            "csharp",
+            """
+            public class Refs
+            {
+                public void Call()
+                {
+                }
+            }
+            """);
+
+        using var db = new DbContext(dbPath);
+        db.InitializeSchema();
+        var refsFileId = GetIndexedFileId(db.Connection, "src/Refs.cs");
+        var references = new List<ReferenceRecord>();
+        AddSyntheticReferences(references, refsFileId, "Path", 500);
+        AddSyntheticReferences(references, refsFileId, "Equal", 450);
+        AddSyntheticReferences(references, refsFileId, "File", 400);
+        AddSyntheticReferences(references, refsFileId, "DeepAuditTarget", 30);
+
+        var writer = new DbWriter(db.Connection);
+        writer.InsertReferences(references);
+        writer.MarkGraphReady();
+        return dbPath;
+    }
+
+    private static long GetIndexedFileId(SqliteConnection connection, string path)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = "SELECT id FROM files WHERE path = @path";
+        cmd.Parameters.AddWithValue("@path", path);
+        return (long)(cmd.ExecuteScalar() ?? throw new InvalidOperationException($"Missing indexed file {path}"));
+    }
+
+    private static void AddSyntheticReferences(List<ReferenceRecord> references, long fileId, string target, int count)
+    {
+        var startLine = references.Count + 1;
+        for (var i = 0; i < count; i++)
+        {
+            references.Add(new ReferenceRecord
+            {
+                FileId = fileId,
+                SymbolName = target,
+                ReferenceKind = "call",
+                Line = startLine + i,
+                Column = 1,
+                Context = $"{target}(); // synthetic {i}",
+                ContainerKind = "function",
+                ContainerName = "Call",
+            });
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Downranks ambiguous generic symbol names in `symbols --sort references`, `--sort hotspot`, and `--sort complexity` using generic-name penalties, duplicate-definition dilution, structural member penalties, and capped size-oriented complexity scoring.
- Keeps raw reference and hotspot counts in JSON while adding ranking diagnostics so adjusted ordering stays explainable.
- Adds a regression fixture covering noisy `Path`, `File`, and `Equal` rows versus a real audit target.

## Validation
- `dotnet build CodeIndex.sln`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~RunSymbols_SortReferencesAndComplexityDemoteGenericNameNoise_Issue4066"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter "FullyQualifiedName~RunSymbols_SortByReferenceSignalsAddsRankingMetadata_Issue3451"`
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review using `.codex/workflows/adversarial-review.md`: No blocking/actionable issues found.

## Documentation / Changelog
- Added `changelog.d/unreleased/4066.fixed.md`.

## Follow-up Candidates
- None.

Fixes #4066