### PR TITLE
Improve validate actionability summaries

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -457,6 +457,7 @@ cdidx validate --kind replacement_char --severity warning --path src/
 cdidx validate --exclude-tests --exclude-path 'fixtures/**'
 cdidx validate --json=array --limit 50 --path legacy/
 cdidx validate --json --limit 50 --path legacy/
+cdidx validate --format compact --limit 50
 ```
 
 `validate` reports indexed files that are likely to produce misleading snippets
@@ -467,8 +468,15 @@ JSON-form instruction payloads.
 For `replacement_char`, JSON and MCP responses include `origin` (`source_literal`
 or `decode_replacement`) and `severity` so agents can distinguish intentional
 U+FFFD literals from likely encoding damage.
+Validation issue rows also include `category` and `actionable` when emitted by
+current binaries; expected fixture literals are grouped as
+`expected_fixture_literal` with `actionable: false`, while decoder replacement
+risks are grouped as `decoding_risk` with `actionable: true`.
 Human-readable output prints the same markers in brackets and adds
 `test_fixture` when a finding comes from a test or fixture path.
+The default JSON object includes a `summary` grouped by kind, severity, origin,
+category, and actionability. Use `--format compact` when an agent or pipeline
+only needs that summary plus compact issue rows.
 Use `--severity warning` to hide informational source literals and focus on
 findings that indicate likely encoding damage.
 Use `--exclude-tests` and repeatable `--exclude-path` to keep validation output
@@ -477,7 +485,7 @@ issue list.
 UTF-8 BOM markers in Visual Studio `.sln` files are treated as expected solution
 file noise and are not reported by default.
 Use `--json=array` when a pipeline expects a bare issue array instead of the
-default `{ "count": ..., "issues": [...] }` object.
+default `{ "count": ..., "summary": ..., "issues": [...] }` object.
 LFS pointers are recorded as `lfs_pointer_skipped`; their placeholder body is
 not indexed, and their checksum stays tied to the pointer identity until you run
 `git lfs pull` and then `cdidx index .` to index the real file content.
@@ -3145,6 +3153,7 @@ cdidx validate --kind replacement_char --severity warning --path src/
 cdidx validate --exclude-tests --exclude-path 'fixtures/**'
 cdidx validate --json=array --limit 50 --path legacy/
 cdidx validate --json --limit 50 --path legacy/
+cdidx validate --format compact --limit 50
 ```
 
 `validate` は、snippet や symbol name を誤らせやすい indexed file を報告します。
@@ -3154,15 +3163,20 @@ placeholder、Dockerfile の JSON-form instruction payload の parse / truncatio
 診断などです。
 `replacement_char` の JSON / MCP response には `origin` (`source_literal` /
 `decode_replacement`) と `severity` が入り、意図的な U+FFFD literal と
-エンコーディング破損の可能性を agent が区別できます。human-readable output
+エンコーディング破損の可能性を agent が区別できます。現在の binary が出力する
+validation issue row には `category` と `actionable` も入り、想定済み fixture literal は
+`expected_fixture_literal` / `actionable: false`、decoder replacement のリスクは
+`decoding_risk` / `actionable: true` として grouped summary に載ります。human-readable output
 にも同じ marker が角括弧で表示され、test / fixture path の finding には
-`test_fixture` が付きます。`--severity warning`
+`test_fixture` が付きます。既定の JSON object には kind、severity、origin、category、
+actionability ごとの `summary` が入り、agent や pipeline が summary と compact な issue row だけを
+必要とする場合は `--format compact` を使えます。`--severity warning`
 を使うと、informational な source literal を隠して、エンコーディング破損の
 可能性がある finding に集中できます。fixture や generated sample が issue list を
 支配する場合は、`--exclude-tests` と繰り返し指定できる `--exclude-path` で
 本番コード側の path に validation output を絞れます。Visual Studio の `.sln`
 file に含まれる UTF-8 BOM marker は solution file の既知ノイズとして扱われ、
-既定では報告されません。pipeline が既定の `{ "count": ..., "issues": [...] }`
+既定では報告されません。pipeline が既定の `{ "count": ..., "summary": ..., "issues": [...] }`
 object ではなく bare issue array を期待する場合は `--json=array` を使えます。LFS pointer
 は `lfs_pointer_skipped` として記録され、placeholder 本文は index されず、checksum は
 実体を取得するまで pointer identity に紐づきます。実体を index するには `git lfs pull`

--- a/changelog.d/unreleased/4138.changed.md
+++ b/changelog.d/unreleased/4138.changed.md
@@ -1,0 +1,19 @@
+---
+category: changed
+issues:
+  - 4138
+affected:
+  - src/CodeIndex/Models/FileIssue.cs
+  - src/CodeIndex/Cli/QueryCommandRunner.cs
+  - src/CodeIndex/Mcp/McpToolHandlers.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerValidateMetadataTests.cs
+  - USER_GUIDE.md
+---
+
+## English
+
+- **`validate` JSON now separates actionable encoding risks from expected fixture literals (#4138)** — validation issues include `category` and `actionable`, the default JSON response includes grouped actionability summaries, and `--format compact` returns the same summary with compact issue rows.
+
+## 日本語
+
+- **`validate` JSON が対応すべき encoding risk と想定済み fixture literal を分けるようになりました (#4138)** — validation issue に `category` と `actionable` を追加し、既定 JSON response に actionability の grouped summary を入れ、`--format compact` で同じ summary と compact な issue row を返します。

--- a/src/CodeIndex/Cli/QueryCommandRunner.cs
+++ b/src/CodeIndex/Cli/QueryCommandRunner.cs
@@ -10243,6 +10243,7 @@ public static partial class QueryCommandRunner
                 options.ExcludeTests,
                 issueLimit,
                 options.Severity);
+            AnnotateValidateIssues(issues);
             var issuesAvailable = reader._hasIssuesTable;
             if (options.CountOnly || options.OutputFormat == OutputFormatCount)
             {
@@ -10253,8 +10254,11 @@ public static partial class QueryCommandRunner
             {
                 if (options.Json)
                 {
-                    if (TryWriteEmptyFormattedResult(options, jsonOptions))
+                    if (options.OutputFormat == OutputFormatCompact)
+                    {
+                        WriteValidateCompactJson(issues, issuesAvailable, jsonOptions);
                         return CommandExitCodes.Success;
+                    }
                     if (options.OutputFormat == OutputFormatJson && options.JsonOutputFormat == JsonOutputFormatArray)
                     {
                         Console.WriteLine(JsonSerializer.Serialize(
@@ -10262,13 +10266,9 @@ public static partial class QueryCommandRunner
                             CliJsonSerializerContextFactory.Create(jsonOptions).ListFileIssue));
                         return CommandExitCodes.Success;
                     }
-                    Console.WriteLine(new JsonObject
-                    {
-                        ["count"] = 0,
-                        ["issues"] = new JsonArray(),
-                        ["issues_table_available"] = issuesAvailable,
-                        ["degraded"] = !issuesAvailable,
-                    }.ToJsonString(jsonOptions));
+                    if (TryWriteEmptyFormattedResult(options, jsonOptions))
+                        return CommandExitCodes.Success;
+                    Console.WriteLine(BuildValidateJsonPayload(issues, issuesAvailable, jsonOptions).ToJsonString(jsonOptions));
                 }
                 else if (!issuesAvailable)
                     CommandErrorWriter.WriteStderr("WARN: file_issues table missing in this index (legacy or read-only DB) — validate output is degraded, not a real clean signal.");
@@ -10282,6 +10282,11 @@ public static partial class QueryCommandRunner
 
             if (options.Json)
             {
+                if (options.OutputFormat == OutputFormatCompact)
+                {
+                    WriteValidateCompactJson(issues, issuesAvailable, jsonOptions);
+                    return CommandExitCodes.Success;
+                }
                 if (TryWriteFormattedLocations(
                     options,
                     issues.Select(i => new FormattedLocation(i.Path, i.Line, null, $"{i.Kind}: {i.Message}")),
@@ -10309,11 +10314,7 @@ public static partial class QueryCommandRunner
                         CliJsonSerializerContextFactory.Create(jsonOptions).ListFileIssue));
                     return CommandExitCodes.Success;
                 }
-                Console.WriteLine(new JsonObject
-                {
-                    ["count"] = issues.Count,
-                    ["issues"] = JsonSerializer.SerializeToNode(issues, CliJsonSerializerContextFactory.Create(jsonOptions).ListFileIssue),
-                }.ToJsonString(jsonOptions));
+                Console.WriteLine(BuildValidateJsonPayload(issues, issuesAvailable, jsonOptions).ToJsonString(jsonOptions));
             }
             else
             {
@@ -10325,9 +10326,163 @@ public static partial class QueryCommandRunner
                 }
                 var kindCounts = issues.GroupBy(i => i.Kind).Select(g => $"{g.Key}: {g.Count()}");
                 CommandErrorWriter.WriteStderr($"\n({issues.Count} issues: {string.Join(", ", kindCounts)})");
+                WriteValidateHumanSummary(issues);
             }
             return CommandExitCodes.Success;
         });
+    }
+
+    internal static void AnnotateValidateIssues(IEnumerable<FileIssue> issues)
+    {
+        foreach (var issue in issues)
+        {
+            issue.Category = CategorizeValidateIssue(issue);
+            issue.Actionable = IsValidateIssueActionable(issue);
+        }
+    }
+
+    internal static JsonObject BuildValidateIssueSummary(IReadOnlyList<FileIssue> issues)
+    {
+        var actionable = issues.Count(IsValidateIssueActionable);
+        return new JsonObject
+        {
+            ["total"] = issues.Count,
+            ["actionable"] = actionable,
+            ["informational"] = issues.Count - actionable,
+            ["actionability"] = issues.Count == 0
+                ? "clean"
+                : actionable == 0
+                    ? "informational_only"
+                    : actionable == issues.Count
+                        ? "actionable"
+                        : "mixed",
+            ["by_kind"] = BuildValidateCountObject(issues, static issue => issue.Kind),
+            ["by_severity"] = BuildValidateCountObject(issues, static issue => issue.Severity),
+            ["by_origin"] = BuildValidateCountObject(issues, static issue => issue.Origin),
+            ["by_category"] = BuildValidateCountObject(issues, static issue => issue.Category),
+        };
+    }
+
+    private static JsonObject BuildValidateJsonPayload(IReadOnlyList<FileIssue> issues, bool issuesAvailable, JsonSerializerOptions jsonOptions)
+    {
+        return new JsonObject
+        {
+            ["count"] = issues.Count,
+            ["summary"] = BuildValidateIssueSummary(issues),
+            ["issues"] = JsonSerializer.SerializeToNode(issues, CliJsonSerializerContextFactory.Create(jsonOptions).ListFileIssue),
+            ["issues_table_available"] = issuesAvailable,
+            ["degraded"] = !issuesAvailable,
+        };
+    }
+
+    private static void WriteValidateCompactJson(IReadOnlyList<FileIssue> issues, bool issuesAvailable, JsonSerializerOptions jsonOptions)
+    {
+        Console.WriteLine(new JsonObject
+        {
+            ["format"] = OutputFormatCompact,
+            ["count"] = issues.Count,
+            ["summary"] = BuildValidateIssueSummary(issues),
+            ["issues"] = BuildCompactValidateIssues(issues),
+            ["issues_table_available"] = issuesAvailable,
+            ["degraded"] = !issuesAvailable,
+        }.ToJsonString(jsonOptions));
+    }
+
+    private static JsonArray BuildCompactValidateIssues(IEnumerable<FileIssue> issues)
+    {
+        var compact = new JsonArray();
+        foreach (var issue in issues)
+        {
+            compact.Add(new JsonObject
+            {
+                ["path"] = issue.Path,
+                ["line"] = issue.Line,
+                ["kind"] = issue.Kind,
+                ["severity"] = issue.Severity,
+                ["origin"] = issue.Origin,
+                ["category"] = issue.Category,
+                ["actionable"] = issue.Actionable,
+                ["message"] = issue.Message,
+            });
+        }
+        return compact;
+    }
+
+    private static JsonObject BuildValidateCountObject(IEnumerable<FileIssue> issues, Func<FileIssue, string?> selector)
+    {
+        var counts = new JsonObject();
+        foreach (var group in issues
+                     .GroupBy(issue => NormalizeValidateSummaryKey(selector(issue)), StringComparer.Ordinal)
+                     .Select(group => new { Key = group.Key, Count = group.Count() })
+                     .OrderByDescending(group => group.Count)
+                     .ThenBy(group => group.Key, StringComparer.Ordinal))
+        {
+            counts[group.Key] = group.Count;
+        }
+        return counts;
+    }
+
+    private static string NormalizeValidateSummaryKey(string? value)
+        => string.IsNullOrWhiteSpace(value) ? "unspecified" : value;
+
+    private static string CategorizeValidateIssue(FileIssue issue)
+    {
+        return issue.Kind switch
+        {
+            "replacement_char" when string.Equals(issue.Origin, FileIssue.OriginSourceLiteral, StringComparison.Ordinal)
+                && IsValidateTestOrFixturePath(issue.Path) => FileIssue.CategoryExpectedFixtureLiteral,
+            "replacement_char" when string.Equals(issue.Origin, FileIssue.OriginSourceLiteral, StringComparison.Ordinal) => FileIssue.CategoryIntentionalSourceLiteral,
+            "replacement_char" or "non_utf8_likely" or "utf16_heuristic" => FileIssue.CategoryDecodingRisk,
+            "bom" or "utf16_bom" => FileIssue.CategoryByteOrderMark,
+            "mixed_line_endings" or "mixed_line_endings_three_way" or "cr_only_line_endings" => FileIssue.CategoryLineEndings,
+            "null_byte" => FileIssue.CategoryRawBytes,
+            "file_too_large" or "fts_token_too_long" or "line_too_long" or "symbol_count_exceeded" or "reference_count_exceeded" => FileIssue.CategoryContentLimit,
+            "lfs_pointer_skipped" or "conflict_markers" or "dockerfile_json_form_invalid" or "dockerfile_json_form_truncated" or "dockerfile_json_form_issue_limit_reached" or "xml_structure_invalid" => FileIssue.CategoryContentStructure,
+            _ => FileIssue.CategoryOther,
+        };
+    }
+
+    private static bool IsValidateIssueActionable(FileIssue issue)
+    {
+        var category = issue.Category ?? CategorizeValidateIssue(issue);
+        if (category is FileIssue.CategoryExpectedFixtureLiteral or FileIssue.CategoryIntentionalSourceLiteral)
+            return false;
+        return !string.Equals(issue.Severity, FileIssue.SeverityInfo, StringComparison.Ordinal);
+    }
+
+    private static void WriteValidateHumanSummary(IReadOnlyList<FileIssue> issues)
+    {
+        var actionable = issues.Count(IsValidateIssueActionable);
+        var parts = new List<string>
+        {
+            $"actionable: {actionable}",
+            $"informational: {issues.Count - actionable}",
+            $"severity: {FormatValidateSummaryCounts(issues, static issue => issue.Severity)}",
+            $"category: {FormatValidateSummaryCounts(issues, static issue => issue.Category)}",
+        };
+        var origins = FormatValidateSummaryCounts(issues, static issue => issue.Origin, includeUnspecified: false);
+        if (origins.Length > 0)
+            parts.Add($"origin: {origins}");
+
+        CommandErrorWriter.WriteStderr($"Summary: {string.Join("; ", parts)}");
+    }
+
+    private static string FormatValidateSummaryCounts(
+        IEnumerable<FileIssue> issues,
+        Func<FileIssue, string?> selector,
+        bool includeUnspecified = true)
+    {
+        return string.Join(
+            ", ",
+            issues
+                .Select(issue => selector(issue))
+                .Where(value => includeUnspecified || !string.IsNullOrWhiteSpace(value))
+                .Select(NormalizeValidateSummaryKey)
+                .GroupBy(value => value, StringComparer.Ordinal)
+                .Select(group => new { Key = group.Key, Count = group.Count() })
+                .OrderByDescending(group => group.Count)
+                .ThenBy(group => group.Key, StringComparer.Ordinal)
+                .Select(group => $"{group.Key}: {group.Count}"));
     }
 
     private static string FormatValidateIssueMetadata(FileIssue issue)

--- a/src/CodeIndex/Mcp/McpToolHandlers.cs
+++ b/src/CodeIndex/Mcp/McpToolHandlers.cs
@@ -4636,6 +4636,7 @@ public partial class McpServer
                 limit: countOnly ? null : FetchLimitForEnvelope(limit),
                 severity: severity);
             var truncated = !countOnly && TrimToRequestedLimit(issues, limit);
+            QueryCommandRunner.AnnotateValidateIssues(issues);
             var pathFilterArray = new JsonArray();
             if (pathPatterns is not null)
             {
@@ -4653,6 +4654,7 @@ public partial class McpServer
                     ["severity"] = severity,
                     ["path"] = pathFilterArray,
                 },
+                ["summary"] = QueryCommandRunner.BuildValidateIssueSummary(issues),
                 ["top_files"] = BuildTopFileHistogram(issues, issue => issue.Path),
             };
             if (countOnly)
@@ -4688,6 +4690,8 @@ public partial class McpServer
                 ["kind"] = issue.Kind,
                 ["severity"] = issue.Severity,
                 ["origin"] = issue.Origin,
+                ["category"] = issue.Category,
+                ["actionable"] = issue.Actionable,
                 ["message"] = issue.Message,
             });
         }

--- a/src/CodeIndex/Models/FileIssue.cs
+++ b/src/CodeIndex/Models/FileIssue.cs
@@ -11,6 +11,15 @@ public class FileIssue
     public const string OriginByteOrderMark = "byte_order_mark";
     public const string SeverityInfo = "info";
     public const string SeverityWarning = "warning";
+    public const string CategoryExpectedFixtureLiteral = "expected_fixture_literal";
+    public const string CategoryIntentionalSourceLiteral = "intentional_source_literal";
+    public const string CategoryDecodingRisk = "decoding_risk";
+    public const string CategoryByteOrderMark = "byte_order_mark";
+    public const string CategoryLineEndings = "line_endings";
+    public const string CategoryRawBytes = "raw_bytes";
+    public const string CategoryContentLimit = "content_limit";
+    public const string CategoryContentStructure = "content_structure";
+    public const string CategoryOther = "other";
 
     public string Path { get; set; } = string.Empty;
     public string Kind { get; set; } = string.Empty;
@@ -18,4 +27,6 @@ public class FileIssue
     public string Message { get; set; } = string.Empty;
     public string? Origin { get; set; }
     public string? Severity { get; set; }
+    public string? Category { get; set; }
+    public bool? Actionable { get; set; }
 }

--- a/tests/CodeIndex.Tests/QueryCommandRunnerValidateMetadataTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerValidateMetadataTests.cs
@@ -40,6 +40,8 @@ public partial class QueryCommandRunnerTests
             Assert.Equal("replacement_char", issue.GetProperty("kind").GetString());
             Assert.Equal(FileIssue.OriginSourceLiteral, issue.GetProperty("origin").GetString());
             Assert.Equal(FileIssue.SeverityInfo, issue.GetProperty("severity").GetString());
+            Assert.Equal(FileIssue.CategoryIntentionalSourceLiteral, issue.GetProperty("category").GetString());
+            Assert.False(issue.GetProperty("actionable").GetBoolean());
         }
         finally
         {
@@ -89,6 +91,86 @@ public partial class QueryCommandRunnerTests
             Assert.Contains("[info, source_literal, test_fixture]", stdout);
             Assert.Contains("U+FFFD source literal", stdout);
             Assert.Contains("(4 issues: replacement_char: 4)", stderr);
+            Assert.Contains("Summary: actionable: 0", stderr);
+            Assert.Contains("category: expected_fixture_literal: 4", stderr);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void RunValidate_JsonSummaryClassifiesExpectedFixtureAndDecodingRisk_Issue4138()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_validate_summary_4138");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            Directory.CreateDirectory(Path.Combine(projectRoot, "src"));
+            Directory.CreateDirectory(Path.Combine(projectRoot, "tests", "fixtures"));
+            File.WriteAllText(
+                Path.Combine(projectRoot, "tests", "fixtures", "literal.cs"),
+                "class Literal { const char Value = '\uFFFD'; }\n");
+
+            var decodeBytes = new List<byte>();
+            decodeBytes.AddRange(System.Text.Encoding.UTF8.GetBytes("class Decode { const string Value = \""));
+            decodeBytes.Add(0xFF);
+            decodeBytes.AddRange(System.Text.Encoding.UTF8.GetBytes("\"; }\n"));
+            File.WriteAllBytes(Path.Combine(projectRoot, "src", "decode.cs"), decodeBytes.ToArray());
+
+            var (indexExitCode, _, indexStderr) = CaptureConsole(() => IndexCommandRunner.Run(
+                [projectRoot, "--db", dbPath, "--json", "--quiet"],
+                _jsonOptions));
+            Assert.Equal(CommandExitCodes.Success, indexExitCode);
+            Assert.Equal(string.Empty, indexStderr);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunValidate(
+                ["--db", dbPath, "--json", "--kind", "replacement_char"],
+                _jsonOptions));
+            var (arrayExitCode, arrayStdout, arrayStderr) = CaptureConsole(() => QueryCommandRunner.RunValidate(
+                ["--db", dbPath, "--json=array", "--kind", "replacement_char"],
+                _jsonOptions));
+            var (compactExitCode, compactStdout, compactStderr) = CaptureConsole(() => QueryCommandRunner.RunValidate(
+                ["--db", dbPath, "--format", "compact", "--kind", "replacement_char"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(CommandExitCodes.Success, arrayExitCode);
+            Assert.Equal(CommandExitCodes.Success, compactExitCode);
+            Assert.Equal(string.Empty, stderr);
+            Assert.Equal(string.Empty, arrayStderr);
+            Assert.Equal(string.Empty, compactStderr);
+
+            using var document = ParseJsonOutput(stdout);
+            var root = document.RootElement;
+            var summary = root.GetProperty("summary");
+            Assert.Equal(2, summary.GetProperty("total").GetInt32());
+            Assert.Equal(1, summary.GetProperty("actionable").GetInt32());
+            Assert.Equal(1, summary.GetProperty("informational").GetInt32());
+            Assert.Equal("mixed", summary.GetProperty("actionability").GetString());
+            Assert.Equal(1, summary.GetProperty("by_category").GetProperty(FileIssue.CategoryExpectedFixtureLiteral).GetInt32());
+            Assert.Equal(1, summary.GetProperty("by_category").GetProperty(FileIssue.CategoryDecodingRisk).GetInt32());
+
+            var issues = root.GetProperty("issues").EnumerateArray().ToList();
+            Assert.Contains(issues, issue =>
+                issue.GetProperty("category").GetString() == FileIssue.CategoryExpectedFixtureLiteral
+                && !issue.GetProperty("actionable").GetBoolean());
+            Assert.Contains(issues, issue =>
+                issue.GetProperty("category").GetString() == FileIssue.CategoryDecodingRisk
+                && issue.GetProperty("actionable").GetBoolean());
+
+            using var arrayDocument = JsonDocument.Parse(arrayStdout);
+            Assert.All(arrayDocument.RootElement.EnumerateArray(), issue =>
+            {
+                Assert.True(issue.TryGetProperty("category", out _));
+                Assert.True(issue.TryGetProperty("actionable", out _));
+            });
+
+            using var compactDocument = ParseJsonOutput(compactStdout);
+            Assert.Equal("compact", compactDocument.RootElement.GetProperty("format").GetString());
+            Assert.Equal("mixed", compactDocument.RootElement.GetProperty("summary").GetProperty("actionability").GetString());
+            Assert.Equal(2, compactDocument.RootElement.GetProperty("issues").GetArrayLength());
         }
         finally
         {


### PR DESCRIPTION
## Summary

- Add validate issue `category` and `actionable` metadata so expected fixture literals are separated from actionable encoding risks.
- Add grouped `summary` output to default validate JSON and MCP validate responses, plus compact validate JSON output.
- Update validate docs and add changelog fragment `changelog.d/unreleased/4138.changed.md`.

## Validation

- `make lint`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~QueryCommandRunnerTests.RunValidate" -p:UseAppHost=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --filter "FullyQualifiedName~McpServerTests.ToolsCall_Validate" -p:UseAppHost=false`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll validate --format compact --limit 10`
- Codex adversarial review: `No blocking/actionable issues found.`

## Notes

- Earlier full `dotnet test` hit an unrelated intermittent net8 package-normalize redaction failure; tracked separately in #4224.

Fixes #4138
Related follow-up: #4224
