### PR TITLE
Standardize test fixture filesystem helpers

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -138,6 +138,8 @@ Prefer the existing helper before writing new setup code.
 
 - `CreateTempProject(prefix)` creates a unique temp workspace.
 - Use `CreateTempProject(prefix)` instead of adding local `Path.GetTempPath()` / `Guid.NewGuid()` directory helpers; keep any local wrapper as a thin prefix-specific delegate only when it preserves existing call-site readability.
+- `ProjectPath(projectRoot, ...)` resolves fixture paths relative to the temp project and rejects absolute paths or `..` escapes outside that root.
+- `CreateDirectory(projectRoot, ...)`, `WriteTextFile(...)`, `AppendTextFile(...)`, and `ReadTextFile(...)` centralize fixture directory creation and text-file setup. Prefer them over local `Path.Combine` + `Directory.CreateDirectory` + `File.*Text` chains when the path belongs to a temp project.
 - `InitializeGitRepo(projectRoot)` initializes git and sets repo-local `user.name` and `user.email`.
 - `CreateProjectDb(projectRoot)` creates `<projectRoot>/.cdidx/codeindex.db`, initializes schema, and seeds `codeindex_meta.indexed_project_root` to match the project root.
 - `InsertIndexedFile(...)` inserts a realistic indexed file with content-derived checksum, chunks, symbols, and references, and now passes the file path into Python symbol extraction so `__init__.py`-based re-export tests can exercise qualified package names.
@@ -381,6 +383,8 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
 
 - `CreateTempProject(prefix)` は一意な一時ワークスペースを作成します。
 - 独自に `Path.GetTempPath()` / `Guid.NewGuid()` を組み合わせた directory helper を増やさず、`CreateTempProject(prefix)` を使ってください。既存呼び出し側の読みやすさを保つ場合だけ、local wrapper は prefix 固有の薄い委譲に留めます。
+- `ProjectPath(projectRoot, ...)` は temp project からの相対 fixture path を解決し、その root の外へ出る絶対 path や `..` escape を拒否します。
+- `CreateDirectory(projectRoot, ...)`、`WriteTextFile(...)`、`AppendTextFile(...)`、`ReadTextFile(...)` は fixture directory 作成と text file setup を集約します。path が temp project に属する場合は、ローカルな `Path.Combine` + `Directory.CreateDirectory` + `File.*Text` の連鎖より優先してください。
 - `InitializeGitRepo(projectRoot)` は git を初期化し、repo-local の `user.name` と `user.email` を設定します。
 - `CreateProjectDb(projectRoot)` は `<projectRoot>/.cdidx/codeindex.db` を作成し、スキーマを初期化したうえで `codeindex_meta.indexed_project_root` に project root を書き込みます。
 - `InsertIndexedFile(...)` は内容由来の checksum、chunks、symbols、references を含む現実的なインデックス済みファイルを挿入し、Python の symbol extraction には file path も渡すため、`__init__.py` ベースの再エクスポートテストで package 修飾名を扱えます。

--- a/changelog.d/unreleased/4140.internal.md
+++ b/changelog.d/unreleased/4140.internal.md
@@ -1,0 +1,18 @@
+---
+category: internal
+issues:
+  - 4140
+affected:
+  - tests/CodeIndex.Tests/TestProjectHelper.cs
+  - tests/CodeIndex.Tests/TestProjectHelperTests.cs
+  - tests/CodeIndex.Tests/GitTestProjectHelperTests.cs
+  - TESTING_GUIDE.md
+---
+
+## English
+
+- **Test fixtures now have shared project-root filesystem helpers (#4140)** — `TestProjectHelper` centralizes temp-project path resolution, directory creation, and text-file setup so tests can avoid ad hoc `Path.Combine` / `File.*Text` fixture code.
+
+## 日本語
+
+- **テスト fixture に project-root ベースの共有 filesystem helper を追加しました (#4140)** — `TestProjectHelper` が temp project の path 解決、directory 作成、text file setup を集約し、テスト内の個別の `Path.Combine` / `File.*Text` fixture code を避けやすくしました。

--- a/tests/CodeIndex.Tests/GitTestProjectHelperTests.cs
+++ b/tests/CodeIndex.Tests/GitTestProjectHelperTests.cs
@@ -6,24 +6,24 @@ public class GitTestProjectHelperTests
     public void InitializeGitRepo_DisablesCommitSigningForFixtureCommits()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_git_signing");
-        var globalConfig = Path.Combine(projectRoot, "global-gitconfig");
+        var globalConfig = TestProjectHelper.WriteTextFile(
+            projectRoot,
+            "global-gitconfig",
+            """
+            [commit]
+                gpgsign = true
+            [gpg]
+                format = ssh
+            [user]
+                signingkey = /definitely/missing/signing-key
+            """);
         try
         {
-            File.WriteAllText(
-                globalConfig,
-                """
-                [commit]
-                    gpgsign = true
-                [gpg]
-                    format = ssh
-                [user]
-                    signingkey = /definitely/missing/signing-key
-                """);
             using var env = EnvironmentVariableScope.Capture("GIT_CONFIG_GLOBAL");
             env.Set("GIT_CONFIG_GLOBAL", globalConfig);
 
             TestProjectHelper.InitializeGitRepo(projectRoot);
-            File.WriteAllText(Path.Combine(projectRoot, "app.cs"), "class App {}\n");
+            TestProjectHelper.WriteTextFile(projectRoot, "app.cs", "class App {}\n");
 
             TestProjectHelper.RunGit(projectRoot, "add", "app.cs");
             var commitSigning = TestProjectHelper.RunGit(projectRoot, "config", "--get", "commit.gpgsign").Trim();

--- a/tests/CodeIndex.Tests/TestProjectHelper.cs
+++ b/tests/CodeIndex.Tests/TestProjectHelper.cs
@@ -16,6 +16,58 @@ internal static class TestProjectHelper
         return projectRoot;
     }
 
+    internal static string ProjectPath(string projectRoot, params string[] relativeSegments)
+    {
+        if (string.IsNullOrWhiteSpace(projectRoot))
+            throw new ArgumentException("Project root is required.", nameof(projectRoot));
+
+        var fullRoot = Path.GetFullPath(projectRoot);
+        var combined = fullRoot;
+        foreach (var segment in relativeSegments)
+        {
+            if (string.IsNullOrEmpty(segment))
+                continue;
+            if (Path.IsPathRooted(segment))
+                throw new ArgumentException("Fixture paths must be relative to the project root.", nameof(relativeSegments));
+
+            combined = Path.Combine(combined, segment);
+        }
+
+        var fullPath = Path.GetFullPath(combined);
+        if (!IsSameOrChildPath(fullRoot, fullPath))
+            throw new ArgumentException("Fixture path escapes the project root.", nameof(relativeSegments));
+
+        return fullPath;
+    }
+
+    internal static string CreateDirectory(string projectRoot, params string[] relativeSegments)
+    {
+        var path = ProjectPath(projectRoot, relativeSegments);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    internal static string WriteTextFile(string projectRoot, string relativePath, string content)
+    {
+        var path = ProjectPath(projectRoot, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    internal static string AppendTextFile(string projectRoot, string relativePath, string content)
+    {
+        var path = ProjectPath(projectRoot, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+        File.AppendAllText(path, content);
+        return path;
+    }
+
+    internal static string ReadTextFile(string projectRoot, string relativePath)
+    {
+        return File.ReadAllText(ProjectPath(projectRoot, relativePath));
+    }
+
     internal static void InitializeGitRepo(string projectRoot)
     {
         RunGit(projectRoot, "init");
@@ -24,9 +76,7 @@ internal static class TestProjectHelper
         RunGit(projectRoot, "config", "commit.gpgsign", "false");
         RunGit(projectRoot, "config", "tag.gpgsign", "false");
 
-        var excludePath = Path.Combine(projectRoot, ".git", "info", "exclude");
-        Directory.CreateDirectory(Path.GetDirectoryName(excludePath)!);
-        File.AppendAllText(excludePath, ".cdidx/\n");
+        AppendTextFile(projectRoot, Path.Combine(".git", "info", "exclude"), ".cdidx/\n");
     }
 
     internal static string CreateProjectDb(string projectRoot)
@@ -193,5 +243,15 @@ internal static class TestProjectHelper
             File.SetAttributes(dir, FileAttributes.Normal);
 
         File.SetAttributes(path, FileAttributes.Normal);
+    }
+
+    private static bool IsSameOrChildPath(string root, string candidate)
+    {
+        var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+        var normalizedRoot = Path.TrimEndingDirectorySeparator(root);
+        var normalizedCandidate = Path.TrimEndingDirectorySeparator(candidate);
+
+        return string.Equals(normalizedRoot, normalizedCandidate, comparison) ||
+               normalizedCandidate.StartsWith(normalizedRoot + Path.DirectorySeparatorChar, comparison);
     }
 }

--- a/tests/CodeIndex.Tests/TestProjectHelperTests.cs
+++ b/tests/CodeIndex.Tests/TestProjectHelperTests.cs
@@ -1,0 +1,40 @@
+namespace CodeIndex.Tests;
+
+public class TestProjectHelperTests
+{
+    [Fact]
+    public void WriteTextFile_CreatesParentDirectoriesAndReadTextFileReadsFixtureContent()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_fixture_write");
+        try
+        {
+            var directoryPath = TestProjectHelper.CreateDirectory(projectRoot, "generated", "nested");
+            var filePath = TestProjectHelper.WriteTextFile(projectRoot, Path.Combine("src", "App.cs"), "class App {}\n");
+            TestProjectHelper.AppendTextFile(projectRoot, Path.Combine("src", "App.cs"), "// appended\n");
+
+            Assert.True(Directory.Exists(directoryPath));
+            Assert.Equal(Path.Combine(projectRoot, "src", "App.cs"), filePath);
+            Assert.True(Directory.Exists(TestProjectHelper.ProjectPath(projectRoot, "src")));
+            Assert.Equal("class App {}\n// appended\n", TestProjectHelper.ReadTextFile(projectRoot, Path.Combine("src", "App.cs")));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void ProjectPath_RejectsFixturePathsOutsideProjectRoot()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_fixture_escape");
+        try
+        {
+            Assert.Throws<ArgumentException>(() => TestProjectHelper.ProjectPath(projectRoot, "..", "escape.txt"));
+            Assert.Throws<ArgumentException>(() => TestProjectHelper.ProjectPath(projectRoot, Path.GetFullPath(Path.Combine(projectRoot, "..", "escape.txt"))));
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add project-root scoped filesystem helpers to `TestProjectHelper` for fixture path resolution, directory creation, and text file setup.
- Move a representative git fixture test to the shared write helper and add focused coverage for helper path containment and text fixture operations.
- Document the new helper guidance in both English and Japanese testing guide sections.

## Validation

- `dotnet test CodeIndex.sln --filter "FullyQualifiedName~TestProjectHelperTests|FullyQualifiedName~GitTestProjectHelperTests" -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

## Changelog

- `changelog.d/unreleased/4140.internal.md`

## Follow-up Candidates

- None.

Fixes #4140