### PR TITLE
[codex] Harden dependency manifest XML parsing

### DIFF
--- a/changelog.d/unreleased/4130.security.md
+++ b/changelog.d/unreleased/4130.security.md
@@ -1,0 +1,16 @@
+---
+category: security
+issues:
+  - 4130
+affected:
+  - src/CodeIndex/Indexer/DependencyPackageExtractor.cs
+  - tests/CodeIndex.Tests/DependencyPackageExtractorTests.cs
+---
+
+## English
+
+- **Dependency manifest XML parsing now uses the shared safe reader policy (#4130)** — package extraction for XML dependency manifests now disables DTD processing, external entity resolution, and oversized documents through the same bounded XML reader settings used by build and metadata extraction.
+
+## 日本語
+
+- **依存関係 manifest の XML 解析が共有の安全な reader policy を使うようになりました (#4130)** — XML 依存関係 manifest の package 抽出は、build / metadata 抽出と同じ上限付き XML reader settings を使い、DTD 処理、外部 entity 解決、過大な document を無効化します。

--- a/src/CodeIndex/Indexer/DependencyPackageExtractor.cs
+++ b/src/CodeIndex/Indexer/DependencyPackageExtractor.cs
@@ -126,7 +126,10 @@ internal static class DependencyPackageExtractor
         XDocument document;
         try
         {
-            document = XDocument.Parse(content, LoadOptions.SetLineInfo);
+            using var reader = XmlReader.Create(
+                new StringReader(content),
+                SymbolExtractor.CreateExtractionXmlReaderSettings(DtdProcessing.Prohibit));
+            document = XDocument.Load(reader, LoadOptions.SetLineInfo);
         }
         catch (XmlException)
         {

--- a/tests/CodeIndex.Tests/DependencyPackageExtractorTests.cs
+++ b/tests/CodeIndex.Tests/DependencyPackageExtractorTests.cs
@@ -92,6 +92,49 @@ public class DependencyPackageExtractorTests
     }
 
     [Fact]
+    public void Extract_DependencyManifest_RejectsDtdWithSharedReaderPolicy_Issue4130()
+    {
+        var symbols = SymbolExtractor.Extract(
+            5,
+            "dependency_manifest",
+            """
+            <!DOCTYPE Project [
+              <!ENTITY packageName "Unsafe.Package">
+            ]>
+            <Project>
+              <ItemGroup>
+                <PackageVersion Include="&packageName;" Version="1.0.0" />
+              </ItemGroup>
+            </Project>
+            """,
+            filePath: "Directory.Packages.props");
+
+        Assert.Empty(symbols);
+    }
+
+    [Fact]
+    public void Extract_DependencyManifest_StopsAtSharedDocumentLimit_Issue4130()
+    {
+        var padding = new string('a', (int)SymbolExtractor.XmlExtractionMaxCharactersInDocument + 1);
+        var symbols = SymbolExtractor.Extract(
+            6,
+            "dependency_manifest",
+            $"""
+            <Project>
+              <ItemGroup>
+                <PackageVersion Include="TooLarge.Package" Version="1.0.0" />
+              </ItemGroup>
+              <PropertyGroup>
+                <Padding>{padding}</Padding>
+              </PropertyGroup>
+            </Project>
+            """,
+            filePath: "Directory.Packages.props");
+
+        Assert.Empty(symbols);
+    }
+
+    [Fact]
     public void Extract_DependencyLock_EmitsResolvedPackageSymbolsAndReferences_Issue3899()
     {
         var content =


### PR DESCRIPTION
## Summary

- Route XML dependency manifest package extraction through the shared safe XML reader settings with `DtdProcessing.Prohibit`.
- Add regression coverage for DTD rejection and shared document-size limits in dependency manifest extraction.
- Add the issue-linked security changelog fragment.

## Root Cause

Dependency manifest package extraction used `XDocument.Parse` directly, so it bypassed the shared XML reader policy used by build and metadata extraction for resolver, DTD, and size-limit posture.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter FullyQualifiedName~DependencyPackageExtractorTests -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter FullyQualifiedName~DependencyPackageExtractorTests -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `dotnet build --no-restore -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

`dotnet format CodeIndex.sln --verify-no-changes --no-restore` and the same command scoped with `--include` were attempted, but both stayed running without useful progress and were interrupted; they are not counted as passing validation.

## Documentation / Changelog

- No README or guide update was needed because this is internal extraction hardening, not a CLI/MCP contract change.
- Changelog fragment: `changelog.d/unreleased/4130.security.md`

## Adversarial Review

No blocking/actionable issues found.

## Follow-up Candidates

None.

Fixes #4130
