### PR TITLE
Add shared GitHub HTTP retry policy

### DIFF
--- a/changelog.d/unreleased/4145.changed.md
+++ b/changelog.d/unreleased/4145.changed.md
@@ -1,0 +1,22 @@
+---
+category: changed
+issues:
+  - 4145
+affected:
+  - src/CodeIndex/Cli/GitHubHttpClientFactory.cs
+  - src/CodeIndex/Cli/GitHubIssueReporter.cs
+  - src/CodeIndex/Cli/IssueDuplicatePreflight.cs
+  - src/CodeIndex/Cli/ProgramRunner.cs
+  - src/CodeIndex/Cli/UpdateChecker.cs
+  - tests/CodeIndex.Tests/FakeHttpMessageHandler.cs
+  - tests/CodeIndex.Tests/GitHubHttpCancellationTests.cs
+  - tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+---
+
+## English
+
+- **GitHub HTTP GET calls now share transient retry handling (#4145)** — GitHub API lookup, update check, and upgrade download GET requests now use the shared bounded HTTP policy for transient network failures and 408/5xx responses, while issue-creation POST requests remain non-retried to avoid duplicate submissions.
+
+## 日本語
+
+- **GitHub HTTP GET 呼び出しが一時的失敗の再試行を共有するようになりました (#4145)** — GitHub API の重複確認、更新確認、アップグレード用ダウンロードの GET リクエストは、一時的なネットワーク失敗と 408/5xx 応答に対して、共通の上限付き HTTP ポリシーを使って再試行するようになりました。重複送信を避けるため、Issue 作成 POST は再試行しません。

--- a/src/CodeIndex/Cli/GitHubHttpClientFactory.cs
+++ b/src/CodeIndex/Cli/GitHubHttpClientFactory.cs
@@ -7,7 +7,13 @@ namespace CodeIndex.Cli;
 internal static class GitHubHttpClientFactory
 {
     internal const string ProxyDefaultCredentialsEnvironmentVariable = "CDIDX_GITHUB_PROXY_USE_DEFAULT_CREDENTIALS";
+    internal const int MaxRetryAttempts = 3;
     internal static readonly TimeSpan MaxRequestTimeout = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan[] RetryDelays =
+    [
+        TimeSpan.FromMilliseconds(100),
+        TimeSpan.FromMilliseconds(250),
+    ];
     private const string GitHubApiVersionHeader = "X-GitHub-Api-Version";
     private const string GitHubApiVersion = "2022-11-28";
     private const string GitHubAcceptMediaType = "application/vnd.github+json";
@@ -52,6 +58,51 @@ internal static class GitHubHttpClientFactory
         TimeSpan timeout,
         CancellationToken cancellationToken)
         => new(timeout, cancellationToken);
+
+    internal static async Task<HttpResponseMessage> SendWithRetryAsync(
+        HttpClient client,
+        Func<HttpRequestMessage> requestFactory,
+        HttpCompletionOption completionOption,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(requestFactory);
+
+        for (var attempt = 1; ; attempt++)
+        {
+            using var request = requestFactory();
+            var canRetry = IsRetryableRequestMethod(request.Method);
+            try
+            {
+                var response = await client.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
+                if (!canRetry || attempt >= MaxRetryAttempts || !IsTransientRetryStatusCode(response.StatusCode))
+                    return response;
+
+                response.Dispose();
+            }
+            catch (HttpRequestException) when (canRetry
+                && attempt < MaxRetryAttempts
+                && !cancellationToken.IsCancellationRequested)
+            {
+            }
+
+            await Task.Delay(GetRetryDelay(attempt), cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    internal static bool IsTransientRetryStatusCode(HttpStatusCode statusCode)
+        => statusCode == HttpStatusCode.RequestTimeout
+            || ((int)statusCode >= 500 && (int)statusCode <= 599);
+
+    internal static bool IsRetryableRequestMethod(HttpMethod method)
+        => method == HttpMethod.Get || method == HttpMethod.Head;
+
+    private static TimeSpan GetRetryDelay(int completedAttempt)
+        => completedAttempt <= 0
+            ? TimeSpan.Zero
+            : completedAttempt <= RetryDelays.Length
+                ? RetryDelays[completedAttempt - 1]
+                : RetryDelays[^1];
 
     internal sealed class RequestCancellationScope : IDisposable
     {

--- a/src/CodeIndex/Cli/GitHubIssueReporter.cs
+++ b/src/CodeIndex/Cli/GitHubIssueReporter.cs
@@ -240,11 +240,14 @@ internal static class GitHubIssueReporter
         var query = Uri.EscapeDataString($"repo:{RepoOwner}/{RepoName} is:issue is:open \"{hash}\" in:body");
         var url = $"{ApiBase}/search/issues?q={query}&per_page=1";
 
-        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
-        ApplyAuthenticatedGitHubApiHeaders(requestMessage, token);
-
-        using var response = await HttpClient.SendAsync(
-            requestMessage,
+        using var response = await GitHubHttpClientFactory.SendWithRetryAsync(
+            HttpClient,
+            () =>
+            {
+                var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
+                ApplyAuthenticatedGitHubApiHeaders(requestMessage, token);
+                return requestMessage;
+            },
             HttpCompletionOption.ResponseHeadersRead,
             cancellationToken);
         if (!response.IsSuccessStatusCode)
@@ -310,11 +313,14 @@ internal static class GitHubIssueReporter
                 var labels = Uri.EscapeDataString(label);
                 var url = $"{ApiBase}/repos/{RepoOwner}/{RepoName}/issues?labels={labels}&state=open&per_page=100&page={page}";
 
-                using var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
-                ApplyAuthenticatedGitHubApiHeaders(requestMessage, token);
-
-                using var response = await HttpClient.SendAsync(
-                    requestMessage,
+                using var response = await GitHubHttpClientFactory.SendWithRetryAsync(
+                    HttpClient,
+                    () =>
+                    {
+                        var requestMessage = new HttpRequestMessage(HttpMethod.Get, url);
+                        ApplyAuthenticatedGitHubApiHeaders(requestMessage, token);
+                        return requestMessage;
+                    },
                     HttpCompletionOption.ResponseHeadersRead,
                     cancellationToken);
                 if (!response.IsSuccessStatusCode)

--- a/src/CodeIndex/Cli/IssueDuplicatePreflight.cs
+++ b/src/CodeIndex/Cli/IssueDuplicatePreflight.cs
@@ -479,17 +479,21 @@ internal sealed class IssueDuplicatePreflight
         var url = $"{GitHubApiBase}/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(name)}/issues?state=open&per_page={GitHubOpenIssuesPerPage.ToString(CultureInfo.InvariantCulture)}&page={page.ToString(CultureInfo.InvariantCulture)}";
         var timeout = GitHubIssueReporter.ResolveSubmitTimeout();
         using var requestCancellation = GitHubHttpClientFactory.CreateRequestCancellationScope(timeout, cancellationToken);
-        using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        GitHubHttpClientFactory.ApplyDefaultHeaders(request.Headers);
         var token = CdidxEnvironment.GetProcessEnvironmentVariable(GitHubTokenEnvironmentVariable);
-        if (!string.IsNullOrWhiteSpace(token))
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
         HttpResponseMessage response;
         try
         {
-            response = await HttpClient.SendAsync(
-                request,
+            response = await GitHubHttpClientFactory.SendWithRetryAsync(
+                HttpClient,
+                () =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Get, url);
+                    GitHubHttpClientFactory.ApplyDefaultHeaders(request.Headers);
+                    if (!string.IsNullOrWhiteSpace(token))
+                        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                    return request;
+                },
                 HttpCompletionOption.ResponseHeadersRead,
                 requestCancellation.Token).ConfigureAwait(false);
         }
@@ -526,17 +530,21 @@ internal sealed class IssueDuplicatePreflight
         var url = $"{GitHubApiBase}/repos/{Uri.EscapeDataString(owner)}/{Uri.EscapeDataString(name)}/labels?per_page={GitHubLabelsPerPage.ToString(CultureInfo.InvariantCulture)}&page={page.ToString(CultureInfo.InvariantCulture)}";
         var timeout = GitHubIssueReporter.ResolveSubmitTimeout();
         using var requestCancellation = GitHubHttpClientFactory.CreateRequestCancellationScope(timeout, cancellationToken);
-        using var request = new HttpRequestMessage(HttpMethod.Get, url);
-        GitHubHttpClientFactory.ApplyDefaultHeaders(request.Headers);
         var token = CdidxEnvironment.GetProcessEnvironmentVariable(GitHubTokenEnvironmentVariable);
-        if (!string.IsNullOrWhiteSpace(token))
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
 
         HttpResponseMessage response;
         try
         {
-            response = await HttpClient.SendAsync(
-                request,
+            response = await GitHubHttpClientFactory.SendWithRetryAsync(
+                HttpClient,
+                () =>
+                {
+                    var request = new HttpRequestMessage(HttpMethod.Get, url);
+                    GitHubHttpClientFactory.ApplyDefaultHeaders(request.Headers);
+                    if (!string.IsNullOrWhiteSpace(token))
+                        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                    return request;
+                },
                 HttpCompletionOption.ResponseHeadersRead,
                 requestCancellation.Token).ConfigureAwait(false);
         }

--- a/src/CodeIndex/Cli/ProgramRunner.cs
+++ b/src/CodeIndex/Cli/ProgramRunner.cs
@@ -4040,10 +4040,14 @@ internal static partial class ProgramRunner
             OperationTimeoutCategories.UpgradeDownload,
             timeout,
             cancellationToken);
-        using var request = new HttpRequestMessage(HttpMethod.Get, BuildReleaseAssetUrl(releaseTag, ReleaseChecksumAssetName));
-        GitHubHttpClientFactory.ApplyReleaseDownloadHeaders(request.Headers);
-        using var response = await client.SendAsync(
-            request,
+        using var response = await GitHubHttpClientFactory.SendWithRetryAsync(
+            client,
+            () =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, BuildReleaseAssetUrl(releaseTag, ReleaseChecksumAssetName));
+                GitHubHttpClientFactory.ApplyReleaseDownloadHeaders(request.Headers);
+                return request;
+            },
             HttpCompletionOption.ResponseHeadersRead,
             downloadScope.Token).ConfigureAwait(false);
         await GitHubHttpClientFactory.EnsureSuccessStatusCodeWithBoundedDiagnosticsAsync(
@@ -4120,10 +4124,14 @@ internal static partial class ProgramRunner
             OperationTimeoutCategories.UpgradeDownload,
             timeout,
             cancellationToken);
-        using var request = new HttpRequestMessage(HttpMethod.Get, BuildInstallerScriptUrl(releaseTag));
-        GitHubHttpClientFactory.ApplyReleaseDownloadHeaders(request.Headers);
-        using var response = await client.SendAsync(
-            request,
+        using var response = await GitHubHttpClientFactory.SendWithRetryAsync(
+            client,
+            () =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, BuildInstallerScriptUrl(releaseTag));
+                GitHubHttpClientFactory.ApplyReleaseDownloadHeaders(request.Headers);
+                return request;
+            },
             HttpCompletionOption.ResponseHeadersRead,
             downloadScope.Token).ConfigureAwait(false);
         await GitHubHttpClientFactory.EnsureSuccessStatusCodeWithBoundedDiagnosticsAsync(

--- a/src/CodeIndex/Cli/UpdateChecker.cs
+++ b/src/CodeIndex/Cli/UpdateChecker.cs
@@ -221,11 +221,14 @@ internal static class UpdateChecker
         CancellationToken cancellationToken)
     {
         using var requestCancellation = GitHubHttpClientFactory.CreateRequestCancellationScope(timeout, cancellationToken);
-        using var request = new HttpRequestMessage(HttpMethod.Get, LatestReleaseUrl);
-        GitHubHttpClientFactory.ApplyDefaultHeaders(request.Headers);
-
-        using var response = await client.SendAsync(
-            request,
+        using var response = await GitHubHttpClientFactory.SendWithRetryAsync(
+            client,
+            static () =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, LatestReleaseUrl);
+                GitHubHttpClientFactory.ApplyDefaultHeaders(request.Headers);
+                return request;
+            },
             HttpCompletionOption.ResponseHeadersRead,
             requestCancellation.Token).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)
@@ -243,11 +246,14 @@ internal static class UpdateChecker
         CancellationToken cancellationToken)
     {
         using var requestCancellation = GitHubHttpClientFactory.CreateRequestCancellationScope(timeout, cancellationToken);
-        using var request = new HttpRequestMessage(HttpMethod.Get, ReleasesUrl);
-        GitHubHttpClientFactory.ApplyDefaultHeaders(request.Headers);
-
-        using var response = await client.SendAsync(
-            request,
+        using var response = await GitHubHttpClientFactory.SendWithRetryAsync(
+            client,
+            static () =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, ReleasesUrl);
+                GitHubHttpClientFactory.ApplyDefaultHeaders(request.Headers);
+                return request;
+            },
             HttpCompletionOption.ResponseHeadersRead,
             requestCancellation.Token).ConfigureAwait(false);
         if (!response.IsSuccessStatusCode)

--- a/tests/CodeIndex.Tests/FakeHttpMessageHandler.cs
+++ b/tests/CodeIndex.Tests/FakeHttpMessageHandler.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Text;
+
+namespace CodeIndex.Tests;
+
+internal sealed class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Queue<Func<RecordedHttpRequest, CancellationToken, Task<HttpResponseMessage>>> responses = new();
+    private readonly List<RecordedHttpRequest> requests = [];
+
+    internal IReadOnlyList<RecordedHttpRequest> Requests => requests;
+
+    internal int RequestCount => requests.Count;
+
+    internal void QueueResponse(HttpResponseMessage response)
+        => responses.Enqueue((_, _) => Task.FromResult(response));
+
+    internal void QueueJson(HttpStatusCode statusCode, string json)
+        => QueueResponse(new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json"),
+        });
+
+    internal void QueueException(Exception exception)
+        => responses.Enqueue((_, _) => Task.FromException<HttpResponseMessage>(exception));
+
+    internal void QueueTimeout()
+        => responses.Enqueue(async (_, cancellationToken) =>
+        {
+            await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken).ConfigureAwait(false);
+            throw new OperationCanceledException(cancellationToken);
+        });
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var recorded = await RecordedHttpRequest.FromAsync(request, cancellationToken).ConfigureAwait(false);
+        requests.Add(recorded);
+
+        if (responses.Count == 0)
+        {
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
+            {
+                Content = new StringContent("{}", Encoding.UTF8, "application/json"),
+            };
+        }
+
+        return await responses.Dequeue()(recorded, cancellationToken).ConfigureAwait(false);
+    }
+}
+
+internal sealed record RecordedHttpRequest(
+    HttpMethod Method,
+    Uri? RequestUri,
+    IReadOnlyDictionary<string, string[]> Headers,
+    string? AuthorizationScheme,
+    string? AuthorizationParameter,
+    string? Body)
+{
+    internal static async Task<RecordedHttpRequest> FromAsync(
+        HttpRequestMessage request,
+        CancellationToken cancellationToken)
+    {
+        var headers = request.Headers.ToDictionary(
+            header => header.Key,
+            header => header.Value.ToArray(),
+            StringComparer.OrdinalIgnoreCase);
+
+        string? body = null;
+        if (request.Content != null)
+            body = await request.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+
+        return new RecordedHttpRequest(
+            request.Method,
+            request.RequestUri,
+            headers,
+            request.Headers.Authorization?.Scheme,
+            request.Headers.Authorization?.Parameter,
+            body);
+    }
+
+    internal bool HasHeaderValue(string name, string value)
+        => Headers.TryGetValue(name, out var values)
+            && values.Any(candidate => string.Equals(candidate, value, StringComparison.Ordinal));
+}

--- a/tests/CodeIndex.Tests/GitHubHttpCancellationTests.cs
+++ b/tests/CodeIndex.Tests/GitHubHttpCancellationTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Net.Http.Headers;
 using CodeIndex.Cli;
 
 namespace CodeIndex.Tests;
@@ -61,6 +62,107 @@ public sealed class GitHubHttpCancellationTests : IDisposable
         Assert.Contains(client.DefaultRequestHeaders.UserAgent, value => value.Product?.Name == "cdidx");
         Assert.Empty(client.DefaultRequestHeaders.Accept);
         Assert.False(client.DefaultRequestHeaders.Contains("X-GitHub-Api-Version"));
+    }
+
+    [Fact]
+    public async Task GitHubHttpClientFactory_SendWithRetryAsync_RetriesTransientGet_Issue4145()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.QueueException(new HttpRequestException("connection reset"));
+        handler.QueueJson(HttpStatusCode.ServiceUnavailable, """{"message":"try later"}""");
+        handler.QueueJson(HttpStatusCode.OK, """{"ok":true}""");
+        using var client = new HttpClient(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+
+        using var response = await GitHubHttpClientFactory.SendWithRetryAsync(
+            client,
+            static () =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/repos/Widthdom/CodeIndex/releases/latest");
+                GitHubHttpClientFactory.ApplyDefaultHeaders(request.Headers);
+                return request;
+            },
+            HttpCompletionOption.ResponseHeadersRead,
+            CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(GitHubHttpClientFactory.MaxRetryAttempts, handler.RequestCount);
+        Assert.All(handler.Requests, request =>
+        {
+            Assert.Equal(HttpMethod.Get, request.Method);
+            Assert.True(request.HasHeaderValue("User-Agent", "cdidx"));
+            Assert.True(request.HasHeaderValue("X-GitHub-Api-Version", "2022-11-28"));
+        });
+    }
+
+    [Fact]
+    public async Task GitHubHttpClientFactory_SendWithRetryAsync_DoesNotRetryRateLimit_Issue4145()
+    {
+        var handler = new FakeHttpMessageHandler();
+        var rateLimited = new HttpResponseMessage((HttpStatusCode)429)
+        {
+            Content = new StringContent("""{"message":"rate limited"}"""),
+        };
+        rateLimited.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(60));
+        handler.QueueResponse(rateLimited);
+        using var client = new HttpClient(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+
+        using var response = await GitHubHttpClientFactory.SendWithRetryAsync(
+            client,
+            static () => new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/rate_limit"),
+            HttpCompletionOption.ResponseHeadersRead,
+            CancellationToken.None);
+
+        Assert.Equal((HttpStatusCode)429, response.StatusCode);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task GitHubHttpClientFactory_SendWithRetryAsync_DoesNotRetryPost_Issue4145()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.QueueJson(HttpStatusCode.ServiceUnavailable, """{"message":"try later"}""");
+        using var client = new HttpClient(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+
+        using var response = await GitHubHttpClientFactory.SendWithRetryAsync(
+            client,
+            static () => new HttpRequestMessage(HttpMethod.Post, "https://api.github.com/repos/Widthdom/CodeIndex/issues")
+            {
+                Content = new StringContent("{}"),
+            },
+            HttpCompletionOption.ResponseHeadersRead,
+            CancellationToken.None);
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        Assert.Equal(1, handler.RequestCount);
+    }
+
+    [Fact]
+    public async Task GitHubHttpClientFactory_SendWithRetryAsync_CallerCancellationStopsFakeTimeout_Issue4145()
+    {
+        var handler = new FakeHttpMessageHandler();
+        handler.QueueTimeout();
+        using var client = new HttpClient(handler)
+        {
+            Timeout = Timeout.InfiniteTimeSpan,
+        };
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(50));
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            GitHubHttpClientFactory.SendWithRetryAsync(
+                client,
+                static () => new HttpRequestMessage(HttpMethod.Get, "https://api.github.com/repos/Widthdom/CodeIndex/releases/latest"),
+                HttpCompletionOption.ResponseHeadersRead,
+                cts.Token));
+        Assert.Equal(1, handler.RequestCount);
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
+++ b/tests/CodeIndex.Tests/GitHubIssueReporterTests.cs
@@ -786,7 +786,7 @@ public class GitHubIssueReporterTests : IDisposable
             Assert.Null(result.IssueUrl);
             Assert.Contains("existing-suggestion lookup failed during search", result.Error);
             Assert.Contains("502", result.Error);
-            Assert.Equal(1, handler.RequestCount);
+            Assert.Equal(GitHubHttpClientFactory.MaxRetryAttempts, handler.RequestCount);
             Assert.DoesNotContain(handler.Requests, r => r.Method == HttpMethod.Post);
         }
         finally
@@ -826,7 +826,7 @@ public class GitHubIssueReporterTests : IDisposable
             Assert.Null(result.IssueUrl);
             Assert.Contains("existing-suggestion lookup failed during label list", result.Error);
             Assert.Contains("503", result.Error);
-            Assert.Equal(2, handler.RequestCount);
+            Assert.Equal(1 + GitHubHttpClientFactory.MaxRetryAttempts, handler.RequestCount);
             Assert.DoesNotContain(handler.Requests, r => r.Method == HttpMethod.Post);
         }
         finally
@@ -1275,7 +1275,7 @@ public class GitHubIssueReporterTests : IDisposable
             Assert.Null(result.IssueUrl);
             Assert.Contains("existing-suggestion lookup failed during search", result.Error);
             Assert.Contains("503", result.Error);
-            Assert.Equal(1, handler.RequestCount);
+            Assert.Equal(GitHubHttpClientFactory.MaxRetryAttempts, handler.RequestCount);
             Assert.Equal(HttpMethod.Get, handler.Requests[0].Method);
             Assert.DoesNotContain(handler.Requests, r => r.Method == HttpMethod.Post);
         }
@@ -1763,7 +1763,7 @@ public class GitHubIssueReporterTests : IDisposable
             _responses.Add((match, response));
         }
 
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
             _requests.Add(request);
             if (request.Content != null)
@@ -1771,12 +1771,37 @@ public class GitHubIssueReporterTests : IDisposable
             foreach (var entry in _responses)
             {
                 if (entry.Match(request))
-                    return Task.FromResult(entry.Response);
+                    return GitHubHttpClientFactory.IsTransientRetryStatusCode(entry.Response.StatusCode)
+                        ? await CloneResponseAsync(entry.Response, cancellationToken).ConfigureAwait(false)
+                        : entry.Response;
             }
-            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NotFound)
+            return new HttpResponseMessage(HttpStatusCode.NotFound)
             {
                 Content = new StringContent("{}", Encoding.UTF8, "application/json"),
-            });
+            };
+        }
+
+        private static async Task<HttpResponseMessage> CloneResponseAsync(
+            HttpResponseMessage response,
+            CancellationToken cancellationToken)
+        {
+            var clone = new HttpResponseMessage(response.StatusCode)
+            {
+                ReasonPhrase = response.ReasonPhrase,
+                Version = response.Version,
+            };
+            foreach (var header in response.Headers)
+                clone.Headers.TryAddWithoutValidation(header.Key, header.Value);
+
+            if (response.Content != null)
+            {
+                var bytes = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+                clone.Content = new ByteArrayContent(bytes);
+                foreach (var header in response.Content.Headers)
+                    clone.Content.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            return clone;
         }
     }
 


### PR DESCRIPTION
## Summary
- Added a shared bounded retry helper for idempotent GitHub HTTP GET/HEAD requests.
- Moved GitHub duplicate lookup, preflight fetches, update checks, and upgrade downloads onto the shared retry path.
- Kept issue-creation POST requests non-retried to avoid duplicate submissions.
- Added reusable HTTP test fake coverage and a changelog fragment.

## Validation
- dotnet build src/CodeIndex/CodeIndex.csproj -c Release -p:UseSharedCompilation=false
- dotnet run --project tools/CodeIndex.Changelog -- check
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net8.0 --filter FullyQualifiedName~GitHubHttpCancellationTests -p:UseSharedCompilation=false
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net8.0 --filter FullyQualifiedName~GitHubIssueReporterTests -p:UseSharedCompilation=false
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net8.0 --filter FullyQualifiedName~IssueDuplicatePreflightTests -p:UseSharedCompilation=false
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net8.0 --filter FullyQualifiedName~UpdateChecker_FetchLatestReleaseTagAsync -p:UseSharedCompilation=false
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net8.0 --filter FullyQualifiedName~DownloadRelease -p:UseSharedCompilation=false
- dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -f net9.0 --filter FullyQualifiedName~GitHubHttpCancellationTests -p:UseSharedCompilation=false

## Review
- Codex adversarial review: No blocking/actionable issues found.

## Documentation / Changelog
- Added changelog fragment `changelog.d/unreleased/4145.changed.md`.
- No AGENT.md, CLAUDE.md, or AGENT_GUIDE.md changes.

Fixes #4145
