### PR TITLE
Make dependency cycle truncation actionable

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1553,7 +1553,7 @@ same source location.
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | Filter to files modified since this ISO 8601 timestamp. Offsetless values (e.g. `2024-01-01T00:00:00`) are treated as UTC so the same flag resolves to the same instant in every timezone; append `Z` or an explicit offset (`+09:00`) to be explicit. |
 | `--no-dedup` | `search` | Disable overlapping-chunk deduplication and return every raw chunk hit; useful for debugging chunk boundaries or measuring raw match density |
 | `--reverse` | `deps` | Reverse lookup: show files that depend ON the matched path |
-| `--cycles` | `deps` | Return dependency cycles from a bounded approximate candidate-edge scan. `--limit` controls displayed cycles; cycle detection examines up to `max(--limit, 50)` lightweight candidate edges and JSON reports `truncated`, `termination_reason`, `truncated_reason`, `candidate_edge_count`, `candidate_edge_limit`, and `cycle_detection_mode` when results are partial. |
+| `--cycles` | `deps` | Return dependency cycles from a bounded approximate candidate-edge scan. `--limit` controls displayed cycles and the candidate budget (`max(--limit, 50)`). When `truncated_reason` is `candidate_edge_limit`, returned cycles are a bounded sample, not a complete or ranked cycle set. JSON includes `truncated`, `termination_reason`, `truncated_reason`, `candidate_edge_count`, `candidate_edge_limit`, `cycle_detection_mode`, `cycle_result_scope`, `cycle_result_note`, and `next_step_flags`; use suggested flags such as `--limit`, `--suppress-noise`, `--symbol`, `--symbol-family`, or `--path` to expand or narrow the scan. |
 | `--strict-not-found` | Query commands | Return exit code `2` when a valid query produces zero rows. Without this flag, zero-result queries exit `0` and keep their normal empty/zero-result output. |
 | `--top <n>` | Query commands | Alias for `--limit` |
 | `--max-results <n>` | `search` | Alias for `--limit` |
@@ -4217,7 +4217,7 @@ raw match density を正確に測る、といった理由で全 raw chunk hit �
 | `--since <datetime>` | `search`, `definition`, `symbols`, `files` | 指定タイムスタンプ以降に変更されたファイルのみ（ISO 8601）。オフセットなしの値（例: `2024-01-01T00:00:00`）は UTC として解釈されるため、どのタイムゾーンから呼び出しても同じ UTC 時点になります。明示したい場合は末尾に `Z` または `+09:00` 等のオフセットを付与してください。 |
 | `--no-dedup` | `search` | overlap chunk の重複排除を無効化し、全 raw chunk hit を返す。chunk 境界の debug や raw match density 計測向け |
 | `--reverse` | `deps` | 逆引き: 指定パスに依存しているファイルを表示 |
-| `--cycles` | `deps` | 上限付きの近似候補 edge scan から依存 cycle を返す。`--limit` は表示する cycle 数を制御し、cycle 検出は最大 `max(--limit, 50)` 件の軽量候補 edge を調べる。結果が部分的な場合、JSON は `truncated`、`termination_reason`、`truncated_reason`、`candidate_edge_count`、`candidate_edge_limit`、`cycle_detection_mode` を返す。 |
+| `--cycles` | `deps` | 上限付きの近似候補 edge scan から依存 cycle を返す。`--limit` は表示する cycle 数と候補 budget（`max(--limit, 50)`）を制御する。`truncated_reason` が `candidate_edge_limit` の場合、返される cycle は上限内のサンプルであり、完全な cycle 集合やランキング済み集合ではない。JSON は `truncated`、`termination_reason`、`truncated_reason`、`candidate_edge_count`、`candidate_edge_limit`、`cycle_detection_mode`、`cycle_result_scope`、`cycle_result_note`、`next_step_flags` を返す。`--limit`、`--suppress-noise`、`--symbol`、`--symbol-family`、`--path` などの候補フラグで scan を広げるか絞り込む。 |
 | `--workspace-db <path>` | `deps` | file dependency query に別の CodeIndex DB を追加する。最大 7 個の distinct な追加 DB（`--db` を含め合計 8 個）まで繰り返し指定でき、JSON edge には同じ相対パスを区別できるよう `source_db` / `target_db` が含まれる。 |
 | `--top <n>` | クエリ系 | `--limit` のエイリアス |
 | `--max-results <n>` | `search` | `--limit` のエイリアス |

--- a/changelog.d/unreleased/4114.fixed.md
+++ b/changelog.d/unreleased/4114.fixed.md
@@ -1,0 +1,24 @@
+---
+category: fixed
+issues:
+  - 4114
+affected:
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - src/CodeIndex/Mcp/McpToolDefinitions.cs
+  - src/CodeIndex/BoundedLineReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+  - tests/CodeIndex.Tests/BoundedLineReaderTests.cs
+  - tests/CodeIndex.Tests/McpServerToolsCallTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Dependency cycle truncation is now actionable (#4114)** — `deps --cycles` JSON now explains whether results are complete, a candidate-edge sample, or display-limited, includes suggested next-step flags, and lets `--suppress-noise` remove generic `Append`-style helper-symbol cycles.
+- **Bounded UTF-8 reads now fail on invalid byte sequences (#4114)** — bounded text reads now report invalid UTF-8 instead of silently accepting replacement characters, with focused byte, line, UTF-8, and tail-capture contract tests.
+
+## 日本語
+
+- **依存 cycle の切り詰め結果を次の操作につなげやすくしました (#4114)** — `deps --cycles` の JSON は結果が完全か、候補 edge のサンプルか、表示上限による部分結果かを説明し、次に試す候補フラグを返すようになりました。`--suppress-noise` は `Append` などの汎用 helper symbol 由来の cycle も除外できます。
+- **上限付き UTF-8 読み込みが不正 byte 列を失敗として扱うようになりました (#4114)** — bounded text read は置換文字として黙って受け入れず invalid UTF-8 を報告し、byte・line・UTF-8・tail capture の契約テストを追加しました。

--- a/src/CodeIndex/BoundedLineReader.cs
+++ b/src/CodeIndex/BoundedLineReader.cs
@@ -30,6 +30,7 @@ internal enum BoundedTextFileReadFailureKind
     BytesExceeded,
     LinesExceeded,
     LineLengthExceeded,
+    InvalidUtf8,
     ReadFailed,
 }
 
@@ -127,7 +128,7 @@ internal static class BoundedLineReader
                 accumulator.Write(buffer, 0, read);
             }
 
-            var text = new UTF8Encoding(false, throwOnInvalidBytes: false).GetString(accumulator.ToArray());
+            var text = new UTF8Encoding(false, throwOnInvalidBytes: true).GetString(accumulator.ToArray());
             if (text.Length > 0 && text[0] == '\uFEFF')
                 text = text[1..];
 
@@ -169,6 +170,15 @@ internal static class BoundedLineReader
 
             lines = result;
             return true;
+        }
+        catch (DecoderFallbackException ex)
+        {
+            var reason = $"it is not valid UTF-8 ({ex.GetType().Name}: {DiagnosticSanitizer.ForMessage(ex.Message)})";
+            failure = new(
+                BoundedTextFileReadFailureKind.InvalidUtf8,
+                reason,
+                ExceptionType: ex.GetType().Name);
+            return false;
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
         {

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -29,6 +29,7 @@ public static partial class QueryCommandRunner
     private const int MaxNamedSearchQueryNameLength = 128;
     internal const int DefaultImpactLimit = 50;
     internal const int DefaultDependencyCycleGraphLimit = 50;
+    internal const string DependencyCycleDetectionMode = "bounded_approximate_candidate_edges";
     internal const int MaxWorkspaceDependencyDatabaseCount = 8;
     internal const int MaxWorkspaceDependencyDatabasePairCount = MaxWorkspaceDependencyDatabaseCount * (MaxWorkspaceDependencyDatabaseCount - 1);
     internal const int FindAllCandidateFileLimit = 4096;
@@ -71,11 +72,14 @@ public static partial class QueryCommandRunner
     };
     private static readonly HashSet<string> DependencyNoiseSymbols = new(StringComparer.OrdinalIgnoreCase)
     {
+        "Append",
+        "AppendLine",
         "Array",
         "Console",
         "DateTime",
         "Dictionary",
         "Directory",
+        "Encoding",
         "Enumerable",
         "File",
         "IEnumerable",
@@ -88,6 +92,7 @@ public static partial class QueryCommandRunner
         "String",
         "StringBuilder",
         "Task",
+        "ToString",
         "Write",
         "WriteLine",
     };
@@ -8682,6 +8687,8 @@ public static partial class QueryCommandRunner
                         ? $"; {BuildDependencyCycleTruncationSummary(dependencyCycleAnalysis)}"
                         : string.Empty;
                     CommandErrorWriter.WriteStderr($"({cycles.Count} dependency cycles{truncationNote})");
+                    if (dependencyCycleAnalysis is { Truncated: true })
+                        CommandErrorWriter.WriteStderr(BuildDependencyCycleTruncationWarning(dependencyCycleAnalysis));
                     WriteSqlGraphContractWarningIfNeeded(json: false, sqlGraphSignal, reader, options);
                     return CommandExitCodes.Success;
                 }
@@ -8868,6 +8875,7 @@ public static partial class QueryCommandRunner
         string? TruncatedReason,
         int CandidateEdgeCount,
         int CandidateEdgeLimit,
+        int DisplayLimit,
         string DetectionMode);
 
     private static DependencyCycleAnalysis AnalyzeDependencyCycles(
@@ -8907,18 +8915,42 @@ public static partial class QueryCommandRunner
             truncatedReason,
             Math.Min(candidateRowCount, candidateEdgeLimit),
             candidateEdgeLimit,
-            "bounded_approximate_candidate_edges");
+            displayLimit,
+            DependencyCycleDetectionMode);
     }
 
     private static void AddDependencyCycleAnalysisJsonFields(JsonObject payload, DependencyCycleAnalysis analysis)
+        => AddDependencyCycleAnalysisJsonFields(
+            payload,
+            analysis.Truncated,
+            analysis.TerminationReason,
+            analysis.TruncatedReason,
+            analysis.CandidateEdgeCount,
+            analysis.CandidateEdgeLimit,
+            analysis.DisplayLimit,
+            analysis.DetectionMode);
+
+    internal static void AddDependencyCycleAnalysisJsonFields(
+        JsonObject payload,
+        bool truncated,
+        string terminationReason,
+        string? truncatedReason,
+        int candidateEdgeCount,
+        int candidateEdgeLimit,
+        int displayLimit,
+        string detectionMode,
+        JsonArray? nextStepFlags = null)
     {
-        payload["truncated"] = analysis.Truncated;
-        payload["termination_reason"] = analysis.TerminationReason;
-        if (analysis.TruncatedReason != null)
-            payload["truncated_reason"] = analysis.TruncatedReason;
-        payload["candidate_edge_count"] = analysis.CandidateEdgeCount;
-        payload["candidate_edge_limit"] = analysis.CandidateEdgeLimit;
-        payload["cycle_detection_mode"] = analysis.DetectionMode;
+        payload["truncated"] = truncated;
+        payload["termination_reason"] = terminationReason;
+        if (truncatedReason != null)
+            payload["truncated_reason"] = truncatedReason;
+        payload["candidate_edge_count"] = candidateEdgeCount;
+        payload["candidate_edge_limit"] = candidateEdgeLimit;
+        payload["cycle_detection_mode"] = detectionMode;
+        payload["cycle_result_scope"] = BuildDependencyCycleResultScope(truncatedReason);
+        payload["cycle_result_note"] = BuildDependencyCycleResultNote(truncatedReason);
+        payload["next_step_flags"] = nextStepFlags ?? BuildDependencyCycleNextStepFlagsJson(truncatedReason, candidateEdgeLimit, displayLimit);
     }
 
     private static string BuildDependencyCycleTruncationSummary(DependencyCycleAnalysis analysis)
@@ -8927,7 +8959,124 @@ public static partial class QueryCommandRunner
             : $"partial: candidate edge limit reached after {analysis.CandidateEdgeCount} candidate edges";
 
     private static string BuildDependencyCycleTruncationWarning(DependencyCycleAnalysis analysis)
-        => $"Warning: dependency cycle detection returned partial results ({BuildDependencyCycleTruncationSummary(analysis)}).";
+    {
+        var nextSteps = BuildDependencyCycleNextStepFlags(
+            analysis.TruncatedReason,
+            analysis.CandidateEdgeLimit,
+            analysis.DisplayLimit);
+        var nextStepsText = nextSteps.Count == 0
+            ? string.Empty
+            : $" Next steps: {string.Join(", ", nextSteps)}.";
+        return "Warning: dependency cycle detection returned partial results "
+               + $"({BuildDependencyCycleTruncationSummary(analysis)}). "
+               + BuildDependencyCycleResultNote(analysis.TruncatedReason)
+               + nextStepsText;
+    }
+
+    private static string BuildDependencyCycleResultScope(string? truncatedReason)
+        => truncatedReason switch
+        {
+            "candidate_edge_limit" => "partial_candidate_edge_sample",
+            "display_limit" => "partial_display_limit",
+            _ => "complete_candidate_edges",
+        };
+
+    private static string BuildDependencyCycleResultNote(string? truncatedReason)
+        => truncatedReason switch
+        {
+            "candidate_edge_limit" => "Candidate edge limit reached before cdidx could prove cycle completeness; returned cycles are a bounded sample, not a complete or ranked cycle set.",
+            "display_limit" => "More cycles were detected than displayed; returned cycles are the first displayed cycles from the bounded candidate scan.",
+            _ => "Cycle detection completed for all candidate edges selected by the current filters.",
+        };
+
+    private static JsonArray BuildDependencyCycleNextStepFlagsJson(
+        string? truncatedReason,
+        int candidateEdgeLimit,
+        int displayLimit)
+        => new(BuildDependencyCycleNextStepFlags(truncatedReason, candidateEdgeLimit, displayLimit)
+            .Select(flag => JsonValue.Create(flag))
+            .ToArray<JsonNode?>());
+
+    internal static JsonArray BuildMcpDependencyCycleNextStepFlagsJson(
+        string? truncatedReason,
+        int candidateEdgeLimit,
+        int displayLimit)
+        => new(BuildMcpDependencyCycleNextStepFlags(truncatedReason, candidateEdgeLimit, displayLimit)
+            .Select(flag => JsonValue.Create(flag))
+            .ToArray<JsonNode?>());
+
+    private static List<string> BuildDependencyCycleNextStepFlags(
+        string? truncatedReason,
+        int candidateEdgeLimit,
+        int displayLimit)
+    {
+        var flags = new List<string>();
+        switch (truncatedReason)
+        {
+            case "candidate_edge_limit":
+                AddHigherLimitFlag(flags, candidateEdgeLimit);
+                flags.Add("--suppress-noise");
+                flags.Add("--symbol <name>");
+                flags.Add("--symbol-family <prefix>");
+                flags.Add("--path <narrower-glob>");
+                break;
+            case "display_limit":
+                AddHigherLimitFlag(flags, displayLimit);
+                flags.Add("--path <narrower-glob>");
+                break;
+        }
+
+        return flags;
+    }
+
+    private static List<string> BuildMcpDependencyCycleNextStepFlags(
+        string? truncatedReason,
+        int candidateEdgeLimit,
+        int displayLimit)
+    {
+        var flags = new List<string>();
+        switch (truncatedReason)
+        {
+            case "candidate_edge_limit":
+                AddHigherLimitArgument(flags, candidateEdgeLimit);
+                flags.Add("path=<narrower-glob>");
+                break;
+            case "display_limit":
+                AddHigherLimitArgument(flags, displayLimit);
+                flags.Add("path=<narrower-glob>");
+                break;
+        }
+
+        return flags;
+    }
+
+    private static void AddHigherLimitFlag(List<string> flags, int currentLimit)
+    {
+        var nextLimit = GetHigherDependencyCycleLimit(currentLimit);
+        if (nextLimit > currentLimit)
+            flags.Add($"--limit {nextLimit}");
+    }
+
+    private static void AddHigherLimitArgument(List<string> flags, int currentLimit)
+    {
+        var nextLimit = GetHigherDependencyCycleLimit(currentLimit);
+        if (nextLimit > currentLimit)
+            flags.Add($"limit={nextLimit}");
+    }
+
+    private static int GetHigherDependencyCycleLimit(int currentLimit)
+    {
+        var upperBound = NumericFlagUpperBounds.TryGetValue("--limit", out var maxLimit)
+            ? maxLimit
+            : int.MaxValue;
+        if (currentLimit >= upperBound)
+            return upperBound;
+
+        var doubled = currentLimit > upperBound / 2
+            ? upperBound
+            : currentLimit * 2;
+        return Math.Min(upperBound, Math.Max(currentLimit + 1, doubled));
+    }
 
     private static DependencySymbolFilterResult ApplyDependencySymbolFilters(IReadOnlyList<FileDependencyResult> edges, QueryCommandOptions options)
     {

--- a/src/CodeIndex/Mcp/McpToolDefinitions.cs
+++ b/src/CodeIndex/Mcp/McpToolDefinitions.cs
@@ -386,7 +386,7 @@ public partial class McpServer
                         ["includeGenerated"] = new JsonObject { ["type"] = "boolean", ["description"] = "Include dependency edges whose source or target file is detected as generated code. Defaults to false, matching other query tools.", ["default"] = false },
                         ["reverse"] = new JsonObject { ["type"] = "boolean", ["description"] = "Reverse lookup: show files that depend ON the matched path", ["default"] = false },
                         ["format"] = new JsonObject { ["type"] = "string", ["enum"] = new JsonArray { "edgelist", "json-graph" }, ["description"] = "Structured response format. `edgelist` preserves the existing edges array; `json-graph` returns nodes and edges.", ["default"] = "edgelist" },
-                        ["cycles"] = new JsonObject { ["type"] = "boolean", ["description"] = "Return dependency cycles instead of ordinary edge rows.", ["default"] = false }
+                        ["cycles"] = new JsonObject { ["type"] = "boolean", ["description"] = "Return dependency cycles instead of ordinary edge rows. Cycle results come from a bounded candidate-edge scan; inspect `cycle_result_scope`, `cycle_result_note`, and MCP-argument-style `next_step_flags` such as `limit=120` when `truncated` is true. / 通常の edge 行ではなく依存 cycle を返す。cycle 結果は上限付きの候補 edge scan から得られるため、`truncated` が true の場合は `cycle_result_scope`、`cycle_result_note`、`limit=120` など MCP 引数形式の `next_step_flags` を確認する。", ["default"] = false }
                     }
                 },
                 ReadOnlyAnnotations()),

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -4858,23 +4858,30 @@ public partial class McpServer
                 payload["edges"] = JsonSerializer.SerializeToNode(outputEdges, _jsonOptions);
             if (cyclesOnly)
             {
-                payload["truncated"] = cycleCandidateTruncated || cycleDisplayTruncated;
                 var truncatedReason = cycleCandidateTruncated
                     ? "candidate_edge_limit"
                     : cycleDisplayTruncated
                         ? "display_limit"
                         : null;
-                payload["termination_reason"] = truncatedReason switch
+                var terminationReason = truncatedReason switch
                 {
                     "candidate_edge_limit" => "candidate_limit_reached",
                     "display_limit" => "display_limit_reached",
                     _ => "completed",
                 };
-                if (truncatedReason != null)
-                    payload["truncated_reason"] = truncatedReason;
-                payload["candidate_edge_count"] = Math.Min(cycleCandidateRowsRead, cycleCandidateLimit);
-                payload["candidate_edge_limit"] = cycleCandidateLimit;
-                payload["cycle_detection_mode"] = "bounded_approximate_candidate_edges";
+                QueryCommandRunner.AddDependencyCycleAnalysisJsonFields(
+                    payload,
+                    cycleCandidateTruncated || cycleDisplayTruncated,
+                    terminationReason,
+                    truncatedReason,
+                    Math.Min(cycleCandidateRowsRead, cycleCandidateLimit),
+                    cycleCandidateLimit,
+                    limit,
+                    QueryCommandRunner.DependencyCycleDetectionMode,
+                    QueryCommandRunner.BuildMcpDependencyCycleNextStepFlagsJson(
+                        truncatedReason,
+                        cycleCandidateLimit,
+                        limit));
             }
             payload["format"] = format;
             payload["includeGenerated"] = includeGenerated;

--- a/tests/CodeIndex.Tests/BoundedLineReaderTests.cs
+++ b/tests/CodeIndex.Tests/BoundedLineReaderTests.cs
@@ -1,3 +1,5 @@
+using System.Text;
+
 namespace CodeIndex.Tests;
 
 public class BoundedLineReaderTests
@@ -14,6 +16,112 @@ public class BoundedLineReaderTests
         Assert.Equal("first line", first);
         Assert.Equal("second line", second);
         Assert.Null(end);
+    }
+
+    [Fact]
+    public void TryReadUtf8File_EnforcesStreamingByteLimit_Issue4114()
+    {
+        var ok = BoundedLineReader.TryReadUtf8File(
+            "input.txt",
+            maxBytes: 5,
+            maxLines: 10,
+            maxLineCharacters: 120,
+            out var lines,
+            out var failure,
+            _ => new NonSeekableReadStream(Encoding.UTF8.GetBytes("abcdef")));
+
+        Assert.False(ok);
+        Assert.Empty(lines);
+        Assert.Equal(BoundedTextFileReadFailureKind.BytesExceeded, failure.Kind);
+        Assert.Equal(5, failure.Limit);
+    }
+
+    [Fact]
+    public void TryReadUtf8File_EnforcesLineLimit_Issue4114()
+    {
+        var ok = BoundedLineReader.TryReadUtf8File(
+            "input.txt",
+            maxBytes: 1024,
+            maxLines: 1,
+            maxLineCharacters: 120,
+            out _,
+            out var failure,
+            _ => new MemoryStream(Encoding.UTF8.GetBytes("first\nsecond\n")));
+
+        Assert.False(ok);
+        Assert.Equal(BoundedTextFileReadFailureKind.LinesExceeded, failure.Kind);
+        Assert.Equal(1, failure.Limit);
+    }
+
+    [Fact]
+    public void TryReadUtf8File_RejectsInvalidUtf8_Issue4114()
+    {
+        var ok = BoundedLineReader.TryReadUtf8File(
+            "input.txt",
+            maxBytes: 1024,
+            maxLines: 10,
+            maxLineCharacters: 120,
+            out var lines,
+            out var failure,
+            _ => new MemoryStream([0xC3, 0x28]));
+
+        Assert.False(ok);
+        Assert.Empty(lines);
+        Assert.Equal(BoundedTextFileReadFailureKind.InvalidUtf8, failure.Kind);
+        Assert.Equal(nameof(DecoderFallbackException), failure.ExceptionType);
+        Assert.Contains("not valid UTF-8", failure.Reason, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task ReadLine_SyncAndAsyncMatchUtf8AndLineBoundaries_Issue4114()
+    {
+        const string text = "alpha\r\nβeta\nlast";
+        using var syncReader = new StringReader(text);
+        using var asyncReader = new StringReader(text);
+
+        var syncLines = new[]
+        {
+            BoundedLineReader.ReadLine(syncReader, 120, 120),
+            BoundedLineReader.ReadLine(syncReader, 120, 120),
+            BoundedLineReader.ReadLine(syncReader, 120, 120),
+            BoundedLineReader.ReadLine(syncReader, 120, 120),
+        };
+        var asyncLines = new[]
+        {
+            await BoundedLineReader.ReadLineAsync(asyncReader, 120, 120, CancellationToken.None),
+            await BoundedLineReader.ReadLineAsync(asyncReader, 120, 120, CancellationToken.None),
+            await BoundedLineReader.ReadLineAsync(asyncReader, 120, 120, CancellationToken.None),
+            await BoundedLineReader.ReadLineAsync(asyncReader, 120, 120, CancellationToken.None),
+        };
+
+        Assert.Equal(new string?[] { "alpha", "βeta", "last", null }, syncLines);
+        Assert.Equal(syncLines, asyncLines);
+
+        using var syncLimitReader = new StringReader("é");
+        using var asyncLimitReader = new StringReader("é");
+        var syncException = Assert.Throws<BoundedLineLengthException>(
+            () => BoundedLineReader.ReadLine(syncLimitReader, 10, 1));
+        var asyncException = await Assert.ThrowsAsync<BoundedLineLengthException>(
+            () => BoundedLineReader.ReadLineAsync(asyncLimitReader, 10, 1, CancellationToken.None));
+
+        Assert.Equal(syncException.Utf8BytesRead, asyncException.Utf8BytesRead);
+        Assert.Equal(syncException.MaxUtf8Bytes, asyncException.MaxUtf8Bytes);
+    }
+
+    [Fact]
+    public void BoundedTextWriter_TruncatesAcrossWriteOverloads_Issue4114()
+    {
+        using var writer = new BoundedTextWriter(maxChars: 5);
+
+        writer.Write("abc");
+        writer.Write(['d', 'e', 'f'], 0, 3);
+        writer.Write('g');
+
+        var captured = writer.GetCapturedText();
+
+        Assert.StartsWith("abcde", captured, StringComparison.Ordinal);
+        Assert.Contains("captured worker console output truncated", captured, StringComparison.Ordinal);
+        Assert.DoesNotContain("fg", captured, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -65,5 +173,47 @@ public class BoundedLineReaderTests
         Assert.Contains("stderr_tail=", message, StringComparison.Ordinal);
         Assert.Contains("<path>", message, StringComparison.Ordinal);
         Assert.DoesNotContain("/private/secret", message, StringComparison.Ordinal);
+    }
+
+    private sealed class NonSeekableReadStream(byte[] bytes) : Stream
+    {
+        private readonly MemoryStream inner = new(bytes);
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+            => inner.Read(buffer, offset, count);
+
+        public override long Seek(long offset, SeekOrigin origin)
+            => throw new NotSupportedException();
+
+        public override void SetLength(long value)
+            => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count)
+            => throw new NotSupportedException();
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                inner.Dispose();
+            base.Dispose(disposing);
+        }
     }
 }

--- a/tests/CodeIndex.Tests/McpServerToolsCallTests.cs
+++ b/tests/CodeIndex.Tests/McpServerToolsCallTests.cs
@@ -3796,10 +3796,17 @@ public partial class McpServerTests
         var structured = response["result"]!["structuredContent"]!;
         var cycle = Assert.Single(structured["cycles"]!.AsArray());
         var nodes = cycle!["nodes"]!.AsArray().Select(node => node!.GetValue<string>()).ToArray();
+        var nextStepFlags = structured["next_step_flags"]!.AsArray()
+            .Select(flag => flag!.GetValue<string>())
+            .ToArray();
 
         Assert.Equal(1, structured["count"]!.GetValue<int>());
         Assert.Equal(2, nodes.Length);
         Assert.All(nodes, node => Assert.StartsWith("src/Cycle", node));
+        Assert.Equal("partial_display_limit", structured["cycle_result_scope"]!.GetValue<string>());
+        Assert.Contains("limit=2", nextStepFlags);
+        Assert.Contains("path=<narrower-glob>", nextStepFlags);
+        Assert.DoesNotContain(nextStepFlags, flag => flag.StartsWith("--", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerTests.cs
@@ -4266,6 +4266,14 @@ public partial class QueryCommandRunnerTests
             Assert.Equal(QueryCommandRunner.DefaultDependencyCycleGraphLimit, json.GetProperty("candidate_edge_count").GetInt32());
             Assert.Equal(QueryCommandRunner.DefaultDependencyCycleGraphLimit, json.GetProperty("candidate_edge_limit").GetInt32());
             Assert.Equal("bounded_approximate_candidate_edges", json.GetProperty("cycle_detection_mode").GetString());
+            Assert.Equal("partial_candidate_edge_sample", json.GetProperty("cycle_result_scope").GetString());
+            Assert.Contains("not a complete or ranked cycle set", json.GetProperty("cycle_result_note").GetString(), StringComparison.Ordinal);
+            var nextStepFlags = json.GetProperty("next_step_flags").EnumerateArray().Select(flag => flag.GetString()).ToArray();
+            Assert.Contains("--limit 100", nextStepFlags);
+            Assert.Contains("--suppress-noise", nextStepFlags);
+            Assert.Contains("--symbol <name>", nextStepFlags);
+            Assert.Contains("--symbol-family <prefix>", nextStepFlags);
+            Assert.Contains("--path <narrower-glob>", nextStepFlags);
 
             var (textExitCode, textStdout, textStderr) = CaptureConsole(() => QueryCommandRunner.RunDeps(
                 ["--db", dbPath, "--cycles", "--limit", "1", "--lang", "csharp"],
@@ -4275,6 +4283,8 @@ public partial class QueryCommandRunnerTests
             Assert.Equal(string.Empty, textStdout);
             Assert.Contains("No dependency cycles found", textStderr, StringComparison.Ordinal);
             Assert.Contains("Warning: dependency cycle detection returned partial results", textStderr, StringComparison.Ordinal);
+            Assert.Contains("not a complete or ranked cycle set", textStderr, StringComparison.Ordinal);
+            Assert.Contains("Next steps: --limit 100, --suppress-noise", textStderr, StringComparison.Ordinal);
         }
         finally
         {
@@ -4499,6 +4509,49 @@ public partial class QueryCommandRunnerTests
             Assert.Equal(5, symbolFilter.GetProperty("symbols_before").GetInt32());
             Assert.Equal(1, symbolFilter.GetProperty("symbols_after").GetInt32());
             Assert.Equal(4, symbolFilter.GetProperty("symbols_removed").GetInt32());
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunDeps_CyclesSuppressNoiseRemovesGenericAppendCycle_Issue4114()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_deps_append_noise_cycle");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            InsertFileWithSymbolsAndReferences(dbPath, "src/BoundedLineReader.cs", ["Append"], ["Append"]);
+            InsertFileWithSymbolsAndReferences(dbPath, "src/BoundedTextWriter.cs", ["Append"], ["Append"]);
+            MarkDependencyGraphReady(dbPath);
+
+            var (defaultExitCode, defaultStdout, defaultStderr) = CaptureConsole(() => QueryCommandRunner.RunDeps(
+                ["--db", dbPath, "--json", "--cycles", "--limit", "10", "--lang", "csharp"],
+                _jsonOptions));
+
+            using var defaultDocument = ParseJsonOutput(defaultStdout);
+
+            Assert.Equal(CommandExitCodes.Success, defaultExitCode);
+            Assert.Equal(string.Empty, defaultStderr);
+            Assert.True(defaultDocument.RootElement.GetProperty("count").GetInt32() >= 1);
+
+            var (filteredExitCode, filteredStdout, filteredStderr) = CaptureConsole(() => QueryCommandRunner.RunDeps(
+                ["--db", dbPath, "--json", "--cycles", "--limit", "10", "--lang", "csharp", "--suppress-noise"],
+                _jsonOptions));
+
+            using var filteredDocument = ParseJsonOutput(filteredStdout);
+            var json = filteredDocument.RootElement;
+            var symbolFilter = json.GetProperty("symbol_filter");
+
+            Assert.Equal(CommandExitCodes.Success, filteredExitCode);
+            Assert.Equal(string.Empty, filteredStderr);
+            Assert.Equal(0, json.GetProperty("count").GetInt32());
+            Assert.Empty(json.GetProperty("cycles").EnumerateArray());
+            Assert.True(symbolFilter.GetProperty("suppress_noise").GetBoolean());
+            Assert.Equal(0, symbolFilter.GetProperty("edges_after").GetInt32());
+            Assert.True(symbolFilter.GetProperty("symbols_removed").GetInt32() > 0);
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Add actionable `deps --cycles` truncation metadata: `cycle_result_scope`, `cycle_result_note`, and `next_step_flags`.
- Make `--suppress-noise` remove generic `Append`-style helper-symbol cycles while preserving default behavior.
- Reject invalid UTF-8 in bounded text reads and add focused Bounded IO contract tests.
- Keep MCP cycle metadata aligned with CLI while returning MCP-argument-style next steps.

## Validation

- `dotnet build -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~BoundedLineReaderTests|FullyQualifiedName~RunDeps_CyclesJsonReportsCandidateLimitTruncation_Issue4065|FullyQualifiedName~RunDeps_CyclesSuppressNoiseRemovesGenericAppendCycle_Issue4114|FullyQualifiedName~RunDeps_CyclesCandidateBudgetCountsDistinctEdges_Issue4065|FullyQualifiedName~RunDeps_CyclesApplySymbolFilters_Issue3943|FullyQualifiedName~ToolsCall_DepsCyclesUsesGraphBudgetBeyondDisplayLimit_Issue3185" -p:UseSharedCompilation=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net9.0 --filter "FullyQualifiedName~BoundedLineReaderTests|FullyQualifiedName~RunDeps_CyclesJsonReportsCandidateLimitTruncation_Issue4065|FullyQualifiedName~RunDeps_CyclesSuppressNoiseRemovesGenericAppendCycle_Issue4114|FullyQualifiedName~RunDeps_CyclesCandidateBudgetCountsDistinctEdges_Issue4065|FullyQualifiedName~RunDeps_CyclesApplySymbolFilters_Issue3943|FullyQualifiedName~ToolsCall_DepsCyclesUsesGraphBudgetBeyondDisplayLimit_Issue3185" -p:UseSharedCompilation=false`
- `dotnet test --no-build --filter Issue4114`
- `dotnet test --no-restore --filter Issue4114`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll deps --json --cycles --path src/ --exclude-tests --limit 60`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll deps --json --cycles --path src/ --exclude-tests --limit 60 --suppress-noise`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index . --commits HEAD --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: initial P2 MCP next-step finding fixed; rerun found no blocking/actionable issues.

## Documentation and Changelog

- Updated `USER_GUIDE.md` English and Japanese `deps --cycles` option documentation.
- Added changelog fragment `changelog.d/unreleased/4114.fixed.md`.

## Follow-up Candidates

- None.

Fixes #4114
