### PR TITLE
Add language capability guidance

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1892,7 +1892,7 @@ The database reflects the working tree at the time of the last index. After swit
 
 ## Supported languages
 
-All indexed languages are searchable through FTS5. Rows with **Symbols = yes** also support structured queries by function, class, import, or language-specific symbol name. Use `cdidx languages --indexed-only --json` to list only languages present in the current DB; JSON rows expose `symbol_extraction`, `reference_extraction`, `graph_queries`, `capability_gaps`, and `indexed_file_count`. Add `--language <name>`, `--extension <ext>`, or `--alias <alias>` to retrieve one language row by canonical name, recognized extension/filename pattern, or display alias. Add `--capability graph|references|symbols|missing-graph|missing-references|missing-symbols|search-only` to narrow the table to languages that support a structured capability or still have a capability gap.
+All indexed languages are searchable through FTS5. Rows with **Symbols = yes** also support structured queries by function, class, import, or language-specific symbol name. Use `cdidx languages --indexed-only --json` to list only languages present in the current DB; JSON rows expose `symbol_extraction`, `reference_extraction`, `graph_queries`, `capability_gaps`, `unsupported_guidance`, and `indexed_file_count`. When references or graph queries are unsupported, `unsupported_guidance` explains why empty reference/graph results are not authoritative and lists fallback commands. Add `--language <name>`, `--extension <ext>`, or `--alias <alias>` to retrieve one language row by canonical name, recognized extension/filename pattern, or display alias. Add `--capability graph|references|symbols|missing-graph|missing-references|missing-symbols|search-only` to narrow the table to languages that support a structured capability or still have a capability gap.
 
 | Language | Extensions | Symbols |
 |---|---|:---:|
@@ -2002,8 +2002,8 @@ All indexed languages are searchable through FTS5. Rows with **Symbols = yes** a
 ### Language extraction matrix
 
 Use `cdidx languages --json` as the live capability probe. JSON rows expose
-`symbol_extraction`, `reference_extraction`, `graph_queries`, and
-`capability_gaps`; DB-backed probes such as `--indexed-only` and lookup by
+`symbol_extraction`, `reference_extraction`, `graph_queries`,
+`capability_gaps`, and `unsupported_guidance`; DB-backed probes such as `--indexed-only` and lookup by
 `--language`, `--extension`, or `--alias` also include `indexed_file_count`.
 Add `--indexed-only` when you only want languages present in the current DB, add
 `--language <name>`, `--extension <ext>`, or `--alias <alias>` when you need one
@@ -2012,6 +2012,9 @@ disambiguated language row, and add
 when auditing a specific structured capability or capability gap. This matrix
 explains the common extraction behavior so users know when to trust structured
 commands and when to fall back to `search`.
+Rows with unsupported references or graph queries include `unsupported_guidance`
+entries with the unsupported capability, an explanatory message, and
+`recommended_commands` for the next safe query.
 
 | Language family | Symbols | References / graph | Notes and example query |
 |---|---|---|---|
@@ -4552,7 +4555,7 @@ indexing はファイル単位の SQLite transaction を commit します。長�
 
 ## 対応言語
 
-全言語が FTS5 全文検索に対応しています。**シンボル = yes** の行は、関数・クラス・import 名などの構造化検索にも対応します。現在の DB に存在する言語だけを一覧するには `cdidx languages --indexed-only --json` を使います。JSON 行には `symbol_extraction`、`reference_extraction`、`graph_queries`、`capability_gaps`、`indexed_file_count` が含まれます。言語名・認識済み拡張子/ファイル名 pattern・表示 alias から 1 行を取得するには `--language <name>`、`--extension <ext>`、`--alias <alias>` を追加してください。
+全言語が FTS5 全文検索に対応しています。**シンボル = yes** の行は、関数・クラス・import 名などの構造化検索にも対応します。現在の DB に存在する言語だけを一覧するには `cdidx languages --indexed-only --json` を使います。JSON 行には `symbol_extraction`、`reference_extraction`、`graph_queries`、`capability_gaps`、`unsupported_guidance`、`indexed_file_count` が含まれます。参照抽出やグラフクエリが未対応の場合、`unsupported_guidance` は空の参照/グラフ結果を根拠として扱えない理由と代替コマンドを示します。言語名・認識済み拡張子/ファイル名 pattern・表示 alias から 1 行を取得するには `--language <name>`、`--extension <ext>`、`--alias <alias>` を追加してください。
 
 | 言語 | 拡張子 | シンボル |
 |---|---|:---:|
@@ -4662,12 +4665,14 @@ indexing はファイル単位の SQLite transaction を commit します。長�
 ### 言語別 extraction matrix
 
 現在の capability は `cdidx languages --json` を live probe として確認してください。JSON 行には
-`symbol_extraction`、`reference_extraction`、`graph_queries`、`capability_gaps` が含まれます。`--indexed-only` や
+`symbol_extraction`、`reference_extraction`、`graph_queries`、`capability_gaps`、`unsupported_guidance` が含まれます。`--indexed-only` や
 `--language`、`--extension`、`--alias` による DB 参照付き lookup では `indexed_file_count` も含まれます。
 現在の DB に存在する言語だけを見たい場合は `--indexed-only`、言語名・拡張子・表示 alias から 1 行を特定したい場合は
 `--language <name>`、`--extension <ext>`、`--alias <alias>`、特定の構造化 capability や capability gap を監査する場合は
 `--capability graph|references|symbols|missing-graph|missing-references|missing-symbols|search-only` を追加します。この matrix は、構造化 command を信頼できる場面と
 `search` に戻るべき場面を判断するための概要です。
+参照抽出やグラフクエリが未対応の行では、`unsupported_guidance` に未対応の機能、説明メッセージ、
+次に安全に使う `recommended_commands` が入ります。
 
 | 言語ファミリ | Symbols | References / graph | メモと例 |
 |---|---|---|---|

--- a/changelog.d/unreleased/4122.added.md
+++ b/changelog.d/unreleased/4122.added.md
@@ -1,0 +1,22 @@
+---
+category: added
+issues:
+  - 4122
+affected:
+  - src/CodeIndex/Models/LanguageCapabilitySupport.cs
+  - src/CodeIndex/Cli/JsonOutputContracts.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - src/CodeIndex/Mcp/McpToolDefinitions.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/McpServerToolsCallTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Language capability JSON now explains unsupported references and graph queries (#4122)** — `languages --json` and the MCP `languages` tool now include `unsupported_guidance` entries with fallback commands when a language does not advertise reference extraction, graph queries, or symbol extraction.
+
+## 日本語
+
+- **言語機能 JSON が未対応の参照抽出とグラフクエリを説明するようになりました (#4122)** — `languages --json` と MCP `languages` ツールは、言語が参照抽出、グラフクエリ、シンボル抽出を提供しない場合に代替コマンドを含む `unsupported_guidance` を返します。

--- a/src/CodeIndex/Cli/JsonOutputContracts.cs
+++ b/src/CodeIndex/Cli/JsonOutputContracts.cs
@@ -417,6 +417,7 @@ internal sealed record LanguageEntryJsonResult(
     [property: JsonPropertyName("reference_extraction")] bool ReferenceExtraction,
     [property: JsonPropertyName("graph_queries")] bool GraphQueries,
     [property: JsonPropertyName("capability_gaps")] List<string> CapabilityGaps,
+    [property: JsonPropertyName("unsupported_guidance")] List<LanguageUnsupportedGuidance> UnsupportedGuidance,
     [property: JsonPropertyName("indexed_file_count")]
     [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] long? IndexedFileCount = null);
 
@@ -731,6 +732,7 @@ internal sealed record ValidateConfigJsonResult(
 [JsonSerializable(typeof(List<HookCommandWarningJsonResult>))]
 [JsonSerializable(typeof(JsonStreamDoneResult))]
 [JsonSerializable(typeof(LanguageEntryJsonResult))]
+[JsonSerializable(typeof(LanguageUnsupportedGuidance))]
 [JsonSerializable(typeof(LanguagesJsonResult))]
 [JsonSerializable(typeof(LspLocation))]
 [JsonSerializable(typeof(LspPosition))]

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -10280,7 +10280,8 @@ public static partial class QueryCommandRunner
                     hasSymbols,
                     hasReferences,
                     hasReferences,
-                    BuildLanguageCapabilityGaps(hasSymbols, hasReferences, hasReferences));
+                    LanguageCapabilitySupport.BuildGaps(hasSymbols, hasReferences, hasReferences),
+                    LanguageCapabilitySupport.BuildUnsupportedGuidance(lang, hasSymbols, hasReferences, hasReferences));
                 allLangs[lang] = info;
             }
             info.Extensions.Add(ext);
@@ -10331,6 +10332,7 @@ public static partial class QueryCommandRunner
                     kv.Value.References,
                     kv.Value.Graph,
                     kv.Value.CapabilityGaps,
+                    kv.Value.UnsupportedGuidance,
                     GetIndexedLanguageCount(indexedLanguageCounts, kv.Key))).ToList();
                 Console.WriteLine(JsonSerializer.Serialize(new LanguagesJsonResult(entries), CliJsonSerializerContextFactory.Create(jsonOptions).LanguagesJsonResult));
             }
@@ -10390,7 +10392,14 @@ public static partial class QueryCommandRunner
         }
     }
 
-    private sealed record LanguageSupportInfo(List<string> Extensions, List<string> Aliases, bool Symbols, bool References, bool Graph, List<string> CapabilityGaps);
+    private sealed record LanguageSupportInfo(
+        List<string> Extensions,
+        List<string> Aliases,
+        bool Symbols,
+        bool References,
+        bool Graph,
+        List<string> CapabilityGaps,
+        List<LanguageUnsupportedGuidance> UnsupportedGuidance);
 
     private static bool HasLanguageLookup(QueryCommandOptions options)
         => options.LanguageLookups.Count > 0 || options.LanguageExtensionLookups.Count > 0 || options.LanguageAliasLookups.Count > 0;
@@ -10466,18 +10475,6 @@ public static partial class QueryCommandRunner
             LanguageCapabilityMissingReferences or
             LanguageCapabilityMissingSymbols or
             LanguageCapabilitySearchOnly;
-    }
-
-    private static List<string> BuildLanguageCapabilityGaps(bool symbols, bool references, bool graph)
-    {
-        var gaps = new List<string>();
-        if (!symbols)
-            gaps.Add("missing-symbols");
-        if (!references)
-            gaps.Add("missing-references");
-        if (!graph)
-            gaps.Add("missing-graph");
-        return gaps;
     }
 
     private static bool TryNormalizeSearchAuditScope(string value, out string scope)

--- a/src/CodeIndex/Mcp/McpToolDefinitions.cs
+++ b/src/CodeIndex/Mcp/McpToolDefinitions.cs
@@ -392,7 +392,7 @@ public partial class McpServer
                 ReadOnlyAnnotations()),
             CreateToolDefinition(
                 "languages",
-                "List supported languages with extensions, aliases, and capabilities. Use `indexedOnly`, `capability`, `extension`, or `alias` to match CLI language filters and extension lookup. / 対応言語一覧を拡張子・別名・機能付きで返す。`indexedOnly` / `capability` / `extension` / `alias` で CLI の言語フィルタと拡張子 lookup に合わせて絞り込める。",
+                "List supported languages with extensions, aliases, capabilities, and unsupported_guidance fallback commands. Use `indexedOnly`, `capability`, `extension`, or `alias` to match CLI language filters and extension lookup. / 対応言語一覧を拡張子・別名・機能・`unsupported_guidance` の代替コマンド付きで返す。`indexedOnly` / `capability` / `extension` / `alias` で CLI の言語フィルタと拡張子 lookup に合わせて絞り込める。",
                 new JsonObject
                 {
                     ["type"] = "object",

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -5424,7 +5424,7 @@ public partial class McpServer
         }
 
         // Build consolidated language info / 統合言語情報を構築
-        var allLangs = new Dictionary<string, (List<string> Extensions, List<string> Aliases, bool Symbols, bool References, bool Graph, List<string> CapabilityGaps)>(StringComparer.Ordinal);
+        var allLangs = new Dictionary<string, (List<string> Extensions, List<string> Aliases, bool Symbols, bool References, bool Graph, List<string> CapabilityGaps, List<LanguageUnsupportedGuidance> UnsupportedGuidance)>(StringComparer.Ordinal);
         foreach (var (ext, lang) in langExtensions)
         {
             if (!allLangs.TryGetValue(lang, out var info))
@@ -5437,7 +5437,8 @@ public partial class McpServer
                     hasSymbols,
                     hasReferences,
                     hasReferences,
-                    BuildLanguageCapabilityGaps(hasSymbols, hasReferences, hasReferences));
+                    LanguageCapabilitySupport.BuildGaps(hasSymbols, hasReferences, hasReferences),
+                    LanguageCapabilitySupport.BuildUnsupportedGuidance(lang, hasSymbols, hasReferences, hasReferences));
                 allLangs[lang] = info;
             }
             info.Extensions.Add(ext);
@@ -5462,6 +5463,17 @@ public partial class McpServer
                 foreach (var ext in info.Extensions.OrderBy(e => e, StringComparer.Ordinal))
                     extArray.Add(ext);
 
+                var guidanceArray = new JsonArray();
+                foreach (var guidance in info.UnsupportedGuidance)
+                {
+                    guidanceArray.Add(new JsonObject
+                    {
+                        ["capability"] = guidance.Capability,
+                        ["message"] = guidance.Message,
+                        ["recommended_commands"] = new JsonArray(guidance.RecommendedCommands.Select(command => JsonValue.Create(command)).ToArray()),
+                    });
+                }
+
                 languagesArray.Add(new JsonObject
                 {
                     ["lang"] = lang,
@@ -5471,6 +5483,7 @@ public partial class McpServer
                     ["reference_extraction"] = info.References,
                     ["graph_queries"] = info.Graph,
                     ["capability_gaps"] = new JsonArray(info.CapabilityGaps.Select(gap => JsonValue.Create(gap)).ToArray()),
+                    ["unsupported_guidance"] = guidanceArray,
                 });
             }
 
@@ -5525,18 +5538,6 @@ public partial class McpServer
             "graph" => graph,
             _ => false,
         };
-
-    private static List<string> BuildLanguageCapabilityGaps(bool symbols, bool references, bool graph)
-    {
-        var gaps = new List<string>();
-        if (!symbols)
-            gaps.Add("missing-symbols");
-        if (!references)
-            gaps.Add("missing-references");
-        if (!graph)
-            gaps.Add("missing-graph");
-        return gaps;
-    }
 
     private sealed record McpIndexUnsupportedMode(string Name, string Reason, bool BlocksIndexing);
 

--- a/src/CodeIndex/Models/LanguageCapabilitySupport.cs
+++ b/src/CodeIndex/Models/LanguageCapabilitySupport.cs
@@ -1,0 +1,85 @@
+using System.Text;
+using System.Text.Json.Serialization;
+
+namespace CodeIndex.Models;
+
+internal sealed record LanguageUnsupportedGuidance(
+    [property: JsonPropertyName("capability")] string Capability,
+    [property: JsonPropertyName("message")] string Message,
+    [property: JsonPropertyName("recommended_commands")] List<string> RecommendedCommands);
+
+internal static class LanguageCapabilitySupport
+{
+    public static List<string> BuildGaps(bool symbols, bool references, bool graph)
+    {
+        var gaps = new List<string>();
+        if (!symbols)
+            gaps.Add("missing-symbols");
+        if (!references)
+            gaps.Add("missing-references");
+        if (!graph)
+            gaps.Add("missing-graph");
+        return gaps;
+    }
+
+    public static List<LanguageUnsupportedGuidance> BuildUnsupportedGuidance(
+        string language,
+        bool symbols,
+        bool references,
+        bool graph)
+    {
+        var guidance = new List<LanguageUnsupportedGuidance>();
+        var fallbackCommands = BuildFallbackCommands(symbols);
+        var fallbackList = FormatCommandList(fallbackCommands);
+
+        if (!symbols)
+        {
+            guidance.Add(new LanguageUnsupportedGuidance(
+                "symbols",
+                $"Symbol extraction is not advertised for '{language}'; use {fallbackList} instead.",
+                fallbackCommands));
+        }
+        if (!references)
+        {
+            guidance.Add(new LanguageUnsupportedGuidance(
+                "references",
+                $"Reference extraction is not advertised for '{language}'; empty references are not authoritative. Use {fallbackList} instead.",
+                fallbackCommands));
+        }
+        if (!graph)
+        {
+            guidance.Add(new LanguageUnsupportedGuidance(
+                "graph",
+                $"Graph queries are not advertised for '{language}'; empty callers, callees, or impact results are not authoritative. Use {fallbackList} instead.",
+                fallbackCommands));
+        }
+
+        return guidance;
+    }
+
+    private static List<string> BuildFallbackCommands(bool symbols)
+        => symbols
+            ? ["search", "symbols", "definition", "outline", "excerpt", "files"]
+            : ["search", "files", "excerpt"];
+
+    private static string FormatCommandList(IReadOnlyList<string> commands)
+    {
+        if (commands.Count == 0)
+            return string.Empty;
+        if (commands.Count == 1)
+            return commands[0];
+        if (commands.Count == 2)
+            return $"{commands[0]} or {commands[1]}";
+
+        var builder = new StringBuilder();
+        for (var i = 0; i < commands.Count; i++)
+        {
+            if (i > 0)
+            {
+                builder.Append(i == commands.Count - 1 ? ", or " : ", ");
+            }
+            builder.Append(commands[i]);
+        }
+        return builder.ToString();
+    }
+}

--- a/tests/CodeIndex.Tests/McpServerToolsCallTests.cs
+++ b/tests/CodeIndex.Tests/McpServerToolsCallTests.cs
@@ -5788,6 +5788,14 @@ public partial class McpServerTests
         Assert.True(yaml["symbol_extraction"]!.GetValue<bool>());
         Assert.Contains("yml", yaml["aliases"]!.AsArray().Select(e => e!.GetValue<string>()));
         Assert.DoesNotContain("missing-symbols", yaml["capability_gaps"]!.AsArray().Select(e => e!.GetValue<string>()));
+        var yamlGuidance = yaml["unsupported_guidance"]!.AsArray();
+        var yamlReferencesGuidance = yamlGuidance.Single(g => g!["capability"]!.GetValue<string>() == "references")!;
+        Assert.Contains("Reference extraction is not advertised for 'yaml'", yamlReferencesGuidance["message"]!.GetValue<string>());
+        Assert.Contains("search", yamlReferencesGuidance["recommended_commands"]!.AsArray().Select(e => e!.GetValue<string>()));
+        var yamlGraphGuidance = yamlGuidance.Single(g => g!["capability"]!.GetValue<string>() == "graph")!;
+        Assert.Contains("empty callers, callees, or impact results are not authoritative", yamlGraphGuidance["message"]!.GetValue<string>());
+        Assert.Contains("files", yamlGraphGuidance["recommended_commands"]!.AsArray().Select(e => e!.GetValue<string>()));
+        Assert.Empty(csharp["unsupported_guidance"]!.AsArray());
 
         // Pin #215: HTML must report symbol_extraction=true and list all four
         // extensions so AI tools discover HTML support via the MCP languages tool.

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -2303,6 +2303,35 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunLanguages_JsonIncludesUnsupportedCapabilityGuidance_Issue4122()
+    {
+        var (exitCode, stdout, stderr) = CaptureConsole(() =>
+            QueryCommandRunner.RunLanguages(["--json"], _jsonOptions));
+
+        Assert.Equal(CommandExitCodes.Success, exitCode);
+        Assert.Equal(string.Empty, stderr);
+
+        using var document = ParseJsonOutput(stdout);
+        var languages = document.RootElement.GetProperty("languages").EnumerateArray()
+            .ToDictionary(entry => entry.GetProperty("lang").GetString()!, entry => entry);
+        var adaGuidance = languages["ada"].GetProperty("unsupported_guidance").EnumerateArray().ToList();
+
+        var referenceGuidance = adaGuidance.Single(guidance => guidance.GetProperty("capability").GetString() == "references");
+        Assert.Contains("Reference extraction is not advertised for 'ada'", referenceGuidance.GetProperty("message").GetString());
+        var referenceCommands = referenceGuidance.GetProperty("recommended_commands").EnumerateArray().Select(command => command.GetString()).ToList();
+        Assert.Contains("search", referenceCommands);
+        Assert.Contains("definition", referenceCommands);
+
+        var graphGuidance = adaGuidance.Single(guidance => guidance.GetProperty("capability").GetString() == "graph");
+        Assert.Contains("empty callers, callees, or impact results are not authoritative", graphGuidance.GetProperty("message").GetString());
+        var graphCommands = graphGuidance.GetProperty("recommended_commands").EnumerateArray().Select(command => command.GetString()).ToList();
+        Assert.Contains("search", graphCommands);
+        Assert.Contains("files", graphCommands);
+
+        Assert.Empty(languages["csharp"].GetProperty("unsupported_guidance").EnumerateArray());
+    }
+
+    [Fact]
     public void RunLanguages_JsonCapabilitySearchOnlyFiltersAllExtractionGaps()
     {
         var (exitCode, stdout, stderr) = CaptureConsole(() =>


### PR DESCRIPTION
## Summary

- Add `unsupported_guidance` to `languages --json` rows and MCP `languages` structured output.
- Share capability-gap and unsupported-guidance construction between CLI and MCP language surfaces.
- Document the new JSON field in English and Japanese, and add the changelog fragment.

## Validation

- `dotnet build -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunLanguages_JsonIncludesUnsupportedCapabilityGuidance_Issue4122|FullyQualifiedName~McpServerTests.ToolsCall_Languages_ReturnsCapabilities|FullyQualifiedName~McpServerTests.ToolsList_EveryDescriptionIncludesLanguageSupportClause" -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format whitespace CodeIndex.sln --verify-no-changes --no-restore --verbosity minimal`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation And Changelog

- Updated `USER_GUIDE.md` English and Japanese language capability sections.
- Added `changelog.d/unreleased/4122.added.md`.

## Follow-Ups

- None.

Fixes #4122