### PR TITLE
Fix YAML outline parent paths

### DIFF
--- a/changelog.d/unreleased/4151.fixed.md
+++ b/changelog.d/unreleased/4151.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 4151
+affected:
+  - src/CodeIndex/Database/DbSymbolReader.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerInspectTests.cs
+---
+
+## English
+
+- **YAML outline display names no longer duplicate parent keys (#4151)** — `outline` now keeps structured YAML paths such as `on.push`, `permissions.contents`, and `jobs.preflight` without repeating their parent segments.
+
+## 日本語
+
+- **YAML outline の display name が親キーを重複表示しないようになりました (#4151)** — `outline` は `on.push`、`permissions.contents`、`jobs.preflight` のような構造化 YAML path で親セグメントを繰り返さなくなりました。

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -2474,7 +2474,10 @@ public partial class DbReader
 
     private static string BuildOutlineSymbolPath(string? containerQualifiedName, string name)
     {
-        return string.IsNullOrWhiteSpace(containerQualifiedName)
+        if (string.IsNullOrWhiteSpace(containerQualifiedName))
+            return name;
+
+        return name.StartsWith(containerQualifiedName + ".", StringComparison.Ordinal)
             ? name
             : $"{containerQualifiedName}.{name}";
     }

--- a/tests/CodeIndex.Tests/QueryCommandRunnerInspectTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerInspectTests.cs
@@ -971,6 +971,67 @@ public partial class QueryCommandRunnerTests
     }
 
     [Fact]
+    public void RunOutline_Json_YamlNestedPathsDoNotDuplicateParentKeys_Issue4151()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_outline_yaml_paths_4151");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                ".github/workflows/release.yml",
+                "yaml",
+                """
+                name: Release
+                on:
+                  push:
+                    tags:
+                      - 'v*'
+                permissions:
+                  contents: read
+                jobs:
+                  preflight:
+                    runs-on: ubuntu-latest
+                """);
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunOutline(
+                [
+                    ".github/workflows/release.yml",
+                    "--db", dbPath,
+                    "--json",
+                    "--outline-fields", "name,display_name,path,container_name"
+                ],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+
+            using var document = ParseJsonOutput(stdout);
+            var symbols = document.RootElement.GetProperty("symbols").EnumerateArray().ToList();
+
+            Assert.Contains(symbols, symbol =>
+                symbol.GetProperty("name").GetString() == "on.push"
+                && symbol.GetProperty("display_name").GetString() == "on.push"
+                && symbol.GetProperty("path").GetString() == "on.push"
+                && symbol.GetProperty("container_name").GetString() == "on");
+            Assert.Contains(symbols, symbol =>
+                symbol.GetProperty("name").GetString() == "permissions.contents"
+                && symbol.GetProperty("display_name").GetString() == "permissions.contents"
+                && symbol.GetProperty("path").GetString() == "permissions.contents"
+                && symbol.GetProperty("container_name").GetString() == "permissions");
+            Assert.Contains(symbols, symbol =>
+                symbol.GetProperty("name").GetString() == "jobs.preflight"
+                && symbol.GetProperty("display_name").GetString() == "jobs.preflight"
+                && symbol.GetProperty("path").GetString() == "jobs.preflight"
+                && symbol.GetProperty("container_name").GetString() == "jobs");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
     public void RunOutline_CompactJson_CapsSymbolsAndReportsTruncation_Issue3009()
     {
         var projectRoot = TestProjectHelper.CreateTempProject("cdidx_outline_compact_json");


### PR DESCRIPTION
## Summary

- Avoid prefixing outline paths when the extracted symbol name is already container-qualified.
- Add regression coverage for nested GitHub Actions YAML keys such as `on.push`, `permissions.contents`, and `jobs.preflight`.
- Add a bilingual changelog fragment for the fix.

## Validation

- `dotnet build CodeIndex.sln --no-restore -p:UseSharedCompilation=false -p:BuildInParallel=false -m:1`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --filter "FullyQualifiedName~RunOutline_Json_YamlNestedPathsDoNotDuplicateParentKeys_Issue4151" -p:UseSharedCompilation=false -p:BuildInParallel=false -m:1`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore -p:UseSharedCompilation=false -p:BuildInParallel=false -m:1`
  - `net8.0`: 8,773 passed, 6 skipped, 0 failed
  - `net9.0`: 8,756 passed, 23 skipped, 0 failed
- `dotnet run --project tools/CodeIndex.Changelog --no-restore -- check`
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore --verbosity minimal`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll outline .github/workflows/release.yml --json --outline-fields name,display_name,path,container_name --limit 8`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation and changelog

- Added `changelog.d/unreleased/4151.fixed.md`.
- No README/user guide changes were needed because this fixes existing outline output behavior without adding flags or changing documented usage.

## Review

- Adversarial review: No blocking/actionable issues found.
- Note: `codex exec review --base origin/main --ephemeral` was attempted first, but that subprocess could not inspect the local repository because its internal shell calls exited with 134; the review was completed directly against `origin/main..HEAD` instead.

Fixes #4151
