### PR TITLE
Test local JSONL relaxed escaping boundary

### DIFF
--- a/changelog.d/unreleased/4135.security.md
+++ b/changelog.d/unreleased/4135.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 4135
+affected:
+  - tests/CodeIndex.Tests/LocalJsonlJsonWriterOptionsTests.cs
+  - changelog.d/unreleased/4135.security.md
+---
+
+## English
+
+- **Pinned the local JSONL relaxed-escaping boundary (#4135)** — Added tests proving private JSONL diagnostics preserve HTML/script-like characters for tail/JSON consumers while control characters remain line-safe, and the relaxed encoder stays limited to local metrics/audit log sinks.
+
+## 日本語
+
+- **local JSONL の relaxed escaping 境界を固定しました (#4135)** — private JSONL diagnostic が tail / JSON consumer 向けに HTML/script-like 文字を保持しつつ control character は1行内に収めること、relaxed encoder の利用先が local metrics / audit log sink に限られることをテストで固定しました。

--- a/tests/CodeIndex.Tests/LocalJsonlJsonWriterOptionsTests.cs
+++ b/tests/CodeIndex.Tests/LocalJsonlJsonWriterOptionsTests.cs
@@ -1,4 +1,6 @@
+using System.Text;
 using System.Text.Encodings.Web;
+using System.Text.Json;
 using CodeIndex.Diagnostics;
 
 namespace CodeIndex.Tests;
@@ -37,6 +39,33 @@ public class LocalJsonlJsonWriterOptionsTests
                 "src/CodeIndex/Mcp/AuditLogSink.cs",
                 "tests/CodeIndex.Tests/LocalJsonlJsonWriterOptionsTests.cs",
             });
+    }
+
+    [Fact]
+    public void Create_PreservesHtmlLikeCharactersWhileKeepingJsonlLineParseable()
+    {
+        const string message = "tail<>&\"' / </script><script>alert(\"x\")</script>\nnext";
+
+        using var buffer = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(buffer, LocalJsonlJsonWriterOptions.Create()))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("message", message);
+            writer.WriteEndObject();
+        }
+
+        var jsonl = Encoding.UTF8.GetString(buffer.ToArray());
+
+        Assert.Contains("</script><script>", jsonl);
+        Assert.Contains("<>&", jsonl);
+        Assert.DoesNotContain("\\u003C", jsonl);
+        Assert.DoesNotContain("\\u003E", jsonl);
+        Assert.DoesNotContain("\\u0026", jsonl);
+        Assert.DoesNotContain("\n", jsonl);
+        Assert.Contains("\\n", jsonl);
+
+        using var document = JsonDocument.Parse(jsonl);
+        Assert.Equal(message, document.RootElement.GetProperty("message").GetString());
     }
 
     private static void AssertOnlyAllowedFilesContain(


### PR DESCRIPTION
## Summary

- Added a regression test that serializes HTML/script-like text through `LocalJsonlJsonWriterOptions`.
- Verified the private JSONL encoder preserves relaxed HTML characters, keeps newline content line-safe, and remains parseable by JSON consumers.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~LocalJsonlJsonWriterOptionsTests -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and changelog

- Added `changelog.d/unreleased/4135.security.md`.
- No docs changes were needed; the existing developer guide already documents the private local JSONL boundary.

## Review

- Adversarial review: No blocking/actionable issues found.

## Follow-up candidates

- None.

Fixes #4135
