### PR TITLE
[codex] Redact bearer tokens in diagnostics

### DIFF
--- a/changelog.d/unreleased/4134.security.md
+++ b/changelog.d/unreleased/4134.security.md
@@ -1,0 +1,19 @@
+---
+category: security
+issues:
+  - 4134
+affected:
+  - src/CodeIndex/Cli/GitHubIssueReporter.cs
+  - src/CodeIndex/Mcp/AuditLogSink.cs
+  - tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+  - tests/CodeIndex.Tests/DiagnosticRedactorTests.cs
+  - tests/CodeIndex.Tests/AuditLogSinkTests.cs
+---
+
+## English
+
+- **Bearer token redaction now covers GitHub diagnostics and MCP audit values (#4134)** — GitHub API error diagnostics now pass through the shared sensitive-text redactor, and MCP audit value sanitization redacts bearer tokens even when they appear inside non-secret argument values.
+
+## 日本語
+
+- **Bearer token の redaction が GitHub 診断と MCP audit 値をカバーするようになりました (#4134)** — GitHub API error 診断は共有の sensitive-text redactor を通り、MCP audit の値 sanitization は secret ではない引数値の中に Bearer token が現れた場合も redact します。

--- a/src/CodeIndex/Cli/GitHubIssueReporter.cs
+++ b/src/CodeIndex/Cli/GitHubIssueReporter.cs
@@ -870,6 +870,7 @@ internal static class GitHubIssueReporter
         var sanitized = TryRedactSensitiveJsonFields(bounded, out var redactedJson)
             ? redactedJson
             : RedactSensitiveJsonLikeFields(bounded);
+        sanitized = DiagnosticRedactor.RedactSensitiveText(sanitized, "[redacted]");
         var normalized = sanitized.Replace("\r", " ").Replace("\n", " ").Trim();
         return normalized.Length == 0 ? "<empty response body>" : normalized;
     }

--- a/src/CodeIndex/Mcp/AuditLogSink.cs
+++ b/src/CodeIndex/Mcp/AuditLogSink.cs
@@ -49,7 +49,7 @@ internal sealed class AuditLogSink : IDisposable
     private static readonly TimeSpan DisposeWriterTimeout = TimeSpan.FromSeconds(5);
 
     private static readonly Regex SecretValuePattern = new(
-        "(?i)(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|sk-(?:proj-)?[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16}|\\bBearer\\s+[A-Za-z0-9._~+/=\\-]{16,}\\b|://[^/\\s:@]+:[^/\\s:@]+@|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|authorization)=[^&\\s]+)",
+        "(?i)(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|sk-(?:proj-)?[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16}|\\bBearer\\s+[A-Za-z0-9._~+/=\\-]{16,}(?=$|[^A-Za-z0-9._~+/=\\-])|://[^/\\s:@]+:[^/\\s:@]+@|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|authorization)=[^&\\s]+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
         RegexTimeoutPolicy.RedactionRegexTimeout);
     private static readonly JsonDocumentOptions ArgValueScalarJsonDocumentOptions = new()

--- a/src/CodeIndex/Mcp/AuditLogSink.cs
+++ b/src/CodeIndex/Mcp/AuditLogSink.cs
@@ -49,7 +49,7 @@ internal sealed class AuditLogSink : IDisposable
     private static readonly TimeSpan DisposeWriterTimeout = TimeSpan.FromSeconds(5);
 
     private static readonly Regex SecretValuePattern = new(
-        "(?i)(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|sk-(?:proj-)?[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16}|://[^/\\s:@]+:[^/\\s:@]+@|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|authorization)=[^&\\s]+)",
+        "(?i)(github_pat_[A-Za-z0-9_]{20,}|gh[pousr]_[A-Za-z0-9_]{20,}|sk-(?:proj-)?[A-Za-z0-9_-]{20,}|xox[baprs]-[A-Za-z0-9-]{20,}|AKIA[0-9A-Z]{16}|\\bBearer\\s+[A-Za-z0-9._~+/=\\-]{16,}\\b|://[^/\\s:@]+:[^/\\s:@]+@|(?:password|passwd|pwd|secret|token|api[_-]?key|access[_-]?key|authorization)=[^&\\s]+)",
         RegexOptions.Compiled | RegexOptions.CultureInvariant,
         RegexTimeoutPolicy.RedactionRegexTimeout);
     private static readonly JsonDocumentOptions ArgValueScalarJsonDocumentOptions = new()

--- a/tests/CodeIndex.Tests/AuditLogSinkTests.cs
+++ b/tests/CodeIndex.Tests/AuditLogSinkTests.cs
@@ -185,6 +185,22 @@ public class AuditLogSinkTests
     }
 
     [Fact]
+    public void SanitizeArgValue_RedactsBearerTokenInNonSecretValue_Issue4134()
+    {
+        const string token = "AbCdEfGhIjKlMnOpQrStUvWxYz123456";
+        var state = new AuditLogSink.ArgValueSanitizationState();
+
+        var sanitized = AuditLogSink.SanitizeArgValue(
+            "query",
+            JsonValue.Create($"curl -H 'Authorization: Bearer {token}' https://example.test"),
+            state);
+
+        Assert.NotNull(sanitized);
+        Assert.True(state.Redacted);
+        Assert.Equal(AuditLogSink.RedactedValue, sanitized!.GetValue<string>());
+    }
+
+    [Fact]
     public void SanitizeArgValue_LongNonSecretString_TruncatesWithoutRedaction_Issue3909()
     {
         var text = new string('x', 100_000);

--- a/tests/CodeIndex.Tests/AuditLogSinkTests.cs
+++ b/tests/CodeIndex.Tests/AuditLogSinkTests.cs
@@ -187,7 +187,7 @@ public class AuditLogSinkTests
     [Fact]
     public void SanitizeArgValue_RedactsBearerTokenInNonSecretValue_Issue4134()
     {
-        const string token = "AbCdEfGhIjKlMnOpQrStUvWxYz123456";
+        const string token = "AbCdEfGhIjKlMnOpQrStUvWxYz123456==";
         var state = new AuditLogSink.ArgValueSanitizationState();
 
         var sanitized = AuditLogSink.SanitizeArgValue(

--- a/tests/CodeIndex.Tests/DiagnosticRedactorTests.cs
+++ b/tests/CodeIndex.Tests/DiagnosticRedactorTests.cs
@@ -36,6 +36,17 @@ public class DiagnosticRedactorTests
     }
 
     [Fact]
+    public void RedactSensitiveText_RedactsAuthorizationBearerHeader_Issue4134()
+    {
+        const string token = "secret-token-4134";
+
+        var redacted = DiagnosticRedactor.RedactSensitiveText($"Authorization: Bearer {token}", "[redacted]");
+
+        Assert.Equal("Authorization: Bearer [redacted]", redacted);
+        Assert.DoesNotContain(token, redacted);
+    }
+
+    [Fact]
     public void RedactReportLogLine_JsonLineRedactsStrings_Issue3724()
     {
         var token = "ghp_" + new string('a', 24);

--- a/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+++ b/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
@@ -382,6 +382,32 @@ public class GitHubIssueReporterTests : IDisposable
     }
 
     [Fact]
+    public void BuildApiFailureMessage_RedactsBearerTokenInPlainTextErrorBody_Issue4134()
+    {
+        const string token = "secret-token-4134";
+
+        var message = GitHubIssueReporter.BuildApiFailureMessage(
+            403,
+            $"Authorization: Bearer {token} denied");
+
+        Assert.Contains("Authorization: Bearer [redacted]", message);
+        Assert.DoesNotContain(token, message);
+    }
+
+    [Fact]
+    public void BuildApiFailureMessage_RedactsBearerTokenInsideMessageField_Issue4134()
+    {
+        const string token = "secret-token-4134";
+
+        var message = GitHubIssueReporter.BuildApiFailureMessage(
+            403,
+            $$"""{ "message": "Authorization: Bearer {{token}} denied" }""");
+
+        Assert.Contains("Bearer [redacted]", message);
+        Assert.DoesNotContain(token, message);
+    }
+
+    [Fact]
     public void BuildRateLimitFailureMessage_RedactsSensitiveErrorBody()
     {
         var retryAt = new DateTime(2026, 5, 23, 10, 0, 0, DateTimeKind.Utc);


### PR DESCRIPTION
## Summary
- Redact bearer tokens in GitHub API failure diagnostics by running sanitized response bodies through the shared diagnostic redactor.
- Extend MCP audit value sanitization to detect bearer tokens inside non-secret argument values, including padded token strings.
- Add focused regression coverage and a security changelog fragment.

Fixes #4134

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~AuditLogSinkTests|FullyQualifiedName~GitHubIssueReporterTests|FullyQualifiedName~DiagnosticRedactorTests" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --filter "FullyQualifiedName~AuditLogSinkTests|FullyQualifiedName~GitHubIssueReporterTests|FullyQualifiedName~DiagnosticRedactorTests" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --json`
- `git diff --check origin/main...HEAD`

## Review Notes
- Codex adversarial review was attempted with `codex exec review --base origin/main --ignore-rules --disable hooks`, but the nested Codex CLI repeatedly failed simple shell/MCP calls with exit 134 and was stopped. I completed a manual adversarial review of the final diff; the one issue found during review (bearer tokens ending in `=` padding) is covered by the second commit and tests.

## Changelog
- `changelog.d/unreleased/4134.security.md`