### PR TITLE
Add phrase risk-pattern search recipe

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -1075,8 +1075,12 @@ should be narrowed or rethrown.
 Built-in recipes include `risky-code`, `json-parse-apis`,
 `auth-token-audit`, `dogfood-risk-patterns`, `dotnet-risk-patterns`,
 `sqlite-query-policy-surfaces`, `xml-parser-security`, `filesystem-traversal`,
-`bounded-read-evidence`, and the
+`bounded-read-evidence`, `phrase-risk-patterns`, and the
 opt-in broad `broad-token-audit` recipe.
+Use `phrase-risk-patterns` for noisy audit phrases such as `async void`,
+`throw new Exception`, `.Result`, `unsafe`, `Skip =`, `Version="`, `TODO`, and
+`Obsolete` when you need exact-substring, origin, result-kind, file-kind, or
+production/test scope facets before filing findings.
 `--recipe <name>` applies normal search filters such as `--lang`, `--path`,
 `--exclude-path`, `--exclude-tests`, `--limit`, and snippet controls to every
 query in the recipe. With `--json`, recipe runs emit one aggregate JSON payload
@@ -3765,7 +3769,12 @@ result level、正規化済みの repository-relative artifact URI を出力し�
 search audit recipe は、名前付き recipe を複数の curated search query に展開します。
 組み込み recipe には `risky-code`、`json-parse-apis`、`dotnet-risk-patterns`、`xml-parser-security`、
 `auth-token-audit`、`dogfood-risk-patterns`、`sqlite-query-policy-surfaces`、
-`filesystem-traversal`、`bounded-read-evidence`、`broad-token-audit` があります。
+`filesystem-traversal`、`bounded-read-evidence`、`phrase-risk-patterns`、
+`broad-token-audit` があります。
+`phrase-risk-patterns` は `async void`、`throw new Exception`、`.Result`、`unsafe`、
+`Skip =`、`Version="`、`TODO`、`Obsolete` のようなノイズの多い監査語句を対象に、
+issue 化前に exact-substring、origin、result-kind、file-kind、production/test scope の
+facet で切り分けたい場合に使います。
 `--list-recipes` は利用可能な名前、
 説明、推奨 label、query text、exact-match mode、false-positive guidance、guard filter、
 risk evidence、query 固有の audit taxonomy metadata を表示します。

--- a/changelog.d/unreleased/4139.added.md
+++ b/changelog.d/unreleased/4139.added.md
@@ -1,0 +1,17 @@
+---
+category: added
+issues:
+  - 4139
+affected:
+  - src/CodeIndex/Cli/SearchAuditRecipes.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **Added a phrase risk-pattern audit recipe (#4139)** - `search --recipe phrase-risk-patterns` now covers noisy audit phrases such as `async void`, `throw new Exception`, `.Result`, `unsafe`, `Skip =`, `Version="`, `TODO`, and `Obsolete` with exact-substring, origin, result-kind, file-kind, and source/test scope facets.
+
+## 日本語
+
+- **phrase risk-pattern 監査レシピを追加しました (#4139)** - `search --recipe phrase-risk-patterns` は `async void`、`throw new Exception`、`.Result`、`unsafe`、`Skip =`、`Version="`、`TODO`、`Obsolete` のようなノイズの多い監査語句を exact-substring、origin、result-kind、file-kind、source/test scope の facet 付きで扱います。

--- a/src/CodeIndex/Cli/SearchAuditRecipes.cs
+++ b/src/CodeIndex/Cli/SearchAuditRecipes.cs
@@ -1234,6 +1234,170 @@ internal static class SearchAuditRecipes
                 }
             ]),
         AllScopedRecipe(
+            "phrase-risk-patterns",
+            "Precision-focused audit searches for noisy code phrases, broad words, and configuration text that need semantic triage facets.",
+            [
+                new(
+                    "async-void-code",
+                    "async void",
+                    "Find exact async void declarations in production source instead of broad async/void lexical coincidences.",
+                    ["audit", "bug"],
+                    "False positives include required event handlers, framework callbacks, and intentionally fire-and-forget boundaries.")
+                {
+                    PathPatterns = [.. DefaultSourcePathPatternsValue],
+                    ExcludePaths = [.. DefaultSourceExcludePathsValue],
+                    MatchOrigins = ["code"],
+                    RiskEvidence =
+                    [
+                        "risk: async void hides exceptions and cancellation from normal Task-based callers.",
+                        "positive: UI/event-handler or host callback signatures can require async void; verify the boundary and exception handling."
+                    ],
+                },
+                new(
+                    "throw-new-exception-code",
+                    "throw new Exception",
+                    "Find exact generic Exception construction in production source instead of broad throw/exception lexical matches.",
+                    ["audit", "bug"],
+                    "False positives include top-level compatibility shims and temporary placeholders already tracked for typed exception cleanup.")
+                {
+                    PathPatterns = [.. DefaultSourcePathPatternsValue],
+                    ExcludePaths = [.. DefaultSourceExcludePathsValue],
+                    MatchOrigins = ["code"],
+                    RiskEvidence =
+                    [
+                        "risk: generic Exception loses typed recovery, category, and diagnostic-contract information.",
+                        "positive: boundary normalization or compatibility wrappers may intentionally translate to a generic exception only after preserving context."
+                    ],
+                },
+                new(
+                    "task-result-property-review",
+                    ".Result",
+                    "Find exact Result property accesses in production source so reviewers can separate Task blocking from ordinary DTO Result properties.",
+                    ["audit", "bug"],
+                    "False positives include DTO, command-result, parse-result, and search-result property access; prioritize hits whose receiver is Task or ValueTask.")
+                {
+                    PathPatterns = [.. DefaultSourcePathPatternsValue],
+                    ExcludePaths = [.. DefaultSourceExcludePathsValue],
+                    MatchOrigins = ["code"],
+                    ResultKinds = ["identifier"],
+                    RiskEvidence =
+                    [
+                        "risk: Task.Result and ValueTask.AsTask().Result can block async continuations and hide cancellation or timeout policy.",
+                        "positive: DTOs and result-wrapper properties named Result should be classified separately from sync-over-async blocking."
+                    ],
+                },
+                new(
+                    "unsafe-keyword-code",
+                    "unsafe ",
+                    "Find exact unsafe keyword usage in production source without documentation, installer text, or compatibility-note matches.",
+                    ["audit", "security"],
+                    "False positives include comments about unsafe APIs and safe-handle names; code-origin matches should be reviewed for pointer and buffer safety.")
+                {
+                    PathPatterns = [.. DefaultSourcePathPatternsValue],
+                    ExcludePaths = [.. DefaultSourceExcludePathsValue],
+                    MatchOrigins = ["code"],
+                    ResultKinds = ["identifier"],
+                    RiskEvidence =
+                    [
+                        "risk: unsafe code can bypass runtime memory safety and needs pointer lifetime, bounds, and pinning review.",
+                        "positive: isolated interop boundaries with SafeHandle, fixed-size buffers, and focused tests reduce triage priority."
+                    ],
+                },
+                new(
+                    "active-test-skip-assignment",
+                    "Skip =",
+                    "Find exact active test skip annotations without broad skip prose, changelog, or documentation matches.",
+                    ["audit", "test"],
+                    "False positives include fixture text that demonstrates skip syntax; active attributes and test-case metadata are the primary review target.")
+                {
+                    Severity = "info",
+                    PathPatterns = ["tests/**"],
+                    MatchOrigins = ["code"],
+                    RiskEvidence =
+                    [
+                        "risk: active Skip assignments can hide disabled coverage in the test suite.",
+                        "positive: documented platform-specific skips or intentionally external-dependency tests may be acceptable when tracked."
+                    ],
+                },
+                new(
+                    "readalltext-call-site",
+                    "ReadAllText",
+                    "Find production ReadAllText call sites while excluding documentation, project files, and config text.",
+                    ["audit", "performance"],
+                    "False positives include bounded helpers or tiny trusted files; prefer this call-site query when bare ReadAllText is noisy.")
+                {
+                    PathPatterns = [.. DefaultSourcePathPatternsValue],
+                    ExcludePaths = [.. DefaultSourceExcludePathsValue],
+                    MatchOrigins = ["code"],
+                    ResultKinds = ["call_site"],
+                    RiskEvidence =
+                    [
+                        "risk: whole-file text reads can materialize unbounded input without sharing or size policy.",
+                        "positive: nearby length checks, BoundedFile helpers, or tiny trusted files can make a hit intentional."
+                    ],
+                },
+                new(
+                    "version-project-config",
+                    "Version=\"",
+                    "Find exact XML Version attributes in project and package configuration instead of documentation or prose matches.",
+                    ["audit"],
+                    "False positives include generated fixture projects and examples; this query is for configuration/version-surface inventory, not source-code risk.")
+                {
+                    Severity = "info",
+                    PathPatterns =
+                    [
+                        "*.csproj",
+                        "*.props",
+                        "*.targets",
+                        "src/**/*.csproj",
+                        "tests/**/*.csproj",
+                        "Directory.Packages.props",
+                        "Directory.Build.props",
+                        "Directory.Build.targets"
+                    ],
+                    RiskEvidence =
+                    [
+                        "risk: dependency and package Version attributes belong to configuration review rather than source-code vulnerability sweeps.",
+                        "positive: exact XML attribute matching keeps version prose, docs, and changelog examples out of this inventory."
+                    ],
+                },
+                new(
+                    "todo-production-comment",
+                    "TODO",
+                    "Find TODO comments in production source without fixture, documentation, and changelog examples dominating the result set.",
+                    ["audit"],
+                    "False positives include intentionally tracked follow-up markers; broad TODO inventory should be requested separately when docs and tests are in scope.")
+                {
+                    Severity = "info",
+                    PathPatterns = [.. DefaultSourcePathPatternsValue],
+                    ExcludePaths = [.. DefaultSourceExcludePathsValue],
+                    MatchOrigins = ["comment"],
+                    ResultKinds = ["comment"],
+                    RiskEvidence =
+                    [
+                        "risk: production TODO comments can mark incomplete behavior that deserves explicit issue tracking.",
+                        "positive: comments that reference an existing issue or explain non-actionable compatibility work are lower risk."
+                    ],
+                },
+                new(
+                    "obsolete-production-code",
+                    "Obsolete",
+                    "Find Obsolete usage in production source without documentation, fixture, and changelog examples dominating the result set.",
+                    ["audit", "bug"],
+                    "False positives include compatibility shims and deliberate API lifecycle annotations; prioritize call sites or declarations that affect runtime paths.")
+                {
+                    PathPatterns = [.. DefaultSourcePathPatternsValue],
+                    ExcludePaths = [.. DefaultSourceExcludePathsValue],
+                    MatchOrigins = ["code"],
+                    ResultKinds = ["identifier"],
+                    RiskEvidence =
+                    [
+                        "risk: Obsolete APIs or attributes in production code can hide compatibility debt or unsupported runtime behavior.",
+                        "positive: explicit migration comments, compatibility guards, or attribute declarations with planned removal can make the hit intentional."
+                    ],
+                }
+            ]),
+        AllScopedRecipe(
             "broad-token-audit",
             "Opt-in broad token search for audits that intentionally need lexical, parser, LSP, cancellation, and auth-token coverage.",
             [

--- a/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerSearchTests.cs
@@ -1348,6 +1348,10 @@ public partial class QueryCommandRunnerTests
             .GetProperty("recipes")
             .EnumerateArray()
             .Single(item => item.GetProperty("name").GetString() == "broad-token-audit");
+        var phraseRiskRecipe = root
+            .GetProperty("recipes")
+            .EnumerateArray()
+            .Single(item => item.GetProperty("name").GetString() == "phrase-risk-patterns");
         var query = recipe
             .GetProperty("queries")
             .EnumerateArray()
@@ -1420,6 +1424,18 @@ public partial class QueryCommandRunnerTests
             .GetProperty("queries")
             .EnumerateArray()
             .Single(item => item.GetProperty("name").GetString() == "enumerate-without-options");
+        var phraseResultQuery = phraseRiskRecipe
+            .GetProperty("queries")
+            .EnumerateArray()
+            .Single(item => item.GetProperty("name").GetString() == "task-result-property-review");
+        var phraseSkipQuery = phraseRiskRecipe
+            .GetProperty("queries")
+            .EnumerateArray()
+            .Single(item => item.GetProperty("name").GetString() == "active-test-skip-assignment");
+        var phraseTodoQuery = phraseRiskRecipe
+            .GetProperty("queries")
+            .EnumerateArray()
+            .Single(item => item.GetProperty("name").GetString() == "todo-production-comment");
 
         Assert.True(root.GetProperty("count").GetInt32() >= 7);
         Assert.Contains(recipe.GetProperty("recommended_labels").EnumerateArray(), label => label.GetString() == "audit");
@@ -1526,6 +1542,21 @@ public partial class QueryCommandRunnerTests
         Assert.Contains(broadTokenRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "parser-token");
         Assert.Contains(broadTokenRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "cancellation-token");
         Assert.Contains(broadTokenRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "lsp-token");
+        Assert.Equal("all", phraseRiskRecipe.GetProperty("default_scope").GetString());
+        Assert.Contains(phraseRiskRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "async-void-code");
+        Assert.Contains(phraseRiskRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "throw-new-exception-code");
+        Assert.Contains(phraseRiskRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "unsafe-keyword-code");
+        Assert.Contains(phraseRiskRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "readalltext-call-site");
+        Assert.Contains(phraseRiskRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "version-project-config");
+        Assert.Contains(phraseRiskRecipe.GetProperty("queries").EnumerateArray(), item => item.GetProperty("name").GetString() == "obsolete-production-code");
+        Assert.Equal(".Result", phraseResultQuery.GetProperty("query").GetString());
+        Assert.Contains(phraseResultQuery.GetProperty("match_origins").EnumerateArray(), origin => origin.GetString() == "code");
+        Assert.Contains(phraseResultQuery.GetProperty("result_kinds").EnumerateArray(), kind => kind.GetString() == "identifier");
+        Assert.Contains("DTO", phraseResultQuery.GetProperty("false_positive_guidance").GetString(), StringComparison.Ordinal);
+        Assert.Equal("Skip =", phraseSkipQuery.GetProperty("query").GetString());
+        Assert.Contains(phraseSkipQuery.GetProperty("path_patterns").EnumerateArray(), path => path.GetString() == "tests/**");
+        Assert.Equal("TODO", phraseTodoQuery.GetProperty("query").GetString());
+        Assert.Contains(phraseTodoQuery.GetProperty("match_origins").EnumerateArray(), origin => origin.GetString() == "comment");
     }
 
     [Fact]
@@ -1734,7 +1765,7 @@ public partial class QueryCommandRunnerTests
         };
 
         Assert.Equal(
-            ["risky-code", "auth-token-audit", "dogfood-risk-patterns", "sqlite-query-policy-surfaces", "json-parse-apis", "dotnet-risk-patterns", "xml-parser-security", "filesystem-traversal", "bounded-read-evidence", "broad-token-audit"],
+            ["risky-code", "auth-token-audit", "dogfood-risk-patterns", "sqlite-query-policy-surfaces", "json-parse-apis", "dotnet-risk-patterns", "xml-parser-security", "filesystem-traversal", "bounded-read-evidence", "phrase-risk-patterns", "broad-token-audit"],
             recipes.Select(recipe => recipe.Name).ToArray());
 
         AssertRecipe(
@@ -1872,6 +1903,22 @@ public partial class QueryCommandRunnerTests
             ["src/**"],
             expectedSourceExcludes,
             ["bounded-file-open-helper", "bounded-memory-accumulator", "bounded-full-byte-read-helper"]);
+        AssertRecipe(
+            "phrase-risk-patterns",
+            SearchAuditRecipes.AllAuditScope,
+            [],
+            [],
+            [
+                "async-void-code",
+                "throw-new-exception-code",
+                "task-result-property-review",
+                "unsafe-keyword-code",
+                "active-test-skip-assignment",
+                "readalltext-call-site",
+                "version-project-config",
+                "todo-production-comment",
+                "obsolete-production-code"
+            ]);
         AssertRecipe(
             "broad-token-audit",
             SearchAuditRecipes.AllAuditScope,


### PR DESCRIPTION
## Summary
- Add `phrase-risk-patterns` as a built-in search recipe for noisy audit phrases such as `async void`, `throw new Exception`, `.Result`, `unsafe`, `Skip =`, `Version="`, `TODO`, and `Obsolete`.
- Attach exact-substring, origin, result-kind, source/test, and project/config path facets so audit sweeps can separate risk-shaped matches from lexical noise.
- Document the recipe in the English and Japanese user guide sections and add a changelog fragment.

## Validation
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false --no-restore`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-restore --filter FullyQualifiedName~RunSearch_ListRecipes -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --cached --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Smoke-tested `phrase-risk-patterns/task-result-property-review`, `version-project-config`, `active-test-skip-assignment`, and `todo-production-comment`.
- Codex adversarial review: `No blocking/actionable issues found.`

## Documentation / Changelog
- Updated `USER_GUIDE.md` in English and Japanese.
- Added `changelog.d/unreleased/4139.added.md`.

## Follow-up Candidates
- None.

Fixes #4139
