### PR TITLE
Harden Docker image contracts

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -13,6 +13,24 @@ This document compares supported and planned ways to install `cdidx`.
 | Manual image build | Any base image that can run the selected install path | Either `install.sh` prerequisites or a .NET SDK for source builds | Rebuild the image with a pinned release or source revision | Mirror release assets or NuGet feeds inside the image build network | Supported as a deployment pattern for customized images |
 | Build from source | Windows, macOS, and Linux with a supported .NET SDK | .NET 8 SDK for production target; .NET 9 SDK if running the full test matrix | Pull source and rebuild | Works with restored package caches and internal NuGet mirrors | Contributor and advanced-user path |
 
+## Container Image Contract
+
+The official GHCR image is built from digest-pinned multi-arch Microsoft .NET
+base-image manifest lists. The build stage intentionally uses the
+repository-pinned .NET 9 SDK, while the runtime stage stays on .NET 8
+`runtime-deps` because the production CLI targets `net8.0`. The Dockerfile maps
+GitHub Actions `TARGETARCH` values to musl RIDs (`amd64` ->
+`linux-musl-x64`, `arm64` -> `linux-musl-arm64`) and rejects unknown
+architectures during both restore and publish.
+
+Runtime packages are intentionally limited to `ca-certificates` and `su-exec`.
+The image does not install `git`, shells beyond the Alpine base shell, package
+managers beyond `apk`, or build tools in the runtime stage. The entrypoint runs
+as root only long enough to derive the target UID/GID from `CDIDX_RUN_UID`,
+`CDIDX_RUN_GID`, or `/repo` ownership, then uses `su-exec` to run `cdidx` with
+`HOME=/repo`. Setting `CDIDX_RUN_UID=0` keeps root execution explicit for
+operators who need it.
+
 ## Planned or Community Channels
 
 | Channel | Status | Notes |
@@ -53,6 +71,7 @@ Before publishing or updating a channel, verify:
 - `install.sh --doctor vX.Y.Z` reports the configured release and API hosts.
 - `dotnet tool install -g cdidx --version <version>` succeeds on a clean .NET 8 tool environment.
 - `docker pull ghcr.io/widthdom/codeindex:<version>` succeeds for published release images, and the registry exposes provenance/SBOM attestations.
+- The GHCR image keeps the SDK/runtime version split, `TARGETARCH` to musl RID mapping, runtime package allowlist, and entrypoint privilege-drop behavior described in the container image contract.
 - `cdidx --version` runs from each installed channel.
 - `cdidx status --help` or another lightweight command runs without requiring a repository.
 - Package metadata preserves license, homepage, and repository links.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-# Base image digests are multi-arch manifest list digests. Refresh with:
+# Base image digests are multi-arch manifest list digests.
+# SDK digest refresh helper (replace <image> with sdk):
 # docker buildx imagetools inspect mcr.microsoft.com/dotnet/<image>:9.0.301-alpine3.22
+# Build uses the repository-pinned .NET 9 SDK; runtime stays on .NET 8
+# runtime-deps because cdidx targets net8.0. Refresh pinned images with:
+# docker buildx imagetools inspect mcr.microsoft.com/dotnet/sdk:9.0.301-alpine3.22
+# docker buildx imagetools inspect mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine
 FROM mcr.microsoft.com/dotnet/sdk:9.0.301-alpine3.22@sha256:bdd1c9e2215a71e43d2f0c6978ace0a0652d7ecc21bf6f659d42d840500e1c44 AS build
 
 WORKDIR /src

--- a/changelog.d/unreleased/4157.security.md
+++ b/changelog.d/unreleased/4157.security.md
@@ -1,0 +1,17 @@
+---
+category: security
+issues:
+  - 4157
+affected:
+  - Dockerfile
+  - DISTRIBUTION.md
+  - tests/CodeIndex.Tests/ReleaseWorkflowDockerContractTests.cs
+---
+
+## English
+
+- **Hardened Docker image contract coverage (#4157)** - documented the official container image SDK/runtime split, runtime package allowlist, musl RID mapping, and entrypoint privilege-drop behavior, and added release workflow tests that lock those contracts.
+
+## 日本語
+
+- **Docker image contract のカバレッジを強化しました (#4157)** - official container image の SDK/runtime 分離、runtime package allowlist、musl RID mapping、entrypoint の privilege-drop 挙動を文書化し、それらの contract を固定する release workflow tests を追加しました。

--- a/tests/CodeIndex.Tests/ReleaseWorkflowDockerContractTests.cs
+++ b/tests/CodeIndex.Tests/ReleaseWorkflowDockerContractTests.cs
@@ -1,0 +1,184 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace CodeIndex.Tests;
+
+public partial class ReleaseWorkflowTests
+{
+    [Fact]
+    public void ReleaseWorkflow_DockerfileDocumentsSdkRuntimeSplit()
+    {
+        var dockerfile = RepositoryTestPaths.ReadText("Dockerfile");
+
+        Assert.Contains("Build uses the repository-pinned .NET 9 SDK", dockerfile);
+        Assert.Contains("runtime-deps because cdidx targets net8.0", dockerfile);
+        Assert.Contains("docker buildx imagetools inspect mcr.microsoft.com/dotnet/sdk:9.0.301-alpine3.22", dockerfile);
+        Assert.Contains("docker buildx imagetools inspect mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine", dockerfile);
+        Assert.Contains("FROM mcr.microsoft.com/dotnet/sdk:9.0.301-alpine3.22@sha256:", dockerfile);
+        Assert.Contains("FROM mcr.microsoft.com/dotnet/runtime-deps:8.0-alpine@sha256:", dockerfile);
+    }
+
+    [Fact]
+    public void ReleaseWorkflow_DockerfileLocksRuntimePackagesAndRidMapping()
+    {
+        var dockerfile = RepositoryTestPaths.ReadText("Dockerfile").ReplaceLineEndings("\n");
+
+        Assert.Equal(2, dockerfile.Split('\n').Count(line => line.Contains("amd64) rid=\"linux-musl-x64\" ;;", StringComparison.Ordinal)));
+        Assert.Equal(2, dockerfile.Split('\n').Count(line => line.Contains("arm64) rid=\"linux-musl-arm64\" ;;", StringComparison.Ordinal)));
+        Assert.Equal(2, dockerfile.Split('\n').Count(line => line.Contains("Unsupported container architecture: $TARGETARCH", StringComparison.Ordinal)));
+
+        var apkAddLines = dockerfile.Split('\n')
+            .Where(line => line.TrimStart().StartsWith("RUN apk add ", StringComparison.Ordinal))
+            .ToArray();
+        var apkAddLine = Assert.Single(apkAddLines);
+        Assert.Equal("RUN apk add --no-cache ca-certificates su-exec \\", apkAddLine);
+        Assert.DoesNotContain(" apk add --update ", dockerfile);
+        Assert.DoesNotContain(" apk add --upgrade ", dockerfile);
+        Assert.DoesNotContain(" apk add --no-cache bash", dockerfile);
+        Assert.DoesNotContain(" apk add --no-cache curl", dockerfile);
+        Assert.DoesNotContain(" apk add --no-cache git", dockerfile);
+        Assert.DoesNotContain(" apk add --no-cache shadow", dockerfile);
+    }
+
+    [Fact]
+    public void ReleaseWorkflow_DockerEntrypointDropsRootToRequestedUidGid()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_entrypoint_drop_root");
+        try
+        {
+            var binDir = Path.Combine(projectRoot, "bin");
+            var tracePath = Path.Combine(projectRoot, "trace.txt");
+            Directory.CreateDirectory(binDir);
+            WriteExecutable(Path.Combine(binDir, "id"), """
+                #!/bin/sh
+                if [ "$1" = "-u" ]; then
+                    echo 0
+                    exit 0
+                fi
+                exit 97
+                """);
+            WriteExecutable(Path.Combine(binDir, "su-exec"), """
+                #!/bin/sh
+                {
+                    printf 'su-exec:%s\n' "$*"
+                    printf 'HOME=%s\n' "$HOME"
+                } > "$CDIDX_TRACE"
+                """);
+            WriteExecutable(Path.Combine(binDir, "cdidx"), """
+                #!/bin/sh
+                {
+                    printf 'cdidx:%s\n' "$*"
+                    printf 'HOME=%s\n' "${HOME:-}"
+                } > "$CDIDX_TRACE"
+                """);
+
+            var result = RunDockerEntrypoint(binDir, tracePath, "123", "456", "--version");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(string.Empty, result.Stderr);
+            var trace = File.ReadAllText(tracePath);
+            Assert.Contains("su-exec:123:456 cdidx --version", trace);
+            Assert.Contains("HOME=/repo", trace);
+            Assert.DoesNotContain("cdidx:", trace);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    [Fact]
+    public void ReleaseWorkflow_DockerEntrypointCanKeepRootWhenExplicitlyRequested()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_entrypoint_keep_root");
+        try
+        {
+            var binDir = Path.Combine(projectRoot, "bin");
+            var tracePath = Path.Combine(projectRoot, "trace.txt");
+            Directory.CreateDirectory(binDir);
+            WriteExecutable(Path.Combine(binDir, "id"), """
+                #!/bin/sh
+                if [ "$1" = "-u" ]; then
+                    echo 0
+                    exit 0
+                fi
+                exit 97
+                """);
+            WriteExecutable(Path.Combine(binDir, "su-exec"), """
+                #!/bin/sh
+                printf 'unexpected su-exec:%s\n' "$*" > "$CDIDX_TRACE"
+                exit 98
+                """);
+            WriteExecutable(Path.Combine(binDir, "cdidx"), """
+                #!/bin/sh
+                {
+                    printf 'cdidx:%s\n' "$*"
+                    printf 'HOME=%s\n' "${HOME:-}"
+                } > "$CDIDX_TRACE"
+                """);
+
+            var result = RunDockerEntrypoint(binDir, tracePath, "0", "0", "status", "--json");
+
+            Assert.Equal(0, result.ExitCode);
+            Assert.Equal(string.Empty, result.Stderr);
+            var trace = File.ReadAllText(tracePath);
+            Assert.Contains("cdidx:status --json", trace);
+            Assert.DoesNotContain("unexpected su-exec", trace);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+
+    private static (int ExitCode, string Stdout, string Stderr) RunDockerEntrypoint(
+        string binDir,
+        string tracePath,
+        string targetUid,
+        string targetGid,
+        params string[] args)
+    {
+        var entrypointPath = RepositoryTestPaths.Combine("scripts", "docker-entrypoint.sh");
+        using var process = new Process();
+        process.StartInfo = new ProcessStartInfo("/bin/sh")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        process.StartInfo.ArgumentList.Add(entrypointPath);
+        foreach (var arg in args)
+            process.StartInfo.ArgumentList.Add(arg);
+        process.StartInfo.Environment["PATH"] = binDir + Path.PathSeparator + (Environment.GetEnvironmentVariable("PATH") ?? string.Empty);
+        process.StartInfo.Environment["CDIDX_TRACE"] = tracePath;
+        process.StartInfo.Environment["CDIDX_RUN_UID"] = targetUid;
+        process.StartInfo.Environment["CDIDX_RUN_GID"] = targetGid;
+
+        process.Start();
+        if (!process.WaitForExit(5000))
+        {
+            process.Kill(entireProcessTree: true);
+            throw new TimeoutException("docker-entrypoint.sh fixture did not exit within 5 seconds.");
+        }
+
+        return (process.ExitCode, process.StandardOutput.ReadToEnd(), process.StandardError.ReadToEnd());
+    }
+
+    private static void WriteExecutable(string path, string content)
+    {
+        File.WriteAllText(path, content.ReplaceLineEndings("\n"), new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+        if (OperatingSystem.IsWindows())
+            throw new PlatformNotSupportedException("Executable fixture permissions require a Unix filesystem.");
+
+        File.SetUnixFileMode(
+            path,
+            UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+            UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+            UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+    }
+}


### PR DESCRIPTION
## Summary

- Document the official GHCR image contract for base image digests, SDK/runtime version split, musl RID mapping, runtime package allowlist, and entrypoint privilege dropping.
- Add release workflow contract tests for Dockerfile comments, runtime package/RID invariants, and `docker-entrypoint.sh` root-drop/explicit-root behavior.
- Add a changelog fragment for #4157.

## Documentation and Changelog

- Updated `DISTRIBUTION.md` with the container image contract and release checklist coverage.
- Added `changelog.d/unreleased/4157.security.md`.

## Validation

- `git diff --check`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-restore -p:BuildInParallel=false -m:1`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net9.0 --no-restore -p:BuildInParallel=false -m:1`
- `dotnet run --no-build --project tools/CodeIndex.Changelog -- check`
- Direct `docker-entrypoint.sh` shell fixture for root-drop and explicit-root paths
- Adversarial review of `main...fix-issue4157` per `.codex/workflows/adversarial-review.md`: No blocking/actionable issues found.

`dotnet test` was attempted with the targeted release workflow filter, but VSTest could not bind its local socket in this environment, even after escalation. `dotnet format whitespace` was attempted and failed with a Roslyn build host timeout.

Fixes #4157