### PR TITLE
[codex] Fix explicit time budgets for issue 4129

### DIFF
--- a/changelog.d/unreleased/4129.fixed.md
+++ b/changelog.d/unreleased/4129.fixed.md
@@ -1,0 +1,20 @@
+---
+category: fixed
+issues:
+  - 4129
+affected:
+  - src/CodeIndex/Cli/IndexWatchRunner.cs
+  - src/CodeIndex/Diagnostics/OperationTimeoutScope.cs
+  - src/CodeIndex/Cli/GitHubHttpClientFactory.cs
+  - tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
+  - tests/CodeIndex.Tests/OperationTimeoutScopeTests.cs
+  - tests/CodeIndex.Tests/GitHubHttpCancellationTests.cs
+---
+
+## English
+
+- **Watch debounce and request cancellation now use explicit time budgets (#4129)** - `cdidx index --watch` now measures debounce windows with `TimeProvider` monotonic timestamps, and shared request timeout handling classifies zero/infinite sentinels through an explicit budget abstraction.
+
+## 日本語
+
+- **watch debounce とリクエスト取り消しが明示的な時間 budget を使うようになりました (#4129)** - `cdidx index --watch` は debounce ウィンドウを `TimeProvider` の単調 timestamp で測定し、共有のリクエスト timeout 処理は zero/infinite sentinel を明示的な budget 抽象で分類するようになりました。

--- a/src/CodeIndex/Cli/GitHubHttpClientFactory.cs
+++ b/src/CodeIndex/Cli/GitHubHttpClientFactory.cs
@@ -61,7 +61,7 @@ internal static class GitHubHttpClientFactory
         {
             scope = OperationTimeoutScope.Create(
                 OperationTimeoutCategories.GitHubApiRequest,
-                NormalizeRequestTimeout(timeout),
+                NormalizeRequestTimeoutBudget(timeout),
                 cancellationToken);
         }
 
@@ -134,9 +134,8 @@ internal static class GitHubHttpClientFactory
         => ShouldUseDefaultProxyCredentials() ? "enabled" : "disabled";
 
     internal static TimeSpan NormalizeRequestTimeout(TimeSpan timeout)
-    {
-        if (timeout == Timeout.InfiniteTimeSpan || timeout <= TimeSpan.Zero)
-            return MaxRequestTimeout;
-        return timeout <= MaxRequestTimeout ? timeout : MaxRequestTimeout;
-    }
+        => NormalizeRequestTimeoutBudget(timeout).Duration ?? MaxRequestTimeout;
+
+    internal static OperationTimeoutBudget NormalizeRequestTimeoutBudget(TimeSpan timeout)
+        => OperationTimeoutBudget.FromTimeoutOrDefault(timeout, MaxRequestTimeout).Clamp(MaxRequestTimeout);
 }

--- a/src/CodeIndex/Cli/IndexWatchRunner.cs
+++ b/src/CodeIndex/Cli/IndexWatchRunner.cs
@@ -806,16 +806,17 @@ internal sealed class FileChangeBatcher
 
     private readonly object _gate = new();
     private readonly HashSet<string> _pending;
-    private DateTime _lastEventUtc = DateTime.MinValue;
+    private long _lastEventTimestamp;
+    private bool _hasLastEventTimestamp;
     private bool _overflowRequested;
     private string? _overflowReason;
     private readonly TimeSpan _debounce;
-    private readonly Func<DateTime> _clock;
+    private readonly TimeProvider _timeProvider;
     private readonly int _maxPendingPaths;
 
     public FileChangeBatcher(
         TimeSpan debounce,
-        Func<DateTime>? clock = null,
+        TimeProvider? timeProvider = null,
         bool ignoreCase = true,
         int maxPendingPaths = DefaultMaxPendingPaths)
     {
@@ -823,7 +824,7 @@ internal sealed class FileChangeBatcher
             throw new ArgumentOutOfRangeException(nameof(maxPendingPaths), "Maximum pending path count must be positive.");
 
         _debounce = debounce;
-        _clock = clock ?? (() => DateTime.UtcNow);
+        _timeProvider = timeProvider ?? TimeProvider.System;
         _maxPendingPaths = maxPendingPaths;
         // On case-sensitive filesystems (Linux ext4), `foo.py` and `Foo.py` are distinct files,
         // so coalescing them via OrdinalIgnoreCase would drop one rename leg and leave the
@@ -839,7 +840,7 @@ internal sealed class FileChangeBatcher
         {
             if (_overflowRequested)
             {
-                _lastEventUtc = _clock();
+                RecordEventTimestampLocked();
                 return;
             }
 
@@ -855,7 +856,7 @@ internal sealed class FileChangeBatcher
                 _pending.Add(path);
             }
 
-            _lastEventUtc = _clock();
+            RecordEventTimestampLocked();
         }
     }
 
@@ -879,7 +880,7 @@ internal sealed class FileChangeBatcher
                 return false;
             }
 
-            if (_clock() - _lastEventUtc < _debounce)
+            if (_hasLastEventTimestamp && _timeProvider.GetElapsedTime(_lastEventTimestamp) < _debounce)
             {
                 batch = Array.Empty<string>();
                 fullRescan = false;
@@ -906,6 +907,12 @@ internal sealed class FileChangeBatcher
         _overflowRequested = true;
         if (!string.IsNullOrEmpty(reason))
             _overflowReason = IndexWatchRunner.FormatWatchDiagnosticText(reason);
-        _lastEventUtc = _clock();
+        RecordEventTimestampLocked();
+    }
+
+    private void RecordEventTimestampLocked()
+    {
+        _lastEventTimestamp = _timeProvider.GetTimestamp();
+        _hasLastEventTimestamp = true;
     }
 }

--- a/src/CodeIndex/Diagnostics/OperationTimeoutScope.cs
+++ b/src/CodeIndex/Diagnostics/OperationTimeoutScope.cs
@@ -10,16 +10,57 @@ internal static class OperationTimeoutCategories
     internal const string SseWrite = "sse_write";
 }
 
+internal readonly record struct OperationTimeoutBudget
+{
+    private OperationTimeoutBudget(TimeSpan? duration)
+    {
+        Duration = duration;
+    }
+
+    internal TimeSpan? Duration { get; }
+
+    internal bool HasTimeout => Duration.HasValue;
+
+    internal static OperationTimeoutBudget None { get; } = new(null);
+
+    internal static OperationTimeoutBudget After(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(timeout), timeout, "Timeout budget must be positive.");
+
+        return new OperationTimeoutBudget(timeout);
+    }
+
+    internal static OperationTimeoutBudget FromTimeout(TimeSpan timeout)
+        => IsDisabledTimeout(timeout) ? None : After(timeout);
+
+    internal static OperationTimeoutBudget FromTimeoutOrDefault(TimeSpan timeout, TimeSpan defaultTimeout)
+        => IsDisabledTimeout(timeout) ? After(defaultTimeout) : After(timeout);
+
+    internal OperationTimeoutBudget Clamp(TimeSpan maxTimeout)
+    {
+        if (maxTimeout <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(maxTimeout), maxTimeout, "Maximum timeout budget must be positive.");
+
+        return Duration is { } duration && duration > maxTimeout
+            ? new OperationTimeoutBudget(maxTimeout)
+            : this;
+    }
+
+    private static bool IsDisabledTimeout(TimeSpan timeout)
+        => timeout == System.Threading.Timeout.InfiniteTimeSpan || timeout <= TimeSpan.Zero;
+}
+
 internal sealed class OperationTimeoutScope : IDisposable
 {
     private readonly CancellationTokenSource? _timeoutCts;
     private readonly CancellationTokenSource _linkedCts;
 
-    private OperationTimeoutScope(string category, TimeSpan timeout, CancellationToken cancellationToken)
+    private OperationTimeoutScope(string category, OperationTimeoutBudget budget, CancellationToken cancellationToken)
     {
         Category = category;
-        Timeout = timeout;
-        if (timeout > TimeSpan.Zero && timeout != System.Threading.Timeout.InfiniteTimeSpan)
+        Budget = budget;
+        if (budget.Duration is { } timeout)
         {
             _timeoutCts = new CancellationTokenSource(timeout);
             _linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _timeoutCts.Token);
@@ -32,7 +73,9 @@ internal sealed class OperationTimeoutScope : IDisposable
 
     internal string Category { get; }
 
-    internal TimeSpan Timeout { get; }
+    internal OperationTimeoutBudget Budget { get; }
+
+    internal TimeSpan Timeout => Budget.Duration ?? System.Threading.Timeout.InfiniteTimeSpan;
 
     internal CancellationToken Token => _linkedCts.Token;
 
@@ -46,7 +89,18 @@ internal sealed class OperationTimeoutScope : IDisposable
         if (string.IsNullOrWhiteSpace(category))
             throw new ArgumentException("Timeout category must be non-empty.", nameof(category));
 
-        return new OperationTimeoutScope(category, timeout, cancellationToken);
+        return new OperationTimeoutScope(category, OperationTimeoutBudget.FromTimeout(timeout), cancellationToken);
+    }
+
+    internal static OperationTimeoutScope Create(
+        string category,
+        OperationTimeoutBudget budget,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(category))
+            throw new ArgumentException("Timeout category must be non-empty.", nameof(category));
+
+        return new OperationTimeoutScope(category, budget, cancellationToken);
     }
 
     public void Dispose()

--- a/tests/CodeIndex.Tests/GitHubHttpCancellationTests.cs
+++ b/tests/CodeIndex.Tests/GitHubHttpCancellationTests.cs
@@ -21,6 +21,15 @@ public sealed class GitHubHttpCancellationTests : IDisposable
     [Fact]
     public void GitHubHttpClientFactory_NormalizesInfiniteTimeoutToBoundedMaximum_Issue3954()
     {
+        var infiniteBudget = GitHubHttpClientFactory.NormalizeRequestTimeoutBudget(Timeout.InfiniteTimeSpan);
+        Assert.True(infiniteBudget.HasTimeout);
+        Assert.Equal(GitHubHttpClientFactory.MaxRequestTimeout, infiniteBudget.Duration);
+
+        var overBudget = GitHubHttpClientFactory.NormalizeRequestTimeoutBudget(
+            GitHubHttpClientFactory.MaxRequestTimeout + TimeSpan.FromSeconds(1));
+        Assert.True(overBudget.HasTimeout);
+        Assert.Equal(GitHubHttpClientFactory.MaxRequestTimeout, overBudget.Duration);
+
         Assert.Equal(
             GitHubHttpClientFactory.MaxRequestTimeout,
             GitHubHttpClientFactory.NormalizeRequestTimeout(Timeout.InfiniteTimeSpan));

--- a/tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
+++ b/tests/CodeIndex.Tests/IndexWatchRunnerTests.cs
@@ -33,8 +33,8 @@ public class IndexWatchRunnerTests
     [Fact]
     public void FileChangeBatcher_TryDrain_BeforeDebounceElapsed_ReturnsFalse()
     {
-        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        var batcher = new FileChangeBatcher(TimeSpan.FromMilliseconds(500), () => now);
+        var timeProvider = new ManualTimeProvider();
+        var batcher = new FileChangeBatcher(TimeSpan.FromMilliseconds(500), timeProvider);
         batcher.Add("/repo/a.py");
         // Less than the debounce window has elapsed.
         Assert.False(batcher.TryDrain(out var batch, out var rescan, out _));
@@ -45,16 +45,15 @@ public class IndexWatchRunnerTests
     [Fact]
     public void FileChangeBatcher_TryDrain_AfterDebounceElapsed_ReturnsBatchOnce()
     {
-        var clock = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        DateTime Clock() => clock;
-        var batcher = new FileChangeBatcher(TimeSpan.FromMilliseconds(500), Clock);
+        var timeProvider = new ManualTimeProvider();
+        var batcher = new FileChangeBatcher(TimeSpan.FromMilliseconds(500), timeProvider);
 
         batcher.Add("/repo/a.py");
         batcher.Add("/repo/b.py");
         // Coalesce duplicates regardless of casing on case-insensitive filesystems.
         batcher.Add("/repo/A.py");
 
-        clock = clock.AddMilliseconds(600);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(600));
         Assert.True(batcher.TryDrain(out var batch, out var rescan, out _));
         Assert.False(rescan);
         Assert.Equal(2, batch.Count);
@@ -70,14 +69,13 @@ public class IndexWatchRunnerTests
         // files; a rename event arrives as Add("foo.py") + Add("Foo.py") and BOTH must be
         // surfaced so the sub-update can purge the old name and index the new one.
         // 大小区別 FS では rename の old/new を別エントリで保持する必要がある。
-        var clock = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        DateTime Clock() => clock;
-        var batcher = new FileChangeBatcher(TimeSpan.FromMilliseconds(500), Clock, ignoreCase: false);
+        var timeProvider = new ManualTimeProvider();
+        var batcher = new FileChangeBatcher(TimeSpan.FromMilliseconds(500), timeProvider, ignoreCase: false);
 
         batcher.Add("/repo/foo.py");
         batcher.Add("/repo/Foo.py");
 
-        clock = clock.AddMilliseconds(600);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(600));
         Assert.True(batcher.TryDrain(out var batch, out _, out _));
         Assert.Equal(2, batch.Count);
         Assert.Contains("/repo/foo.py", batch);
@@ -87,12 +85,12 @@ public class IndexWatchRunnerTests
     [Fact]
     public void FileChangeBatcher_RequestFullRescan_DrainsOverflowAndReason()
     {
-        var clock = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        var batcher = new FileChangeBatcher(TimeSpan.FromMilliseconds(100), () => clock);
+        var timeProvider = new ManualTimeProvider();
+        var batcher = new FileChangeBatcher(TimeSpan.FromMilliseconds(100), timeProvider);
         batcher.Add("/repo/a.py");
         batcher.RequestFullRescan("buffer overflowed");
 
-        clock = clock.AddMilliseconds(200);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(200));
         Assert.True(batcher.TryDrain(out var batch, out var rescan, out var reason));
         Assert.True(rescan);
         Assert.Equal("buffer overflowed", reason);
@@ -102,8 +100,8 @@ public class IndexWatchRunnerTests
     [Fact]
     public void FileChangeBatcher_RequestFullRescan_SanitizesAndBoundsReason_Issue3804()
     {
-        var clock = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        var batcher = new FileChangeBatcher(TimeSpan.FromMilliseconds(100), () => clock);
+        var timeProvider = new ManualTimeProvider();
+        var batcher = new FileChangeBatcher(TimeSpan.FromMilliseconds(100), timeProvider);
         var rawReason = "watch failed for /Users/alice/private/project/secret.txt token=ghp_"
             + new string('a', 40)
             + " "
@@ -111,7 +109,7 @@ public class IndexWatchRunnerTests
 
         batcher.RequestFullRescan(rawReason);
 
-        clock = clock.AddMilliseconds(200);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(200));
         Assert.True(batcher.TryDrain(out _, out var rescan, out var reason));
         Assert.True(rescan);
         Assert.NotNull(reason);
@@ -155,10 +153,10 @@ public class IndexWatchRunnerTests
     [Fact]
     public void FileChangeBatcher_Add_WhenPendingPathLimitExceeded_CollapsesToFullRescan()
     {
-        var clock = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var timeProvider = new ManualTimeProvider();
         var batcher = new FileChangeBatcher(
             TimeSpan.FromMilliseconds(100),
-            () => clock,
+            timeProvider,
             maxPendingPaths: 2);
 
         batcher.Add("/repo/a.py");
@@ -166,7 +164,7 @@ public class IndexWatchRunnerTests
         batcher.Add("/repo/c.py");
         batcher.Add("/repo/d.py");
 
-        clock = clock.AddMilliseconds(200);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(200));
         Assert.True(batcher.TryDrain(out var batch, out var rescan, out var reason));
         Assert.True(rescan);
         Assert.Empty(batch);
@@ -177,23 +175,38 @@ public class IndexWatchRunnerTests
     [Fact]
     public void FileChangeBatcher_NewEventDuringWait_ExtendsDebounce()
     {
-        var clock = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        var batcher = new FileChangeBatcher(TimeSpan.FromMilliseconds(500), () => clock);
+        var timeProvider = new ManualTimeProvider();
+        var batcher = new FileChangeBatcher(TimeSpan.FromMilliseconds(500), timeProvider);
         batcher.Add("/repo/a.py");
 
-        clock = clock.AddMilliseconds(400);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(400));
         // A new event before the window closes resets the timer.
         batcher.Add("/repo/b.py");
         Assert.False(batcher.TryDrain(out _, out _, out _));
 
-        clock = clock.AddMilliseconds(400);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(400));
         // 400ms after the second event is still < 500ms; not ready yet.
         Assert.False(batcher.TryDrain(out _, out _, out _));
 
-        clock = clock.AddMilliseconds(200);
+        timeProvider.Advance(TimeSpan.FromMilliseconds(200));
         // Now > 500ms after the second event.
         Assert.True(batcher.TryDrain(out var batch, out _, out _));
         Assert.Equal(2, batch.Count);
+    }
+
+    [Fact]
+    public void FileChangeBatcher_TryDrain_UsesMonotonicElapsedTime_Issue4129()
+    {
+        var timeProvider = new ManualTimeProvider();
+        var batcher = new FileChangeBatcher(TimeSpan.FromMilliseconds(500), timeProvider);
+        batcher.Add("/repo/a.py");
+
+        timeProvider.AdjustUtc(TimeSpan.FromHours(-1));
+        timeProvider.Advance(TimeSpan.FromMilliseconds(600));
+
+        Assert.True(batcher.TryDrain(out var batch, out var rescan, out _));
+        Assert.False(rescan);
+        Assert.Equal(["/repo/a.py"], batch);
     }
 
     [Fact]
@@ -915,6 +928,32 @@ public class IndexWatchRunnerTests
 
         var mode = File.GetUnixFileMode(path) & DataDirectorySecurity.PermissionBits;
         Assert.Equal(DataDirectorySecurity.PrivateFileMode, mode);
+    }
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private DateTimeOffset utcNow = new(2025, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        private long timestamp;
+
+        public override long TimestampFrequency => TimeSpan.TicksPerSecond;
+
+        public override DateTimeOffset GetUtcNow() => utcNow;
+
+        public override long GetTimestamp() => timestamp;
+
+        internal void Advance(TimeSpan elapsed)
+        {
+            if (elapsed < TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(elapsed), elapsed, "Elapsed time must be non-negative.");
+
+            utcNow += elapsed;
+            timestamp += elapsed.Ticks;
+        }
+
+        internal void AdjustUtc(TimeSpan offset)
+        {
+            utcNow += offset;
+        }
     }
 
     private sealed class SignalingStringWriter : StringWriter

--- a/tests/CodeIndex.Tests/OperationTimeoutScopeTests.cs
+++ b/tests/CodeIndex.Tests/OperationTimeoutScopeTests.cs
@@ -5,6 +5,42 @@ namespace CodeIndex.Tests;
 public sealed class OperationTimeoutScopeTests
 {
     [Fact]
+    public void Token_InfiniteTimeoutUsesNoTimeoutBudget_Issue4129()
+    {
+        using var cts = new CancellationTokenSource();
+        using var scope = OperationTimeoutScope.Create(
+            OperationTimeoutCategories.McpRequest,
+            Timeout.InfiniteTimeSpan,
+            cts.Token);
+
+        Assert.False(scope.Budget.HasTimeout);
+        Assert.Equal(Timeout.InfiniteTimeSpan, scope.Timeout);
+
+        cts.Cancel();
+
+        Assert.True(scope.Token.IsCancellationRequested);
+        Assert.False(scope.IsTimeoutCancellationRequested);
+    }
+
+    [Fact]
+    public void Token_ZeroTimeoutUsesNoTimeoutBudget_Issue4129()
+    {
+        using var cts = new CancellationTokenSource();
+        using var scope = OperationTimeoutScope.Create(
+            OperationTimeoutCategories.McpRequest,
+            TimeSpan.Zero,
+            cts.Token);
+
+        Assert.False(scope.Budget.HasTimeout);
+        Assert.Equal(Timeout.InfiniteTimeSpan, scope.Timeout);
+
+        cts.Cancel();
+
+        Assert.True(scope.Token.IsCancellationRequested);
+        Assert.False(scope.IsTimeoutCancellationRequested);
+    }
+
+    [Fact]
     public async Task Token_RecordsTimeoutCancellation_Issue3998()
     {
         using var scope = OperationTimeoutScope.Create(


### PR DESCRIPTION
## Summary

- Replaced the watch-mode debounce clock with `TimeProvider` monotonic timestamps so `cdidx index --watch` no longer depends on wall-clock movement.
- Added `OperationTimeoutBudget` and routed GitHub request cancellation through it while preserving the existing bounded timeout policy for zero/infinite values.
- Added focused tests and a bilingual changelog fragment.

## Impact

This keeps watch batching stable across wall-clock jumps and centralizes timeout sentinel handling behind an explicit budget abstraction.

Fixes #4129

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~IndexWatchRunnerTests|FullyQualifiedName~OperationTimeoutScopeTests|FullyQualifiedName~GitHubHttpCancellationTests"`
- `git diff --check`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore`
- `dotnet build CodeIndex.sln -c Release`
- `dotnet build CodeIndex.sln`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

Note: `dotnet test CodeIndex.sln -c Release --no-build` was interrupted after about 7 minutes with no failure output beyond existing skipped tests; the focused affected test set passed on net8.0 and net9.0.