### PR TITLE
Fix Python spans and hotspot counts for #4159

### DIFF
--- a/changelog.d/unreleased/4159.fixed.md
+++ b/changelog.d/unreleased/4159.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 4159
+affected:
+  - src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+  - src/CodeIndex/Database/DbSymbolReader.cs
+---
+
+## English
+
+- **Fixed Python symbol spans and file hotspot counts (#4159)** — annotated and multiline Python function/class headers now report their full symbol spans, and file hotspot `symbol_count` now matches the filtered file symbol summary instead of counting only referenced hotspot rows.
+
+## 日本語
+
+- **Python の symbol span と file hotspot の count を修正しました (#4159)** — アノテーション付きおよび複数行の Python 関数/クラスヘッダーが完全な symbol span を返すようになり、file hotspot の `symbol_count` は参照された hotspot 行だけでなくフィルタ後のファイル別 symbol summary と一致するようになりました。

--- a/src/CodeIndex/Database/DbSymbolReader.cs
+++ b/src/CodeIndex/Database/DbSymbolReader.cs
@@ -2775,6 +2775,7 @@ public partial class DbReader
         if (!_hasReferencesTable) return [];
         var query = BuildSymbolHotspotRowsQuery(kind, lang, pathPatterns, excludePathPatterns, excludeTests, visibilityFilters, excludeVisibilityFilters);
         var genericNamePenaltySql = GetGenericHotspotNamePenaltySql("gr.name");
+        var fileSymbolCountSql = "MAX(fsc.symbol_count)";
         var structuralRankPenaltySql = GetFileHotspotStructuralRankPenaltySql("COUNT(*)");
         var sql = query.Sql + @"
             SELECT gr.path,
@@ -2788,9 +2789,12 @@ public partial class DbReader
                        ELSE 1.0
                    END AS generic_name_penalty,
                    (" + structuralRankPenaltySql + @") AS structural_rank_penalty,
-                   COUNT(*) AS symbol_count
+                   " + fileSymbolCountSql + @" AS symbol_count
             FROM grouped_rows gr
             JOIN reference_counts rc ON rc.symbol_id = gr.symbol_id
+            JOIN file_symbol_counts fsc
+              ON fsc.path = gr.path
+             AND fsc.lang_key = COALESCE(gr.lang, '')
             WHERE rc.ref_count > 0
             GROUP BY gr.path, gr.lang
             ORDER BY ranking_score DESC,
@@ -3200,6 +3204,13 @@ public partial class DbReader
                   ON crc.logical_target_key = gr.logical_target_key
                  AND crc.name = gr.name
                  AND crc.kind = gr.kind
+            ),
+            file_symbol_counts AS (
+                SELECT path,
+                       COALESCE(lang, '') AS lang_key,
+                       COUNT(*) AS symbol_count
+                FROM filtered_candidates
+                GROUP BY path, COALESCE(lang, '')
             )";
         return new SymbolHotspotRowsQuery(sql, graphLangs, hotspotFamilyLangs);
     }

--- a/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
+++ b/src/CodeIndex/Indexer/Symbols/SymbolExtractor.Python.cs
@@ -117,13 +117,21 @@ public static partial class SymbolExtractor
         return endExclusive == text.Length ? text : text[..endExclusive];
     }
 
-    private static (int EndLine, int? BodyStartLine, int? BodyEndLine) FindPythonIndentedBodyRange(string[] lines, int startLineIndex)
+    private static (int EndLine, int? BodyStartLine, int? BodyEndLine) FindPythonIndentedBodyRange(string[] lines, int startLineIndex, int startColumn = 0)
     {
         var declarationIndent = CountIndent(lines[startLineIndex]);
-        int? firstBodyLine = null;
-        var lastBodyLine = startLineIndex + 1;
+        var (headerEndLineIndex, colonColumn) = FindPythonLogicalHeaderColon(lines, startLineIndex, startColumn);
+        if (colonColumn >= 0)
+        {
+            var suffix = lines[headerEndLineIndex][(colonColumn + 1)..].Trim();
+            if (suffix.Length > 0 && !suffix.StartsWith('#'))
+                return (headerEndLineIndex + 1, headerEndLineIndex + 1, headerEndLineIndex + 1);
+        }
 
-        for (var i = startLineIndex + 1; i < lines.Length; i++)
+        int? firstBodyLine = null;
+        var lastBodyLine = headerEndLineIndex + 1;
+
+        for (var i = headerEndLineIndex + 1; i < lines.Length; i++)
         {
             if (string.IsNullOrWhiteSpace(lines[i]))
                 continue;
@@ -138,7 +146,67 @@ public static partial class SymbolExtractor
 
         return firstBodyLine.HasValue
             ? (lastBodyLine, firstBodyLine.Value, lastBodyLine)
-            : (startLineIndex + 1, null, null);
+            : (headerEndLineIndex + 1, null, null);
+    }
+
+    private static (int LineIndex, int ColonColumn) FindPythonLogicalHeaderColon(string[] lines, int startLineIndex, int startColumn)
+    {
+        var parenDepth = 0;
+        var bracketDepth = 0;
+        var braceDepth = 0;
+        var inString = false;
+        var quote = '\0';
+
+        for (var i = startLineIndex; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            var column = i == startLineIndex ? Math.Clamp(startColumn, 0, line.Length) : 0;
+            for (var j = column; j < line.Length; j++)
+            {
+                var ch = line[j];
+                if (inString)
+                {
+                    if (ch == '\\')
+                    {
+                        j++;
+                        continue;
+                    }
+
+                    if (ch == quote)
+                        inString = false;
+                    continue;
+                }
+
+                if (ch is '\'' or '"')
+                {
+                    inString = true;
+                    quote = ch;
+                    continue;
+                }
+
+                if (ch == '#')
+                    break;
+                if (ch == '(')
+                    parenDepth++;
+                else if (ch == ')' && parenDepth > 0)
+                    parenDepth--;
+                else if (ch == '[')
+                    bracketDepth++;
+                else if (ch == ']' && bracketDepth > 0)
+                    bracketDepth--;
+                else if (ch == '{')
+                    braceDepth++;
+                else if (ch == '}' && braceDepth > 0)
+                    braceDepth--;
+                else if (ch == ':' && parenDepth == 0 && bracketDepth == 0 && braceDepth == 0)
+                    return (i, j);
+            }
+
+            if (parenDepth == 0 && bracketDepth == 0 && braceDepth == 0 && !EndsWithPythonLineContinuation(line))
+                return (i, -1);
+        }
+
+        return (startLineIndex, -1);
     }
 
     private static string BuildPythonLogicalHeaderSignature(string[] lines, int startLineIndex, int startColumn)
@@ -1296,46 +1364,7 @@ public static partial class SymbolExtractor
 
     private static (int EndLine, int? BodyStartLine, int? BodyEndLine) FindIndentRange(string[] lines, int startIndex)
     {
-        var currentLine = lines[startIndex];
-        var currentIndent = CountIndent(currentLine);
-        var trimmedCurrent = currentLine.Trim();
-
-        if (trimmedCurrent.Contains(':'))
-        {
-            var suffix = trimmedCurrent[(trimmedCurrent.IndexOf(':') + 1)..].Trim();
-            if (suffix.Length > 0 && !suffix.StartsWith('#'))
-                return (startIndex + 1, startIndex + 1, startIndex + 1);
-        }
-
-        int? bodyStartLine = null;
-        int endLine = startIndex + 1;
-
-        for (int i = startIndex + 1; i < lines.Length; i++)
-        {
-            var trimmed = lines[i].Trim();
-            if (trimmed.Length == 0)
-                continue;
-
-            var indent = CountIndent(lines[i]);
-            if (bodyStartLine == null)
-            {
-                if (indent <= currentIndent)
-                    return (endLine, null, null);
-
-                bodyStartLine = i + 1;
-                endLine = i + 1;
-                continue;
-            }
-
-            if (indent <= currentIndent)
-                return (endLine, bodyStartLine, endLine);
-
-            endLine = i + 1;
-        }
-
-        return bodyStartLine == null
-            ? (startIndex + 1, null, null)
-            : (endLine, bodyStartLine, endLine);
+        return FindPythonIndentedBodyRange(lines, startIndex);
     }
 
 }

--- a/tests/CodeIndex.Tests/DbReaderIssue4159Tests.cs
+++ b/tests/CodeIndex.Tests/DbReaderIssue4159Tests.cs
@@ -1,0 +1,26 @@
+namespace CodeIndex.Tests;
+
+public partial class DbReaderTests
+{
+    [Fact]
+    public void GetFileSymbolHotspots_SymbolCountIncludesUnreferencedFilteredSymbols_Issue4159()
+    {
+        InsertIndexedFile("src/file_hotspot_symbol_count.py", "python",
+            "def ReferencedTarget():\n    return True\n\n" +
+            "def UnreferencedTarget():\n    return True\n\n" +
+            "def use_target():\n    ReferencedTarget()\n");
+
+        var results = _reader.GetFileSymbolHotspots(
+            limit: 10,
+            kind: "function",
+            lang: "python",
+            pathPatterns: ["src/file_hotspot_symbol_count.py"],
+            excludePathPatterns: null,
+            excludeTests: false);
+
+        var file = Assert.Single(results);
+        Assert.Equal("src/file_hotspot_symbol_count.py", file.Path);
+        Assert.Equal(1, file.ReferenceCount);
+        Assert.Equal(3, file.SymbolCount);
+    }
+}

--- a/tests/CodeIndex.Tests/DbReaderTests.cs
+++ b/tests/CodeIndex.Tests/DbReaderTests.cs
@@ -1734,14 +1734,14 @@ public partial class DbReaderTests : IDisposable
                 Assert.Equal("src/file_hotspot_one.py", first.Path);
                 Assert.Equal("python", first.Lang);
                 Assert.Equal(3, first.ReferenceCount);
-                Assert.Equal(2, first.SymbolCount);
+                Assert.Equal(3, first.SymbolCount);
             },
             second =>
             {
                 Assert.Equal("src/file_hotspot_two.py", second.Path);
                 Assert.Equal("python", second.Lang);
                 Assert.Equal(2, second.ReferenceCount);
-                Assert.Equal(1, second.SymbolCount);
+                Assert.Equal(2, second.SymbolCount);
             });
     }
 

--- a/tests/CodeIndex.Tests/SymbolExtractorPythonIssue4159Tests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorPythonIssue4159Tests.cs
@@ -1,0 +1,50 @@
+using CodeIndex.Indexer;
+
+namespace CodeIndex.Tests;
+
+public partial class SymbolExtractorTests
+{
+    [Fact]
+    public void Extract_Python_UsesLogicalHeaderColonForAnnotatedSpans_Issue4159()
+    {
+        const string content = """
+            def evaluate_bash_command(command: str, *, strict: bool = False) -> bool:
+                if strict:
+                    return command.startswith("safe")
+                return True
+
+            def _split_command(
+                command: str,
+                fallback: str | None = None,
+            ) -> list[str]:
+                parts = command.split()
+                return parts
+
+            class CommandEvaluator(
+                BaseEvaluator,
+            ):
+                def run(self) -> None:
+                    pass
+            """;
+
+        var symbols = SymbolExtractor.Extract(1, "python", content);
+
+        var evaluate = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "evaluate_bash_command");
+        Assert.Equal(1, evaluate.StartLine);
+        Assert.Equal(4, evaluate.EndLine);
+        Assert.Equal(2, evaluate.BodyStartLine);
+        Assert.Equal(4, evaluate.BodyEndLine);
+
+        var split = Assert.Single(symbols, s => s.Kind == "function" && s.Name == "_split_command");
+        Assert.Equal(6, split.StartLine);
+        Assert.Equal(11, split.EndLine);
+        Assert.Equal(10, split.BodyStartLine);
+        Assert.Equal(11, split.BodyEndLine);
+
+        var evaluator = Assert.Single(symbols, s => s.Kind == "class" && s.Name == "CommandEvaluator");
+        Assert.Equal(13, evaluator.StartLine);
+        Assert.Equal(17, evaluator.EndLine);
+        Assert.Equal(16, evaluator.BodyStartLine);
+        Assert.Equal(17, evaluator.BodyEndLine);
+    }
+}


### PR DESCRIPTION
## Summary
- Fix Python symbol span detection so annotated and multiline function/class headers use the real logical header colon.
- Count all filtered file symbols in file-grouped hotspots instead of only referenced hotspot rows.
- Add #4159 regression coverage and update the existing file-hotspot symbol count expectation.

## Validation
- `git diff --cached --check`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore -m:1 -nr:false -p:UseSharedCompilation=false`
- `dotnet run --project tools/CodeIndex.Changelog --no-restore -- check`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --no-build -m:1 -nr:false -p:UseSharedCompilation=false --filter 'FullyQualifiedName~Issue4159|FullyQualifiedName~GetFileSymbolHotspots'`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --no-build -m:1 -nr:false -p:UseSharedCompilation=false --filter 'FullyQualifiedName~Python|FullyQualifiedName~GetFileSymbolHotspots'`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Adversarial review: `codex exec` could not run because the account hit the usage limit; manual review found no blocking/actionable issues.

## Documentation and changelog
- Added changelog fragment: `changelog.d/unreleased/4159.fixed.md`.
- No README or guide update was needed because this fixes existing Python span and hotspot count behavior without adding user-facing commands or flags.

## Follow-up candidates
- None.

Fixes #4159
