### PR TITLE
Harden release workflow privilege split

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,9 +90,6 @@ jobs:
           - os: macos-latest
             rid: osx-arm64
     runs-on: ${{ matrix.os }}
-    env:
-      WIN_SIGNING_CERT_BASE64: ${{ secrets.WIN_SIGNING_CERT_BASE64 }}
-      WIN_SIGNING_CERT_PASSWORD: ${{ secrets.WIN_SIGNING_CERT_PASSWORD }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -369,21 +366,16 @@ jobs:
         shell: pwsh
         run: Get-ChildItem publish -Filter *.pdb -Recurse | Remove-Item
 
-      - name: Warn when Windows Authenticode signing is not configured
-        if: runner.os == 'Windows' && (env.WIN_SIGNING_CERT_BASE64 == '' || env.WIN_SIGNING_CERT_PASSWORD == '')
+      - name: Sign Windows executable if configured
+        if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          WIN_SIGNING_CERT_BASE64: ${{ secrets.WIN_SIGNING_CERT_BASE64 }}
+          WIN_SIGNING_CERT_PASSWORD: ${{ secrets.WIN_SIGNING_CERT_PASSWORD }}
         run: |
-          Write-Warning "Windows Authenticode signing secrets are not configured; publishing unsigned Windows release binary."
-
-      - name: Authenticode sign Windows executable
-        if: runner.os == 'Windows' && env.WIN_SIGNING_CERT_BASE64 != '' && env.WIN_SIGNING_CERT_PASSWORD != ''
-        shell: pwsh
-        run: |
-          if ([string]::IsNullOrWhiteSpace($env:WIN_SIGNING_CERT_BASE64)) {
-            throw "WIN_SIGNING_CERT_BASE64 secret is required to Authenticode-sign Windows release binaries."
-          }
-          if ([string]::IsNullOrWhiteSpace($env:WIN_SIGNING_CERT_PASSWORD)) {
-            throw "WIN_SIGNING_CERT_PASSWORD secret is required to Authenticode-sign Windows release binaries."
+          if ([string]::IsNullOrWhiteSpace($env:WIN_SIGNING_CERT_BASE64) -or [string]::IsNullOrWhiteSpace($env:WIN_SIGNING_CERT_PASSWORD)) {
+            Write-Warning "Windows Authenticode signing secrets are not configured; publishing unsigned Windows release binary."
+            exit 0
           }
 
           $exe = Join-Path (Resolve-Path publish) "cdidx.exe"
@@ -519,16 +511,13 @@ jobs:
           name: CodeIndex-${{ matrix.rid }}
           path: artifacts/**
 
-  create-release:
+  prepare-release-files:
     if: github.repository == 'Widthdom/CodeIndex'
     runs-on: ubuntu-latest
     needs: [preflight, release]
-    timeout-minutes: 45
+    timeout-minutes: 30
     permissions:
-      contents: write
-      id-token: write
-      attestations: write
-    environment: release-production
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -578,53 +567,6 @@ jobs:
           fi
           sha256sum * > sha256sums.txt
 
-      - name: Import release GPG key
-        env:
-          RELEASE_GPG_PRIVATE_KEY: ${{ secrets.RELEASE_GPG_PRIVATE_KEY }}
-          RELEASE_GPG_PASSPHRASE: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
-        run: |
-          set -euo pipefail
-          if [ -z "${RELEASE_GPG_PRIVATE_KEY}" ]; then
-            echo "RELEASE_GPG_PRIVATE_KEY secret is required to sign sha256sums.txt." >&2
-            exit 1
-          fi
-
-          mkdir -p ~/.gnupg
-          chmod 700 ~/.gnupg
-          printf '%s' "${RELEASE_GPG_PRIVATE_KEY}" | gpg --batch --import
-          if [ -n "${RELEASE_GPG_PASSPHRASE}" ]; then
-            printf '%s' "${RELEASE_GPG_PASSPHRASE}" > ~/.gnupg/release-passphrase
-            chmod 600 ~/.gnupg/release-passphrase
-          fi
-
-      - name: Sign release checksum manifest
-        env:
-          RELEASE_GPG_KEY_ID: ${{ secrets.RELEASE_GPG_KEY_ID }}
-          RELEASE_GPG_PASSPHRASE: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
-        run: |
-          set -euo pipefail
-          sign_args=(--batch --yes --armor --detach-sign)
-          if [ -n "${RELEASE_GPG_KEY_ID}" ]; then
-            sign_args+=(--local-user "${RELEASE_GPG_KEY_ID}")
-          fi
-          if [ -n "${RELEASE_GPG_PASSPHRASE}" ]; then
-            sign_args+=(--pinentry-mode loopback --passphrase-file ~/.gnupg/release-passphrase)
-          fi
-
-          gpg "${sign_args[@]}" --output release-files/sha256sums.txt.asc release-files/sha256sums.txt
-          test -s release-files/sha256sums.txt.asc
-
-      - name: Attest release artifacts
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
-        with:
-          subject-path: |
-            release-files/*.tar.gz
-            release-files/*.zip
-            release-files/*.cdx.json
-            release-files/install.sh
-            release-files/sha256sums.txt
-            release-files/sha256sums.txt.asc
-
       - name: Write release install notes
         run: |
           cat > release-install-notes.md <<'EOF'
@@ -673,6 +615,85 @@ jobs:
 
           previous_version="${previous_tag#v}"
           dotnet run --project tools/CodeIndex.Changelog -- release-notes --version "${version}" --previous-version "${previous_version}" > release-notes.md
+
+      - name: Upload prepared release payload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-payload
+          path: |
+            release-files/**
+            release-*.md
+          if-no-files-found: error
+          retention-days: 1
+
+  create-release:
+    if: github.repository == 'Widthdom/CodeIndex'
+    runs-on: ubuntu-latest
+    needs: [preflight, prepare-release-files]
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    environment: release-production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.preflight.outputs.ref }}
+
+      - name: Download prepared release payload
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-payload
+          path: .
+
+      - name: Import release GPG key
+        env:
+          RELEASE_GPG_PRIVATE_KEY: ${{ secrets.RELEASE_GPG_PRIVATE_KEY }}
+          RELEASE_GPG_PASSPHRASE: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RELEASE_GPG_PRIVATE_KEY}" ]; then
+            echo "RELEASE_GPG_PRIVATE_KEY secret is required to sign sha256sums.txt." >&2
+            exit 1
+          fi
+
+          mkdir -p ~/.gnupg
+          chmod 700 ~/.gnupg
+          printf '%s' "${RELEASE_GPG_PRIVATE_KEY}" | gpg --batch --import
+          if [ -n "${RELEASE_GPG_PASSPHRASE}" ]; then
+            printf '%s' "${RELEASE_GPG_PASSPHRASE}" > ~/.gnupg/release-passphrase
+            chmod 600 ~/.gnupg/release-passphrase
+          fi
+
+      - name: Sign release checksum manifest
+        env:
+          RELEASE_GPG_KEY_ID: ${{ secrets.RELEASE_GPG_KEY_ID }}
+          RELEASE_GPG_PASSPHRASE: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          sign_args=(--batch --yes --armor --detach-sign)
+          if [ -n "${RELEASE_GPG_KEY_ID}" ]; then
+            sign_args+=(--local-user "${RELEASE_GPG_KEY_ID}")
+          fi
+          if [ -n "${RELEASE_GPG_PASSPHRASE}" ]; then
+            sign_args+=(--pinentry-mode loopback --passphrase-file ~/.gnupg/release-passphrase)
+          fi
+
+          gpg "${sign_args[@]}" --output release-files/sha256sums.txt.asc release-files/sha256sums.txt
+          test -s release-files/sha256sums.txt.asc
+
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            release-files/*.tar.gz
+            release-files/*.zip
+            release-files/*.cdx.json
+            release-files/install.sh
+            release-files/sha256sums.txt
+            release-files/sha256sums.txt.asc
 
       - name: Create GitHub release
         env:

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -101,6 +101,7 @@ in [DISTRIBUTION.md](DISTRIBUTION.md):
 | NuGet global tool | Install/update on a clean .NET 8 tool environment. |
 | NuGet trusted publishing | GitHub Actions variable `NUGET_TRUSTED_PUBLISHING_USER` is set to the NuGet.org username that created the trusted publishing policy; this can differ from the package owner. |
 | Release assets | Published asset exists for every advertised RID. |
+| Release workflow privilege split | `.github/workflows/release.yml` keeps `prepare-release-files` on `contents: read`, hands only the short-lived `release-payload` artifact to `create-release`, and scopes Windows signing secrets to the signing step. |
 | GHCR container image | Published `linux/amd64` and `linux/arm64` images run `cdidx --version`, omit runtime `git`, and expose provenance/SBOM attestations. |
 | Package metadata | License, repository URL, tags, and runtime prerequisites are correct. |
 | Documentation links | README, USER_GUIDE, and package metadata links resolve to the intended docs. |
@@ -2447,6 +2448,7 @@ channel をすべて確認してください。
 | NuGet global tool | clean な .NET 8 tool environment での install/update。 |
 | NuGet trusted publishing | GitHub Actions variable `NUGET_TRUSTED_PUBLISHING_USER` が trusted publishing policy を作成した NuGet.org ユーザー名に設定されていること。この値は package owner と異なり得る。 |
 | release asset | advertised RID ごとに published release asset があること。 |
+| release workflow の権限分離 | `.github/workflows/release.yml` は `prepare-release-files` を `contents: read` に保ち、短命の `release-payload` artifact だけを `create-release` に渡し、Windows 署名 secret を署名 step のみにスコープする。 |
 | GHCR container image | 公開済みの `linux/amd64` / `linux/arm64` image で `cdidx --version` が動作し、runtime `git` を含まず、provenance / SBOM attestation を公開していること。 |
 | package metadata | license、repository URL、tag、runtime prerequisite が正しいこと。 |
 | documentation link | README、USER_GUIDE、package metadata からの link が意図した docs を指すこと。 |

--- a/changelog.d/unreleased/4147.security.md
+++ b/changelog.d/unreleased/4147.security.md
@@ -1,0 +1,17 @@
+---
+category: security
+issues:
+  - 4147
+affected:
+  - .github/workflows/release.yml
+  - tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
+  - DEVELOPER_GUIDE.md
+---
+
+## English
+
+- **Release publishing now separates prepared payloads from privileged publishing (#4147)** — the release workflow prepares artifacts under read-only permissions, hands off a short-lived `release-payload` artifact, and scopes Windows signing secrets to the signing step.
+
+## 日本語
+
+- **release publishing で prepared payload と privileged publishing を分離しました (#4147)** — release workflow は read-only 権限で成果物を準備し、短命の `release-payload` artifact だけを引き渡し、Windows 署名 secret を署名 step のみにスコープします。

--- a/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
+++ b/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
@@ -158,6 +158,45 @@ public partial class ReleaseWorkflowTests
     }
 
     [Fact]
+    public void ReleaseWorkflow_SplitsReleasePayloadPreparationFromPrivilegedPublishing_Issue4147()
+    {
+        var workflow = ReadReleaseWorkflow();
+        var releaseJob = ExtractWorkflowJob(workflow, "release");
+        var prepareJob = ExtractWorkflowJob(workflow, "prepare-release-files");
+        var createJob = ExtractWorkflowJob(workflow, "create-release");
+
+        Assert.Contains("needs: [preflight, release]", prepareJob);
+        Assert.Contains("permissions:\n      contents: read", prepareJob);
+        Assert.Contains("name: Collect release files", prepareJob);
+        Assert.Contains("name: Write release install notes", prepareJob);
+        Assert.Contains("name: Write curated release notes", prepareJob);
+        Assert.Contains("name: Upload prepared release payload", prepareJob);
+        Assert.Contains("name: release-payload", prepareJob);
+        Assert.Contains("retention-days: 1", prepareJob);
+        Assert.DoesNotContain("RELEASE_GPG_PRIVATE_KEY", prepareJob);
+        Assert.DoesNotContain("actions/attest-build-provenance", prepareJob);
+        Assert.DoesNotContain("contents: write", prepareJob);
+        Assert.DoesNotContain("environment: release-production", prepareJob);
+
+        Assert.Contains("needs: [preflight, prepare-release-files]", createJob);
+        Assert.Contains("environment: release-production", createJob);
+        Assert.Contains("permissions:\n      contents: write\n      id-token: write\n      attestations: write", createJob);
+        Assert.Contains("name: Download prepared release payload", createJob);
+        Assert.Contains("name: release-payload", createJob);
+        Assert.Contains("name: Import release GPG key", createJob);
+        Assert.Contains("name: Sign release checksum manifest", createJob);
+        Assert.Contains("name: Attest release artifacts", createJob);
+        Assert.Contains("name: Create GitHub release", createJob);
+
+        Assert.Contains("name: Sign Windows executable if configured", releaseJob);
+        Assert.Contains("WIN_SIGNING_CERT_BASE64: ${{ secrets.WIN_SIGNING_CERT_BASE64 }}", releaseJob);
+        Assert.DoesNotContain("name: Warn when Windows Authenticode signing is not configured", releaseJob);
+        Assert.DoesNotContain(
+            "\n    env:\n      WIN_SIGNING_CERT_BASE64: ${{ secrets.WIN_SIGNING_CERT_BASE64 }}\n      WIN_SIGNING_CERT_PASSWORD: ${{ secrets.WIN_SIGNING_CERT_PASSWORD }}",
+            releaseJob);
+    }
+
+    [Fact]
     public void ReleaseWorkflow_UsesChangelogToolForTemplatedReleaseNotes()
     {
         var workflow = ReadReleaseWorkflow();
@@ -975,4 +1014,39 @@ public partial class ReleaseWorkflowTests
     }
 
     private static string ReadReleaseWorkflow() => RepositoryTestPaths.ReadWorkflow("release.yml");
+
+    private static string ExtractWorkflowJob(string workflow, string jobName)
+    {
+        var marker = $"  {jobName}:";
+        using var reader = new StringReader(workflow);
+        var job = new StringBuilder();
+        var inJob = false;
+
+        while (reader.ReadLine() is { } line)
+        {
+            if (!inJob)
+            {
+                if (line == marker)
+                {
+                    inJob = true;
+                    job.AppendLine(line);
+                }
+
+                continue;
+            }
+
+            if (line.StartsWith("  ", StringComparison.Ordinal)
+                && !line.StartsWith("    ", StringComparison.Ordinal)
+                && line.EndsWith(':'))
+            {
+                break;
+            }
+
+            job.AppendLine(line);
+        }
+
+        var text = job.ToString();
+        Assert.False(string.IsNullOrEmpty(text), $"Could not find workflow job '{jobName}'.");
+        return text;
+    }
 }

--- a/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
+++ b/tests/CodeIndex.Tests/ReleaseWorkflowTests.cs
@@ -167,6 +167,9 @@ public partial class ReleaseWorkflowTests
         var createJob = ExtractWorkflowJob(workflow, "create-release");
         var verifyJob = ExtractWorkflowJob(workflow, "verify-release-install");
 
+        Assert.DoesNotContain("\r\n", prepareJob);
+        Assert.DoesNotContain("\r\n", createJob);
+        Assert.DoesNotContain("\r\n", verifyJob);
         Assert.Contains("needs: [preflight, release]", prepareJob);
         Assert.Contains("permissions:\n      contents: read", prepareJob);
         Assert.Contains("name: Collect release files", prepareJob);
@@ -1046,7 +1049,7 @@ public partial class ReleaseWorkflowTests
                 if (line == marker)
                 {
                     inJob = true;
-                    job.AppendLine(line);
+                    job.Append(line).Append('\n');
                 }
 
                 continue;
@@ -1059,7 +1062,7 @@ public partial class ReleaseWorkflowTests
                 break;
             }
 
-            job.AppendLine(line);
+            job.Append(line).Append('\n');
         }
 
         var text = job.ToString();


### PR DESCRIPTION
## Summary
- Split release artifact preparation, privileged release publishing, and installer verification into separate workflow jobs.
- Scoped Windows signing secrets to the signing step, used temporary GPG material for release signing, and moved installer verification to a read-only job.
- Added release workflow contract tests, bilingual developer-guide notes, and a changelog fragment.
- Fixed the Windows CI failure by making the release workflow job extraction test helper normalize snippets to LF before LF-based assertions.

## Validation
- `dotnet test CodeIndex.sln --filter FullyQualifiedName~ReleaseWorkflowTests -p:UseSharedCompilation=false`
- `dotnet build CodeIndex.sln -p:UseSharedCompilation=false`
- `dotnet format CodeIndex.sln --verify-no-changes`
- `dotnet run --project tools/CodeIndex.Changelog -- check`
- `git diff --check origin/main...HEAD`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: `No blocking/actionable issues found.`

CI follow-up:
- Previous failure: `Build and Test / build (windows-latest, net8.0)` failed because `ExtractWorkflowJob` used platform-native `AppendLine()`, yielding CRLF snippets on Windows while assertions searched LF strings.
- Fix pushed in `0985603fa8902a568f538984c71e0779c90cb899`.

Fixes #4147