### PR TITLE
Audit SQLite query policy surfaces

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1062,7 +1062,8 @@ cleanup, probe, diagnostic-sanitization, and worker boundaries from catches that
 should be narrowed or rethrown.
 Built-in recipes include `risky-code`, `json-parse-apis`,
 `auth-token-audit`, `dogfood-risk-patterns`, `dotnet-risk-patterns`,
-`xml-parser-security`, `filesystem-traversal`, `bounded-read-evidence`, and the
+`sqlite-query-policy-surfaces`, `xml-parser-security`, `filesystem-traversal`,
+`bounded-read-evidence`, and the
 opt-in broad `broad-token-audit` recipe.
 `--recipe <name>` applies normal search filters such as `--lang`, `--path`,
 `--exclude-path`, `--exclude-tests`, `--limit`, and snippet controls to every
@@ -3726,8 +3727,9 @@ result level、正規化済みの repository-relative artifact URI を出力し�
 
 search audit recipe は、名前付き recipe を複数の curated search query に展開します。
 組み込み recipe には `risky-code`、`json-parse-apis`、`dotnet-risk-patterns`、`xml-parser-security`、
-`auth-token-audit`、`dogfood-risk-patterns`、`filesystem-traversal`、`bounded-read-evidence`、
-`broad-token-audit` があります。`--list-recipes` は利用可能な名前、
+`auth-token-audit`、`dogfood-risk-patterns`、`sqlite-query-policy-surfaces`、
+`filesystem-traversal`、`bounded-read-evidence`、`broad-token-audit` があります。
+`--list-recipes` は利用可能な名前、
 説明、推奨 label、query text、exact-match mode、false-positive guidance、guard filter、
 risk evidence、query 固有の audit taxonomy metadata を表示します。
 `--query <filter>` を追加すると、recipe/query 名、query text、label、severity、path metadata、

--- a/changelog.d/unreleased/4128.security.md
+++ b/changelog.d/unreleased/4128.security.md
@@ -1,0 +1,20 @@
+---
+category: security
+issues:
+  - 4128
+affected:
+  - USER_GUIDE.md
+  - src/CodeIndex/Database/DbPragmaPolicy.cs
+  - src/CodeIndex/Database/DbContext.cs
+  - src/CodeIndex/Cli/SearchAuditRecipes.cs
+  - tests/CodeIndex.Tests/DbConnectionPolicyTests.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+---
+
+## English
+
+- **Added a SQLite query-policy audit recipe (#4128)** - `search --recipe sqlite-query-policy-surfaces` now covers raw `CommandText`, PRAGMA, Execute* calls, DDL, transactions, metadata, read-only/immutable, migration, CHECK constraint, and maintenance status surfaces, while dynamic maintenance PRAGMAs now route through bounded policy helpers.
+
+## 日本語
+
+- **SQLite query policy 監査レシピを追加しました (#4128)** - `search --recipe sqlite-query-policy-surfaces` は raw `CommandText`、PRAGMA、Execute* 呼び出し、DDL、transaction、metadata、read-only/immutable、migration、CHECK constraint、maintenance status の各 surface を対象にし、動的 maintenance PRAGMA は境界チェック済みの policy helper を通すようになりました。

--- a/src/CodeIndex/Cli/SearchAuditRecipes.cs
+++ b/src/CodeIndex/Cli/SearchAuditRecipes.cs
@@ -778,6 +778,153 @@ internal static class SearchAuditRecipes
                 }
             ]),
         SourceScopedRecipe(
+            "sqlite-query-policy-surfaces",
+            "Audit SQLite raw SQL, PRAGMA, schema, transaction, metadata, and read-only compatibility surfaces under the shared command/query policy.",
+            [
+                new(
+                    "sqlite-policy-command-text",
+                    "CommandText",
+                    "Find SQLite command text construction that may need parameterization, identifier quoting, timeout, and cancellation review.",
+                    ["audit", "security"],
+                    "False positives include constant SQL text with all values bound through SqliteCommandPolicy helpers.")
+                {
+                    RiskEvidence =
+                    [
+                        "risk: raw CommandText can mix trusted SQL, dynamic identifiers, and user values without a single policy checkpoint.",
+                        "positive: typed SqliteCommandPolicy parameters and SqliteIdentifier quoting are safer evidence."
+                    ],
+                },
+                new(
+                    "sqlite-policy-create-command",
+                    "CreateCommand",
+                    "Find SQLite command creation sites that may need the shared command policy before executing SQL.",
+                    ["audit", "security"],
+                    "False positives include isolated tests or commands immediately populated by a shared policy helper.")
+                {
+                    RiskEvidence =
+                    [
+                        "risk: ad hoc commands can skip typed parameters, timeout setup, cancellation boundaries, or read-only checks.",
+                        "positive: command wrappers that centralize timeout, typed parameter, and SQL text policy reduce the risk."
+                    ],
+                },
+                new(
+                    "sqlite-policy-execute-reader",
+                    "ExecuteReader",
+                    "Find SQLite reader execution surfaces that may need timeout, cancellation, and result-bounding review.",
+                    ["audit", "bug"],
+                    "False positives include bounded internal queries and reader loops with explicit cancellation or row limits."),
+                new(
+                    "sqlite-policy-execute-non-query",
+                    "ExecuteNonQuery",
+                    "Find SQLite mutation execution surfaces that may need transaction, timeout, cancellation, and read-only compatibility review.",
+                    ["audit", "security"],
+                    "False positives include schema setup or maintenance operations already guarded by mode checks and shared SQL helpers."),
+                new(
+                    "sqlite-policy-execute-scalar",
+                    "ExecuteScalar",
+                    "Find SQLite scalar execution surfaces that may need type conversion, timeout, and PRAGMA compatibility review.",
+                    ["audit", "bug"],
+                    "False positives include constant bounded probes whose result conversion is centralized."),
+                new(
+                    "sqlite-policy-add-with-value",
+                    "AddWithValue",
+                    "Find SQLite parameter binding that may need explicit type or size review instead of provider inference.",
+                    ["audit", "bug"],
+                    "False positives include tests and intentionally unconstrained values that cannot affect SQL shape."),
+                new(
+                    "sqlite-policy-pragma",
+                    "PRAGMA",
+                    "Find SQLite PRAGMA surfaces that may need allowlisted names, bounded values, and read-only fallback review.",
+                    ["audit", "security"],
+                    "False positives include constant read-only PRAGMA probes and calls routed through DbPragmaPolicy or SqliteCommandPolicy helpers.")
+                {
+                    RiskEvidence =
+                    [
+                        "risk: PRAGMA syntax is commonly string-built because SQLite cannot bind every pragma value like a normal parameter.",
+                        "positive: allowlisted pragma names, bounded numeric builders, and fixed values are safer evidence."
+                    ],
+                },
+                new(
+                    "sqlite-policy-create-table",
+                    "CREATE TABLE",
+                    "Find SQLite table DDL that may need schema compatibility, identifier, and migration review.",
+                    ["audit", "security"],
+                    "False positives include static schema statements covered by migration tests."),
+                new(
+                    "sqlite-policy-alter-table",
+                    "ALTER TABLE",
+                    "Find SQLite schema evolution statements that may need legacy database compatibility review.",
+                    ["audit", "bug"],
+                    "False positives include static migrations guarded by schema-version checks."),
+                new(
+                    "sqlite-policy-create-index",
+                    "CREATE INDEX",
+                    "Find SQLite index DDL that may need identifier quoting, uniqueness, and migration compatibility review.",
+                    ["audit", "bug"],
+                    "False positives include static index definitions covered by migration tests."),
+                new(
+                    "sqlite-policy-drop-table",
+                    "DROP TABLE",
+                    "Find SQLite destructive DDL that may need transaction and legacy compatibility review.",
+                    ["audit", "security"],
+                    "False positives include temporary-table cleanup in isolated maintenance paths."),
+                new(
+                    "sqlite-policy-delete-from",
+                    "DELETE FROM",
+                    "Find SQLite delete statements that may need parameterization, transaction, and read-only mode review.",
+                    ["audit", "security"],
+                    "False positives include bounded maintenance cleanup with typed parameters and explicit mode checks."),
+                new(
+                    "sqlite-policy-begin-transaction",
+                    "BeginTransaction",
+                    "Find SQLite transaction boundaries that may need isolation, busy timeout, WAL, and cancellation review.",
+                    ["audit", "bug"],
+                    "False positives include short-lived schema transactions covered by rollback tests."),
+                new(
+                    "sqlite-policy-codeindex-meta",
+                    "codeindex_meta",
+                    "Find SQLite metadata stamping and reads that may need migration, downgrade, and read-only compatibility review.",
+                    ["audit", "bug"],
+                    "False positives include constant metadata keys covered by schema compatibility tests."),
+                new(
+                    "sqlite-policy-user-version",
+                    "user_version",
+                    "Find SQLite user_version reads and writes that may need migration and read-only fallback review.",
+                    ["audit", "bug"],
+                    "False positives include constant version probes with explicit writable-mode checks."),
+                new(
+                    "sqlite-policy-check-constraint",
+                    "CHECK (",
+                    "Find SQLite CHECK constraints that may encode enum or state allowlists needing compatibility review.",
+                    ["audit", "bug"],
+                    "False positives include static constraints whose allowed values are covered by round-trip tests."),
+                new(
+                    "sqlite-policy-immutable-uri",
+                    "immutable=1",
+                    "Find SQLite immutable read-only URI handling that may need WAL, side-file, and migration compatibility review.",
+                    ["audit", "bug"],
+                    "False positives include diagnostic text and tests that only assert the documented fallback path."),
+                new(
+                    "sqlite-policy-read-only",
+                    "read-only",
+                    "Find SQLite read-only fallback text and control flow that may need write avoidance and compatibility review.",
+                    ["audit", "bug"],
+                    "False positives include user-facing help text and tests that intentionally exercise read-only failures."),
+                new(
+                    "sqlite-policy-migration",
+                    "Migration",
+                    "Find SQLite migration code paths that may need legacy schema, metadata, and downgrade compatibility review.",
+                    ["audit", "bug"],
+                    "False positives include stable diagnostic constants and tests that only assert migration messages."),
+                new(
+                    "sqlite-policy-maintenance-progress",
+                    "ReportMaintenanceProgress",
+                    "Find SQLite maintenance status surfaces that may need PRAGMA, transaction, and read-only compatibility review.",
+                    ["audit", "bug"],
+                    "False positives include progress-only emission that does not affect database state.")
+            ],
+            DefaultExecutableExcludeOriginsValue),
+        SourceScopedRecipe(
             "json-parse-apis",
             "Audit JSON parse and deserialize API families that may need payload bounds, streaming, or serializer-option review.",
             [

--- a/src/CodeIndex/Database/DbContext.cs
+++ b/src/CodeIndex/Database/DbContext.cs
@@ -452,7 +452,7 @@ public class DbContext : IDisposable
             if (!string.Equals(journalMode, "wal", StringComparison.OrdinalIgnoreCase))
                 CommandErrorWriter.WriteStderr($"Warning: WAL mode not enabled (got '{journalMode}')");
             ExecuteSynchronousPragmaWithFallback(Execute);
-            Execute($"PRAGMA wal_autocheckpoint={DefaultWalAutocheckpointPages}");
+            Execute(DbPragmaPolicy.WalAutocheckpointPragmaSql(DefaultWalAutocheckpointPages));
             ApplyPrivateDatabaseFileModes(dbPath);
             Execute("PRAGMA optimize=0x10002");
             WarnIfBatchInProgress();
@@ -491,7 +491,7 @@ public class DbContext : IDisposable
                     if (!string.Equals(journalMode, "wal", StringComparison.OrdinalIgnoreCase))
                         CommandErrorWriter.WriteStderr($"Warning: WAL mode not enabled (got '{journalMode}')");
                     ExecuteSynchronousPragmaWithFallback(Execute);
-                    Execute($"PRAGMA wal_autocheckpoint={DefaultWalAutocheckpointPages}");
+                    Execute(DbPragmaPolicy.WalAutocheckpointPragmaSql(DefaultWalAutocheckpointPages));
                     ApplyPrivateDatabaseFileModes(dbPath);
                     Execute("PRAGMA optimize=0x10002");
                     WarnIfBatchInProgress();
@@ -734,7 +734,7 @@ public class DbContext : IDisposable
         if (!dryRun && before.AutoVacuumMode == 2)
         {
             ReportMaintenanceProgress("vacuum", "incremental_vacuum", _connection.DataSource);
-            Execute($"PRAGMA incremental_vacuum({before.FreelistCount})");
+            Execute(DbPragmaPolicy.IncrementalVacuumPragmaSql(before.FreelistCount));
         }
         else if (!dryRun)
         {

--- a/src/CodeIndex/Database/DbPragmaPolicy.cs
+++ b/src/CodeIndex/Database/DbPragmaPolicy.cs
@@ -1,5 +1,6 @@
 using CodeIndex.Cli;
 using Microsoft.Data.Sqlite;
+using System.Globalization;
 
 namespace CodeIndex.Database;
 
@@ -46,9 +47,10 @@ internal static class DbPragmaPolicy
         Action<string> execute,
         string synchronousMode)
     {
+        var sql = SynchronousPragmaSql(synchronousMode);
         try
         {
-            execute($"PRAGMA synchronous={synchronousMode}");
+            execute(sql);
         }
         catch (SqliteException ex) when (IsSafetyLevelTransactionError(ex))
         {
@@ -74,21 +76,51 @@ internal static class DbPragmaPolicy
     {
         if (busyTimeoutMs is < 0 or > MaxBusyTimeoutMs)
             throw new ArgumentOutOfRangeException(nameof(busyTimeoutMs), busyTimeoutMs, $"SQLite busy_timeout must be between 0 and {MaxBusyTimeoutMs} milliseconds.");
-        return $"PRAGMA busy_timeout={busyTimeoutMs}";
+        return $"PRAGMA busy_timeout={busyTimeoutMs.ToString(CultureInfo.InvariantCulture)}";
     }
 
     internal static string CacheSizePragmaSql(int cacheSizeKb)
     {
         if (cacheSizeKb <= 0)
             throw new ArgumentOutOfRangeException(nameof(cacheSizeKb), cacheSizeKb, "SQLite cache_size kilobytes must be positive.");
-        return $"PRAGMA cache_size=-{cacheSizeKb}";
+        return $"PRAGMA cache_size=-{cacheSizeKb.ToString(CultureInfo.InvariantCulture)}";
     }
 
     internal static string MmapSizePragmaSql(long mmapSizeBytes)
     {
         if (mmapSizeBytes < 0)
             throw new ArgumentOutOfRangeException(nameof(mmapSizeBytes), mmapSizeBytes, "SQLite mmap_size bytes must be non-negative.");
-        return $"PRAGMA mmap_size={mmapSizeBytes}";
+        return $"PRAGMA mmap_size={mmapSizeBytes.ToString(CultureInfo.InvariantCulture)}";
+    }
+
+    internal static string SynchronousPragmaSql(string synchronousMode)
+        => $"PRAGMA synchronous={NormalizeSynchronousMode(synchronousMode)}";
+
+    internal static string WalAutocheckpointPragmaSql(int pageCount)
+    {
+        if (pageCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(pageCount), pageCount, "SQLite wal_autocheckpoint page count must be non-negative.");
+        return $"PRAGMA wal_autocheckpoint={pageCount.ToString(CultureInfo.InvariantCulture)}";
+    }
+
+    internal static string IncrementalVacuumPragmaSql(long pageCount)
+    {
+        if (pageCount < 0)
+            throw new ArgumentOutOfRangeException(nameof(pageCount), pageCount, "SQLite incremental_vacuum page count must be non-negative.");
+        return $"PRAGMA incremental_vacuum({pageCount.ToString(CultureInfo.InvariantCulture)})";
+    }
+
+    private static string NormalizeSynchronousMode(string synchronousMode)
+    {
+        if (string.IsNullOrWhiteSpace(synchronousMode))
+            throw new ArgumentException("SQLite synchronous mode must be one of OFF, NORMAL, FULL, or EXTRA.", nameof(synchronousMode));
+
+        var normalized = synchronousMode.Trim().ToUpperInvariant();
+        return normalized switch
+        {
+            "OFF" or "NORMAL" or "FULL" or "EXTRA" => normalized,
+            _ => throw new ArgumentOutOfRangeException(nameof(synchronousMode), synchronousMode, "SQLite synchronous mode must be one of OFF, NORMAL, FULL, or EXTRA.")
+        };
     }
 
     private static int ReadPositiveIntEnvironment(string name, int fallback, int maximum)

--- a/tests/CodeIndex.Tests/DbConnectionPolicyTests.cs
+++ b/tests/CodeIndex.Tests/DbConnectionPolicyTests.cs
@@ -78,6 +78,20 @@ public class DbConnectionPolicyTests
     }
 
     [Fact]
+    public void DbPragmaPolicy_DynamicPragmaSqlHelpers_ConstrainValues_Issue4128()
+    {
+        Assert.Equal("PRAGMA synchronous=NORMAL", DbPragmaPolicy.SynchronousPragmaSql("normal"));
+        Assert.Equal("PRAGMA synchronous=EXTRA", DbPragmaPolicy.SynchronousPragmaSql(" EXTRA "));
+        Assert.Equal("PRAGMA wal_autocheckpoint=1000", DbPragmaPolicy.WalAutocheckpointPragmaSql(1000));
+        Assert.Equal("PRAGMA incremental_vacuum(123)", DbPragmaPolicy.IncrementalVacuumPragmaSql(123));
+
+        Assert.Throws<ArgumentException>(() => DbPragmaPolicy.SynchronousPragmaSql(""));
+        Assert.Throws<ArgumentOutOfRangeException>(() => DbPragmaPolicy.SynchronousPragmaSql("NORMAL; DROP TABLE files"));
+        Assert.Throws<ArgumentOutOfRangeException>(() => DbPragmaPolicy.WalAutocheckpointPragmaSql(-1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => DbPragmaPolicy.IncrementalVacuumPragmaSql(-1));
+    }
+
+    [Fact]
     public void DbPragmaPolicy_ReadBusyTimeoutPragmaSql_UsesBoundedEnvironmentValue_Issue4070()
     {
         using var scope = CdidxEnvironment.Push(new Dictionary<string, string>

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -1285,6 +1285,10 @@ public partial class QueryCommandRunnerTests
             .GetProperty("recipes")
             .EnumerateArray()
             .Single(item => item.GetProperty("name").GetString() == "dogfood-risk-patterns");
+        var sqlitePolicyRecipe = root
+            .GetProperty("recipes")
+            .EnumerateArray()
+            .Single(item => item.GetProperty("name").GetString() == "sqlite-query-policy-surfaces");
         var xmlRecipe = root
             .GetProperty("recipes")
             .EnumerateArray()
@@ -1325,6 +1329,14 @@ public partial class QueryCommandRunnerTests
             .GetProperty("queries")
             .EnumerateArray()
             .Single(item => item.GetProperty("name").GetString() == "raw-sql-command-text");
+        var sqlitePolicyCommandTextQuery = sqlitePolicyRecipe
+            .GetProperty("queries")
+            .EnumerateArray()
+            .Single(item => item.GetProperty("name").GetString() == "sqlite-policy-command-text");
+        var sqlitePolicyPragmaQuery = sqlitePolicyRecipe
+            .GetProperty("queries")
+            .EnumerateArray()
+            .Single(item => item.GetProperty("name").GetString() == "sqlite-policy-pragma");
         var emptyCatchQuery = recipe
             .GetProperty("queries")
             .EnumerateArray()
@@ -1431,6 +1443,10 @@ public partial class QueryCommandRunnerTests
         Assert.Contains(dogfoodRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "static-regex-api-negated");
         Assert.Contains(dogfoodRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "static-regex-api-parenthesized");
         Assert.Contains(dogfoodSqlQuery.GetProperty("risk_evidence").EnumerateArray(), evidence => evidence.GetString()!.Contains("identifier", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains(sqlitePolicyCommandTextQuery.GetProperty("risk_evidence").EnumerateArray(), evidence => evidence.GetString()!.Contains("SqliteCommandPolicy", StringComparison.Ordinal));
+        Assert.Contains(sqlitePolicyPragmaQuery.GetProperty("risk_evidence").EnumerateArray(), evidence => evidence.GetString()!.Contains("cannot bind every pragma value", StringComparison.Ordinal));
+        Assert.Contains(sqlitePolicyRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "sqlite-policy-immutable-uri");
+        Assert.Contains(sqlitePolicyRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "sqlite-policy-maintenance-progress");
         Assert.Contains(recipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "file-read-all-text");
         Assert.Contains(recipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "file-read-all-bytes");
         Assert.Contains(recipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "thread-sleep");
@@ -1600,6 +1616,7 @@ public partial class QueryCommandRunnerTests
         var recipes = root.GetProperty("recipes").EnumerateArray().ToList();
         var dotnetRecipe = Assert.Single(recipes, recipe => recipe.GetProperty("name").GetString() == "dotnet-risk-patterns");
         var dogfoodRecipe = Assert.Single(recipes, recipe => recipe.GetProperty("name").GetString() == "dogfood-risk-patterns");
+        var sqlitePolicyRecipe = Assert.Single(recipes, recipe => recipe.GetProperty("name").GetString() == "sqlite-query-policy-surfaces");
         var dotnetQueryNames = dotnetRecipe.GetProperty("queries")
             .EnumerateArray()
             .Select(query => query.GetProperty("name").GetString() ?? string.Empty)
@@ -1608,14 +1625,21 @@ public partial class QueryCommandRunnerTests
             .EnumerateArray()
             .Select(query => query.GetProperty("name").GetString() ?? string.Empty)
             .ToList();
+        var sqlitePolicyQueryNames = sqlitePolicyRecipe.GetProperty("queries")
+            .EnumerateArray()
+            .Select(query => query.GetProperty("name").GetString() ?? string.Empty)
+            .ToList();
 
         Assert.Equal(CommandExitCodes.Success, exitCode);
         Assert.Equal(string.Empty, stderr);
-        Assert.Equal(2, root.GetProperty("count").GetInt32());
+        Assert.Equal(3, root.GetProperty("count").GetInt32());
         Assert.Equal(root.GetProperty("count").GetInt32(), recipes.Count);
         Assert.Contains("sqlite-addwithvalue", dotnetQueryNames);
         Assert.All(dotnetQueryNames, name => Assert.Contains("sqlite", name, StringComparison.OrdinalIgnoreCase));
         Assert.Equal(["pragma-command"], dogfoodQueryNames);
+        Assert.Contains("sqlite-policy-command-text", sqlitePolicyQueryNames);
+        Assert.Contains("sqlite-policy-pragma", sqlitePolicyQueryNames);
+        Assert.All(sqlitePolicyQueryNames, name => Assert.Contains("sqlite", name, StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -1667,7 +1691,7 @@ public partial class QueryCommandRunnerTests
         };
 
         Assert.Equal(
-            ["risky-code", "auth-token-audit", "dogfood-risk-patterns", "json-parse-apis", "dotnet-risk-patterns", "xml-parser-security", "filesystem-traversal", "bounded-read-evidence", "broad-token-audit"],
+            ["risky-code", "auth-token-audit", "dogfood-risk-patterns", "sqlite-query-policy-surfaces", "json-parse-apis", "dotnet-risk-patterns", "xml-parser-security", "filesystem-traversal", "bounded-read-evidence", "broad-token-audit"],
             recipes.Select(recipe => recipe.Name).ToArray());
 
         AssertRecipe(
@@ -1747,6 +1771,33 @@ public partial class QueryCommandRunnerTests
                 "environment-variable-parser",
                 "plugin-activator",
                 "assembly-load-context"
+            ]);
+        AssertRecipe(
+            "sqlite-query-policy-surfaces",
+            SearchAuditRecipes.DefaultAuditScope,
+            ["src/**"],
+            expectedSourceExcludes,
+            [
+                "sqlite-policy-command-text",
+                "sqlite-policy-create-command",
+                "sqlite-policy-execute-reader",
+                "sqlite-policy-execute-non-query",
+                "sqlite-policy-execute-scalar",
+                "sqlite-policy-add-with-value",
+                "sqlite-policy-pragma",
+                "sqlite-policy-create-table",
+                "sqlite-policy-alter-table",
+                "sqlite-policy-create-index",
+                "sqlite-policy-drop-table",
+                "sqlite-policy-delete-from",
+                "sqlite-policy-begin-transaction",
+                "sqlite-policy-codeindex-meta",
+                "sqlite-policy-user-version",
+                "sqlite-policy-check-constraint",
+                "sqlite-policy-immutable-uri",
+                "sqlite-policy-read-only",
+                "sqlite-policy-migration",
+                "sqlite-policy-maintenance-progress"
             ]);
         AssertRecipe(
             "json-parse-apis",

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -1889,7 +1889,8 @@ public partial class QueryCommandRunnerTests
         Assert.Equal(string.Empty, stdout);
         Assert.Contains("unknown recipe query 'raw-sql' for recipe 'risky-code'", stderr);
         Assert.Contains("Suggestions across all recipes:", stderr);
-        Assert.Contains("dotnet-risk-patterns/sqlite-addwithvalue", stderr);
+        Assert.Contains("dogfood-risk-patterns/raw-sql-command-text", stderr);
+        Assert.Contains("sqlite-query-policy-surfaces/sqlite-policy-add-with-value", stderr);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Added `sqlite-query-policy-surfaces` to cover SQLite raw SQL, PRAGMA, Execute*, DDL, transaction, metadata, read-only/immutable, migration, CHECK constraint, and maintenance progress audit surfaces.
- Routed dynamic maintenance PRAGMAs through bounded `DbPragmaPolicy` builders for synchronous mode, WAL autocheckpoint, and incremental vacuum.
- Updated `USER_GUIDE.md` in both English and Japanese sections, plus the changelog fragment `changelog.d/unreleased/4128.security.md`.

## Validation

- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~DbConnectionPolicyTests|FullyQualifiedName~RunSearch_ListRecipesJsonIncludesBuiltInAuditMetadata_Issue3144|FullyQualifiedName~RunSearch_ListRecipesQueryFiltersChildQueries_Issue3975|FullyQualifiedName~RunSearch_BuiltInRecipeSnapshotCoversNamesScopesAndQueries_Issue3692"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --framework net8.0 --filter "FullyQualifiedName~DbConnectionPolicyTests|FullyQualifiedName~RunSearch_ListRecipesJsonIncludesBuiltInAuditMetadata_Issue3144|FullyQualifiedName~RunSearch_ListRecipesQueryFiltersChildQueries_Issue3975|FullyQualifiedName~RunSearch_BuiltInRecipeSnapshotCoversNamesScopesAndQueries_Issue3692" -p:UseSharedCompilation=false -p:BuildInParallel=false -m:1 --no-restore`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~RunSearch_ListRecipesQueryCombinesRecipeAndChildFields_Issue3975" -p:UseSharedCompilation=false --no-restore`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search --list-recipes --query sqlite --names --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search --recipe sqlite-query-policy-surfaces/sqlite-policy-pragma --format compact --limit 1`
- Codex adversarial review: `No blocking/actionable issues found.`

`dotnet test CodeIndex.sln -c Release -p:UseSharedCompilation=false --no-restore` and full/targeted `dotnet format --verify-no-changes` were attempted but interrupted after long no-output waits in this local environment.

## Documentation / Changelog

- Updated `USER_GUIDE.md` English and Japanese built-in recipe lists.
- Added `changelog.d/unreleased/4128.security.md`.

## Follow-ups

None.

Fixes #4128