### PR TITLE
[codex] Fix validate fixture encoding clarity

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -465,6 +465,8 @@ JSON-form instruction payloads.
 For `replacement_char`, JSON and MCP responses include `origin` (`source_literal`
 or `decode_replacement`) and `severity` so agents can distinguish intentional
 U+FFFD literals from likely encoding damage.
+Human-readable output prints the same markers in brackets and adds
+`test_fixture` when a finding comes from a test or fixture path.
 Use `--severity warning` to hide informational source literals and focus on
 findings that indicate likely encoding damage.
 Use `--exclude-tests` and repeatable `--exclude-path` to keep validation output
@@ -3094,7 +3096,9 @@ placeholder、Dockerfile の JSON-form instruction payload の parse / truncatio
 診断などです。
 `replacement_char` の JSON / MCP response には `origin` (`source_literal` /
 `decode_replacement`) と `severity` が入り、意図的な U+FFFD literal と
-エンコーディング破損の可能性を agent が区別できます。`--severity warning`
+エンコーディング破損の可能性を agent が区別できます。human-readable output
+にも同じ marker が角括弧で表示され、test / fixture path の finding には
+`test_fixture` が付きます。`--severity warning`
 を使うと、informational な source literal を隠して、エンコーディング破損の
 可能性がある finding に集中できます。fixture や generated sample が issue list を
 支配する場合は、`--exclude-tests` と繰り返し指定できる `--exclude-path` で

--- a/changelog.d/unreleased/4068.fixed.md
+++ b/changelog.d/unreleased/4068.fixed.md
@@ -1,0 +1,19 @@
+---
+category: fixed
+issues:
+  - 4068
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Database/DbWriter.cs
+  - tests/CodeIndex.Tests/DatabaseTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerValidateMetadataTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **`validate` now labels intentional fixture encoding findings more clearly (#4068)** — human output includes severity, origin, and test-fixture markers, and stale BOM / UTF-16 BOM metadata rows are rechecked so expected `.sln` BOM noise does not survive incremental reuse.
+
+## 日本語
+
+- **`validate` が意図的な fixture の encoding finding をより明確に表示するようになりました (#4068)** — human output に severity、origin、test-fixture marker を表示し、古い BOM / UTF-16 BOM metadata 行を再確認することで、期待される `.sln` BOM ノイズが incremental reuse で残り続けないようにしました。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -10050,13 +10050,57 @@ public static partial class QueryCommandRunner
                 foreach (var issue in issues)
                 {
                     var location = issue.Line > 0 ? $":{issue.Line}" : "";
-                    Console.WriteLine($"  {issue.Kind,-20} {issue.Path}{location}  {issue.Message}");
+                    var metadata = FormatValidateIssueMetadata(issue);
+                    Console.WriteLine($"  {issue.Kind,-20} {issue.Path}{location}  {metadata}{issue.Message}");
                 }
                 var kindCounts = issues.GroupBy(i => i.Kind).Select(g => $"{g.Key}: {g.Count()}");
                 CommandErrorWriter.WriteStderr($"\n({issues.Count} issues: {string.Join(", ", kindCounts)})");
             }
             return CommandExitCodes.Success;
         });
+    }
+
+    private static string FormatValidateIssueMetadata(FileIssue issue)
+    {
+        var tags = new List<string>(3);
+        if (!string.IsNullOrWhiteSpace(issue.Severity))
+            tags.Add(issue.Severity);
+        if (!string.IsNullOrWhiteSpace(issue.Origin))
+            tags.Add(issue.Origin);
+        if (IsValidateTestOrFixturePath(issue.Path))
+            tags.Add("test_fixture");
+
+        return tags.Count == 0
+            ? string.Empty
+            : $"[{string.Join(", ", tags)}] ";
+    }
+
+    private static bool IsValidateTestOrFixturePath(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+        var lower = normalized.ToLowerInvariant();
+        return lower.StartsWith("test/", StringComparison.Ordinal)
+            || lower.StartsWith("tests/", StringComparison.Ordinal)
+            || lower.StartsWith("fixture/", StringComparison.Ordinal)
+            || lower.StartsWith("fixtures/", StringComparison.Ordinal)
+            || lower.Contains("/test/", StringComparison.Ordinal)
+            || lower.Contains("/tests/", StringComparison.Ordinal)
+            || lower.Contains("/fixture/", StringComparison.Ordinal)
+            || lower.Contains("/fixtures/", StringComparison.Ordinal)
+            || lower.StartsWith("test.", StringComparison.Ordinal)
+            || lower.StartsWith("tests.", StringComparison.Ordinal)
+            || lower.StartsWith("test_", StringComparison.Ordinal)
+            || lower.StartsWith("tests_", StringComparison.Ordinal)
+            || lower.Contains("/test.", StringComparison.Ordinal)
+            || lower.Contains("/tests.", StringComparison.Ordinal)
+            || lower.Contains("/test_", StringComparison.Ordinal)
+            || lower.Contains("/tests_", StringComparison.Ordinal)
+            || lower.Contains("_test.", StringComparison.Ordinal)
+            || lower.Contains("_tests.", StringComparison.Ordinal)
+            || lower == "conftest.py"
+            || lower.EndsWith("/conftest.py", StringComparison.Ordinal)
+            || lower.Contains(".spec.", StringComparison.Ordinal)
+            || lower.Contains(".test.", StringComparison.Ordinal);
     }
 
     public static int RunLanguages(string[] cmdArgs, JsonSerializerOptions jsonOptions)

--- a/src/CodeIndex/Database/DbWriter.cs
+++ b/src/CodeIndex/Database/DbWriter.cs
@@ -784,19 +784,28 @@ public class DbWriter
             return false;
         }
 
+        var isSolutionFile = string.Equals(Path.GetExtension(relativePath), ".sln", StringComparison.OrdinalIgnoreCase);
         var cmd = RentCommand(
             @"
             SELECT 1
             FROM file_issues i
             JOIN files f ON i.file_id = f.id
             WHERE f.path = @path
-              AND i.kind IN ('replacement_char', 'non_utf8_likely')
-              AND (i.origin IS NULL OR i.severity IS NULL)
+              AND (
+                  (i.kind IN ('replacement_char', 'non_utf8_likely', 'bom', 'utf16_bom')
+                      AND (i.origin IS NULL OR i.severity IS NULL))
+                  OR (i.kind = 'bom' AND @is_solution_file = 1)
+              )
             LIMIT 1",
-            static c => c.Parameters.Add("@path", SqliteType.Text));
+            static c =>
+            {
+                c.Parameters.Add("@path", SqliteType.Text);
+                c.Parameters.Add("@is_solution_file", SqliteType.Integer);
+            });
         try
         {
             cmd.Parameters["@path"].Value = relativePath;
+            cmd.Parameters["@is_solution_file"].Value = isSolutionFile ? 1 : 0;
             return cmd.ExecuteScalar() != null;
         }
         finally

--- a/tests/CodeIndex.Tests/DatabaseTests.cs
+++ b/tests/CodeIndex.Tests/DatabaseTests.cs
@@ -1648,6 +1648,113 @@ public class DatabaseTests : IDisposable
     }
 
     [Fact]
+    public void GetUnchangedFileId_ReturnsNullWhenBomMetadataStaleOrSuppressed_Issue4068()
+    {
+        var modified = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var sourceFile = new FileRecord
+        {
+            Path = "src/bom.cs",
+            Lang = "csharp",
+            Size = 50,
+            Lines = 1,
+            Modified = modified,
+        };
+        var sourceFileId = _writer.UpsertFile(sourceFile);
+        _writer.InsertIssues(sourceFileId,
+        [
+            new FileIssue
+            {
+                Path = sourceFile.Path,
+                Kind = "bom",
+                Line = 1,
+                Message = "legacy BOM row without metadata",
+            },
+        ]);
+
+        Assert.Null(_writer.GetUnchangedFileId(sourceFile.Path, modified));
+
+        _writer.InsertIssues(sourceFileId,
+        [
+            new FileIssue
+            {
+                Path = sourceFile.Path,
+                Kind = "bom",
+                Line = 1,
+                Message = "UTF-8 BOM marker detected",
+                Origin = FileIssue.OriginByteOrderMark,
+                Severity = FileIssue.SeverityWarning,
+            },
+        ]);
+
+        Assert.NotNull(_writer.GetUnchangedFileId(sourceFile.Path, modified));
+
+        var utf16File = new FileRecord
+        {
+            Path = "src/utf16.cs",
+            Lang = "csharp",
+            Size = 50,
+            Lines = 1,
+            Modified = modified,
+        };
+        var utf16FileId = _writer.UpsertFile(utf16File);
+        _writer.InsertIssues(utf16FileId,
+        [
+            new FileIssue
+            {
+                Path = utf16File.Path,
+                Kind = "utf16_bom",
+                Line = 1,
+                Message = "legacy UTF-16 BOM row without metadata",
+            },
+        ]);
+
+        Assert.Null(_writer.GetUnchangedFileId(utf16File.Path, modified));
+
+        _writer.InsertIssues(utf16FileId,
+        [
+            new FileIssue
+            {
+                Path = utf16File.Path,
+                Kind = "utf16_bom",
+                Line = 1,
+                Message = "UTF-16 LE BOM detected (decoded as UTF-16)",
+                Origin = FileIssue.OriginByteOrderMark,
+                Severity = FileIssue.SeverityWarning,
+            },
+        ]);
+
+        Assert.NotNull(_writer.GetUnchangedFileId(utf16File.Path, modified));
+
+        var solutionFile = new FileRecord
+        {
+            Path = "CodeIndex.sln",
+            Lang = "solution",
+            Size = 50,
+            Lines = 1,
+            Modified = modified,
+        };
+        var solutionFileId = _writer.UpsertFile(solutionFile);
+        _writer.InsertIssues(solutionFileId,
+        [
+            new FileIssue
+            {
+                Path = solutionFile.Path,
+                Kind = "bom",
+                Line = 1,
+                Message = "UTF-8 BOM marker detected",
+                Origin = FileIssue.OriginByteOrderMark,
+                Severity = FileIssue.SeverityWarning,
+            },
+        ]);
+
+        Assert.Null(_writer.GetUnchangedFileId(solutionFile.Path, modified));
+
+        _writer.InsertIssues(solutionFileId, []);
+
+        Assert.NotNull(_writer.GetUnchangedFileId(solutionFile.Path, modified));
+    }
+
+    [Fact]
     public void GetUnchangedFileId_WithNullChecksumUsesModifiedAndSize()
     {
         var modified = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);

--- a/tests/CodeIndex.Tests/QueryCommandRunnerValidateMetadataTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerValidateMetadataTests.cs
@@ -48,6 +48,55 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunValidate_HumanOutputLabelsSourceLiteralTestFixtures_Issue4068()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_validate_fixture_label_4068");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            Directory.CreateDirectory(Path.Combine(projectRoot, "tests", "fixtures"));
+            Directory.CreateDirectory(Path.Combine(projectRoot, "tests_utils"));
+            File.WriteAllText(
+                Path.Combine(projectRoot, "tests", "fixtures", "literal.cs"),
+                "class Literal { const char Value = '\uFFFD'; }\n");
+            File.WriteAllText(
+                Path.Combine(projectRoot, "src", "foo.test.cs"),
+                "class FooTest { const char Value = '\uFFFD'; }\n");
+            File.WriteAllText(
+                Path.Combine(projectRoot, "tests_utils", "helper.cs"),
+                "class Helper { const char Value = '\uFFFD'; }\n");
+            File.WriteAllText(
+                Path.Combine(projectRoot, "conftest.py"),
+                "VALUE = '\uFFFD'\n");
+
+            var (indexExitCode, _, indexStderr) = CaptureConsole(() => IndexCommandRunner.Run(
+                [projectRoot, "--db", dbPath, "--json", "--quiet"],
+                _jsonOptions));
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(string.Empty, indexStderr);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunValidate(
+                ["--db", dbPath, "--kind", "replacement_char"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Contains("replacement_char", stdout);
+            Assert.Contains("conftest.py", stdout);
+            Assert.Contains("src/foo.test.cs", stdout);
+            Assert.Contains("tests/fixtures/literal.cs", stdout);
+            Assert.Contains("tests_utils/helper.cs", stdout);
+            Assert.Contains("[info, source_literal, test_fixture]", stdout);
+            Assert.Contains("U+FFFD source literal", stdout);
+            Assert.Contains("(4 issues: replacement_char: 4)", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunValidate_FormatLspIncludesRangeAndDiagnosticMetadata_Issue3949()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_validate_lsp_metadata_3949");


### PR DESCRIPTION
## Summary
- Adds severity/origin/test-fixture markers to human `cdidx validate` output so intentional fixture U+FFFD literals are distinguishable without JSON.
- Refreshes stale `bom` / `utf16_bom` issue metadata during unchanged-file reuse, and rechecks `.sln` BOM rows so suppressed solution-file noise does not persist from old indexes.
- Updates `USER_GUIDE.md` and adds changelog fragment `changelog.d/unreleased/4068.fixed.md`.

## Validation
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~DatabaseTests.GetUnchangedFileId_ReturnsNullWhenBomMetadataStaleOrSuppressed_Issue4068|FullyQualifiedName~QueryCommandRunnerTests.RunValidate_HumanOutputLabelsSourceLiteralTestFixtures_Issue4068" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~RunValidate" -p:UseSharedCompilation=false --no-build`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~GetUnchangedFileId" -p:UseSharedCompilation=false --no-build`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --no-build --filter "FullyQualifiedName~DatabaseTests.GetUnchangedFileId_ReturnsNullWhenBomMetadataStaleOrSuppressed_Issue4068|FullyQualifiedName~QueryCommandRunnerTests.RunValidate_HumanOutputLabelsSourceLiteralTestFixtures_Issue4068"`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll validate --json=array --limit 100`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll validate --limit 3`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Notes
- Codex adversarial review found two P2 issues (`utf16_bom` stale metadata and test-path marker alignment); both were fixed. A rerun was attempted after the fixes, but Codex CLI reported a usage limit before completing.
- A full Release solution test run was attempted before these targeted fixes and hit unrelated existing/environment-sensitive failures in `FileSystemBoundaryTests.TryValidateDirectoryCleanupTarget_RejectsSymlinkDirectory_Issue3970` and two symbol-extractor runaway guard tests, then was interrupted after a long no-output period. Targeted Release coverage for this change passes.

Fixes #4068