### PR TITLE
Fix atomic overwrite mode ordering

### DIFF
--- a/changelog.d/unreleased/4132.fixed.md
+++ b/changelog.d/unreleased/4132.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 4132
+affected:
+  - src/CodeIndex/Cli/AtomicFileWriter.cs
+  - tests/CodeIndex.Tests/AtomicFileWriterTests.cs
+---
+
+## English
+
+- **Atomic overwrite moves avoid post-replace mode failures (#4132)** — overwrite moves that need destination metadata now apply that metadata to the staged source before replacing the target, so a mode failure leaves both the source and existing destination intact.
+
+## 日本語
+
+- **atomic overwrite move で置換後の mode 失敗を避けるようになりました (#4132)** — 宛先 metadata が必要な overwrite move は、target を置換する前に staged source 側へ metadata を適用するため、mode 失敗時に source と既存 destination の両方が保持されます。

--- a/src/CodeIndex/Cli/AtomicFileWriter.cs
+++ b/src/CodeIndex/Cli/AtomicFileWriter.cs
@@ -166,11 +166,16 @@ internal static class AtomicFileWriter
         bool overwrite,
         Action<string>? applyDestinationMode)
     {
+        if (overwrite)
+            applyDestinationMode?.Invoke(sourcePath);
+
         File.Move(
             LongPath.EnsureWindowsPrefix(sourcePath),
             LongPath.EnsureWindowsPrefix(destinationPath),
             overwrite);
-        applyDestinationMode?.Invoke(destinationPath);
+
+        if (!overwrite)
+            applyDestinationMode?.Invoke(destinationPath);
     }
 
     internal static void FlushParentDirectoryAfterReplace(string path)

--- a/tests/CodeIndex.Tests/AtomicFileWriterTests.cs
+++ b/tests/CodeIndex.Tests/AtomicFileWriterTests.cs
@@ -142,6 +142,40 @@ public class AtomicFileWriterTests
     }
 
     [Fact]
+    public void MoveFile_OverwriteModeFailureBeforeMove_LeavesSourceAndDestination_Issue4132()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("atomic_overwrite_mode_failure");
+        try
+        {
+            var sourcePath = Path.Combine(projectRoot, "source.db");
+            var destinationPath = Path.Combine(projectRoot, "destination.db");
+            string? modePath = null;
+            File.WriteAllText(sourcePath, "new", Utf8NoBom);
+            File.WriteAllText(destinationPath, "old", Utf8NoBom);
+
+            var ex = Assert.Throws<UnauthorizedAccessException>(() =>
+                AtomicFileWriter.MoveFile(
+                    sourcePath,
+                    destinationPath,
+                    overwrite: true,
+                    applyDestinationMode: path =>
+                    {
+                        modePath = path;
+                        throw new UnauthorizedAccessException("mode denied");
+                    }));
+
+            Assert.Contains("mode denied", ex.Message, StringComparison.Ordinal);
+            Assert.Equal(sourcePath, modePath);
+            Assert.Equal("new", File.ReadAllText(sourcePath, Utf8NoBom));
+            Assert.Equal("old", File.ReadAllText(destinationPath, Utf8NoBom));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void PublishDirectory_ParentDirectoryFlushFailure_ReportsPublishedDirectory_Issue4001()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("atomic_directory_publish_flush");


### PR DESCRIPTION
## Summary

- Apply destination metadata to the source before overwrite moves, so metadata failures do not replace the existing target.
- Add regression coverage for overwrite mode failures preserving both source and destination.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --filter FullyQualifiedName~AtomicFileWriterTests -p:UseSharedCompilation=false`
- `dotnet build src/CodeIndex/CodeIndex.csproj -c Release -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Attempted `dotnet build CodeIndex.sln -c Release -p:UseSharedCompilation=false`; stopped after it remained in test-project compilation for about 9 minutes, with compiler exit 130 from the manual interruption.

## Documentation / Changelog

- Added `changelog.d/unreleased/4132.fixed.md`.
- No docs change was needed; this is an internal atomic-write safety fix without a CLI or documented contract change.

## Review

Adversarial review result: No blocking/actionable issues found.

## Follow-up Candidates

None.

Fixes #4132
