### PR TITLE
Fix SymbolExtractor practical budget guards

### DIFF
--- a/changelog.d/unreleased/4087.fixed.md
+++ b/changelog.d/unreleased/4087.fixed.md
@@ -1,0 +1,17 @@
+---
+category: fixed
+issues:
+  - 4087
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
+  - tests/CodeIndex.Tests/SymbolExtractorCSharpTests.cs
+  - tests/CodeIndex.Tests/SymbolExtractorTests.cs
+---
+
+## English
+
+- **SymbolExtractor practical budget guards are less flaky on slow Release hosts (#4087)** - large exported JavaScript object literal property symbols now keep compact per-property signatures, and the affected runaway guard budgets leave room for observed local Release variance.
+
+## 日本語
+
+- **SymbolExtractor の practical budget guard が低速な Release 環境で失敗しにくくなりました (#4087)** - 大きな exported JavaScript object literal の property symbol は property ごとの短い signature を保持するようになり、対象の runaway guard 予算は観測されたローカル Release の揺れを許容します。

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.JavaScriptTypeScriptSupport.cs
@@ -4802,12 +4802,14 @@ public static partial class SymbolExtractor
                             AddJavaScriptTypeScriptExportedObjectLiteralPropertySymbol(
                                 fileId,
                                 rawLines,
+                                sanitizedLines,
                                 symbols,
                                 existingContainerSymbolNames,
                                 target.ContainerName,
                                 propertyName,
                                 lineIndex,
-                                scanColumn);
+                                scanColumn,
+                                identifierValueStartColumn);
 
                             scanColumn = identifierValueStartColumn;
                             skippingPropertyValue = true;
@@ -4824,12 +4826,14 @@ public static partial class SymbolExtractor
                             AddJavaScriptTypeScriptExportedObjectLiteralPropertySymbol(
                                 fileId,
                                 rawLines,
+                                sanitizedLines,
                                 symbols,
                                 existingContainerSymbolNames,
                                 target.ContainerName,
                                 literalPropertyName,
                                 lineIndex,
-                                scanColumn);
+                                scanColumn,
+                                literalValueStartColumn);
 
                             scanColumn = literalValueStartColumn;
                             skippingPropertyValue = true;
@@ -4846,12 +4850,14 @@ public static partial class SymbolExtractor
                             AddJavaScriptTypeScriptExportedObjectLiteralPropertySymbol(
                                 fileId,
                                 rawLines,
+                                sanitizedLines,
                                 symbols,
                                 existingContainerSymbolNames,
                                 target.ContainerName,
                                 computedLiteralPropertyName,
                                 lineIndex,
-                                scanColumn);
+                                scanColumn,
+                                computedLiteralValueStartColumn);
 
                             scanColumn = computedLiteralValueStartColumn;
                             skippingPropertyValue = true;
@@ -4873,12 +4879,14 @@ public static partial class SymbolExtractor
                             AddJavaScriptTypeScriptExportedObjectLiteralPropertySymbol(
                                 fileId,
                                 rawLines,
+                                sanitizedLines,
                                 symbols,
                                 existingContainerSymbolNames,
                                 target.ContainerName,
                                 shorthandPropertyName,
                                 lineIndex,
-                                scanColumn);
+                                scanColumn,
+                                shorthandEndColumn);
 
                             scanColumn = shorthandEndColumn;
                             continue;
@@ -4933,15 +4941,23 @@ public static partial class SymbolExtractor
     private static void AddJavaScriptTypeScriptExportedObjectLiteralPropertySymbol(
         long fileId,
         string[] rawLines,
+        string[] sanitizedLines,
         List<SymbolRecord> symbols,
         HashSet<string> existingContainerSymbolNames,
         string containerName,
         string propertyName,
         int lineIndex,
-        int startColumn)
+        int startColumn,
+        int valueStartColumn)
     {
         if (propertyName.Length == 0 || !existingContainerSymbolNames.Add(propertyName))
             return;
+
+        var signature = BuildJavaScriptTypeScriptObjectLiteralPropertySignature(
+            rawLines[lineIndex],
+            sanitizedLines[lineIndex],
+            startColumn,
+            valueStartColumn);
 
         AddSymbolRecord(
             symbols,
@@ -4956,12 +4972,78 @@ public static partial class SymbolExtractor
                 StartLine = lineIndex + 1,
                 StartColumn = startColumn,
                 EndLine = lineIndex + 1,
-                Signature = rawLines[lineIndex].Trim(),
+                Signature = signature,
                 ContainerKind = "object",
                 ContainerName = containerName,
                 Visibility = "export",
             },
             rawLines[lineIndex]);
+    }
+
+    private const int JavaScriptTypeScriptObjectLiteralPropertySignatureMaxLength = 240;
+
+    private static string BuildJavaScriptTypeScriptObjectLiteralPropertySignature(
+        string rawLine,
+        string sanitizedLine,
+        int startColumn,
+        int valueStartColumn)
+    {
+        var lineLength = Math.Min(rawLine.Length, sanitizedLine.Length);
+        var signatureStart = Math.Clamp(startColumn, 0, lineLength);
+        var scanColumn = Math.Clamp(valueStartColumn, signatureStart, sanitizedLine.Length);
+        var endColumn = sanitizedLine.Length;
+        var braceDepth = 0;
+        var parenDepth = 0;
+        var bracketDepth = 0;
+
+        while (scanColumn < sanitizedLine.Length)
+        {
+            var ch = sanitizedLine[scanColumn];
+            if (braceDepth == 0 && parenDepth == 0 && bracketDepth == 0 && ch is ',' or '}' or ';')
+            {
+                endColumn = scanColumn;
+                break;
+            }
+
+            switch (ch)
+            {
+                case '{':
+                    braceDepth++;
+                    break;
+                case '}':
+                    if (braceDepth > 0)
+                        braceDepth--;
+                    break;
+                case '(':
+                    parenDepth++;
+                    break;
+                case ')':
+                    if (parenDepth > 0)
+                        parenDepth--;
+                    break;
+                case '[':
+                    bracketDepth++;
+                    break;
+                case ']':
+                    if (bracketDepth > 0)
+                        bracketDepth--;
+                    break;
+            }
+
+            scanColumn++;
+        }
+
+        endColumn = Math.Clamp(endColumn, signatureStart, rawLine.Length);
+        while (endColumn > signatureStart && char.IsWhiteSpace(rawLine[endColumn - 1]))
+            endColumn--;
+
+        var signature = rawLine[signatureStart..endColumn].Trim();
+        if (signature.Length == 0)
+            signature = rawLine.Trim();
+
+        return signature.Length <= JavaScriptTypeScriptObjectLiteralPropertySignatureMaxLength
+            ? signature
+            : signature[..(JavaScriptTypeScriptObjectLiteralPropertySignatureMaxLength - 3)] + "...";
     }
 
     private static bool TryReadJavaScriptTypeScriptIdentifierObjectLiteralKeyName(

--- a/tests/CodeIndex.Tests/SymbolExtractorCSharpTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorCSharpTests.cs
@@ -6677,7 +6677,7 @@ public partial class SymbolExtractorTests
 
         Assert.Contains(symbols, s => s.Kind == "class" && s.Name == "InstallScriptTests");
         Assert.Contains(symbols, s => s.Kind == "test.method" && s.Name == "Main_WithoutExplicitVersion_DoesNotShortCircuitBrokenZeroVersionInstall");
-        var runawayBudget = TimeSpan.FromSeconds(60);
+        var runawayBudget = TimeSpan.FromSeconds(90);
         Assert.True(
             stopwatch.Elapsed < runawayBudget,
             $"InstallScriptTests.cs extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -13468,6 +13468,31 @@ public partial class SymbolExtractorTests
         Assert.Contains(symbols, s => s.Kind == "generator" && s.Name == "gen" && s.ContainerKind == "object");
     }
 
+    [Fact]
+    public void Extract_JavaScript_ExportedObjectLiteralPropertySignaturesStayScoped()
+    {
+        const string content = """
+            export default {
+                scalar: 1,
+                nested: { text: "x,y", items: [1, 2] },
+                "quoted,key": 2,
+                ["computed"]: call(1, 2),
+                shorthand,
+            };
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "javascript", content);
+
+        SymbolRecord FindProperty(string name) => Assert.Single(
+            symbols.Where(s => s.Kind == "property" && s.Name == name && s.ContainerKind == "object" && s.ContainerName == "default"));
+
+        Assert.Equal("scalar: 1", FindProperty("scalar").Signature);
+        Assert.Equal("nested: { text: \"x,y\", items: [1, 2] }", FindProperty("nested").Signature);
+        Assert.Equal("\"quoted,key\": 2", FindProperty("quoted,key").Signature);
+        Assert.Equal("[\"computed\"]: call(1, 2)", FindProperty("computed").Signature);
+        Assert.Equal("shorthand", FindProperty("shorthand").Signature);
+    }
+
 #if NET8_0
     [Fact]
 #else
@@ -13482,9 +13507,11 @@ public partial class SymbolExtractorTests
         var symbols = SymbolExtractor.Extract(1, "javascript", content);
         stopwatch.Stop();
 
-        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "p0" && s.ContainerKind == "object" && s.ContainerName == "default");
-        Assert.Contains(symbols, s => s.Kind == "property" && s.Name == "p2999" && s.ContainerKind == "object" && s.ContainerName == "default");
-        var runawayBudget = TimeSpan.FromSeconds(10);
+        var first = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "p0" && s.ContainerKind == "object" && s.ContainerName == "default"));
+        var last = Assert.Single(symbols.Where(s => s.Kind == "property" && s.Name == "p2999" && s.ContainerKind == "object" && s.ContainerName == "default"));
+        Assert.Equal("p0: 0", first.Signature);
+        Assert.Equal("p2999: 2999", last.Signature);
+        var runawayBudget = TimeSpan.FromSeconds(30);
         Assert.True(
             stopwatch.Elapsed < runawayBudget,
             $"Large JavaScript exported object literal extraction took {stopwatch.Elapsed.TotalSeconds:F2}s, expected < {runawayBudget.TotalSeconds:F0}s runaway guard budget.");


### PR DESCRIPTION
## Summary
- keep exported JavaScript object literal property signatures scoped to each property instead of the full object line
- widen the affected SymbolExtractor runaway guard budgets for observed Release host variance
- add a changelog fragment for #4087

## Validation
- dotnet build CodeIndex.sln -c Release
- dotnet build CodeIndex.sln
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --no-build --framework net8.0 --filter "FullyQualifiedName~Extract_JavaScript_ExportedObjectLiteralPropertySignaturesStayScoped|FullyQualifiedName~Extract_JavaScriptLargeExportedObjectLiteralProperties_CompletesWithinPracticalBudget"
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --no-build --framework net8.0 --filter "FullyQualifiedName~Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget|FullyQualifiedName~Extract_JavaScriptLargeExportedObjectLiteralProperties_CompletesWithinPracticalBudget|FullyQualifiedName~Extract_CSharp_ReferenceExtractorFixture_CompletesWithinPracticalBudget"
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --no-build --framework net9.0 --filter "FullyQualifiedName~Extract_CSharp_InstallScriptFixture_CompletesWithinPracticalBudget|FullyQualifiedName~Extract_JavaScriptLargeExportedObjectLiteralProperties_CompletesWithinPracticalBudget|FullyQualifiedName~Extract_CSharp_ReferenceExtractorFixture_CompletesWithinPracticalBudget" (all skipped)
- dotnet run --project tools/CodeIndex.Changelog -- check
- dotnet format CodeIndex.sln --verify-no-changes --no-restore
- git diff --check
- dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json

## Review
- Codex adversarial review: No blocking/actionable issues found.

Fixes #4087