### PR TITLE
Add documentation drift checks for guides and workflows

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -59,6 +59,8 @@ The test project mirrors the production areas closely.
   `InstallScriptTests.RunInstallerSnippet` enforces a bounded timeout and kills the snippet process tree on timeout, so installer regressions fail with captured output instead of hanging the suite.
 - `CiWorkflowTests.cs`, `ReleaseWorkflowTests.cs`, `ReleaseWorkflowTests.PackageHelpers.cs`
   CI and release workflow contract tests. Release workflow package-normalization ZIP fixture helpers live in `ReleaseWorkflowTests.PackageHelpers.cs` so workflow assertions stay near the workflow contracts.
+- `DocumentationStatusContractTests.cs`, `DocumentationDriftTests.cs`
+  Checked-in documentation contract tests. They use `RepositoryTestPaths` to keep status fields, workflow references, documented `cdidx` command examples, release/changelog workflow snippets, and representative English/Japanese guide sections synchronized.
 - `IndexCommandRunnerTests.Run_CancelDuringFreshIndex_ReturnsInterruptedJson`, `Run_CancelDuringDryRunScan_ReturnsInterruptedJson`, and `Run_CancelBeforeFreshScan_ReturnsInterruptedJson`
   exercise the same in-process cancellation paths used after Ctrl-C/SIGINT wiring, including scan-time cancellation, so interrupted index runs keep returning the canonical JSON error contract.
 - `IndexCommandRunnerTests.SymbolExtractionWorker_LegacyEnvironmentHooksAreIgnored_Issue3398`
@@ -307,6 +309,8 @@ dotnet test --filter "FullyQualifiedName~GitHelperTests"
   `InstallScriptTests.RunInstallerSnippet` は bounded timeout を強制し、timeout 時は snippet の process tree を kill するため、installer 回帰は suite を hang させずに captured output 付きで失敗します。
 - `CiWorkflowTests.cs`、`ReleaseWorkflowTests.cs`、`ReleaseWorkflowTests.PackageHelpers.cs`
   CI と release workflow の契約テスト。Release workflow の package-normalization ZIP fixture helper は `ReleaseWorkflowTests.PackageHelpers.cs` に置き、workflow assertion が workflow 契約の近くに残るようにします。
+- `DocumentationStatusContractTests.cs`、`DocumentationDriftTests.cs`
+  checked-in documentation の契約テスト。`RepositoryTestPaths` を使って、status field、workflow 参照、文書化された `cdidx` コマンド例、release/changelog workflow の snippet、代表的な英日 guide セクションの同期を維持します。
 - `IndexCommandRunnerTests.Run_CancelDuringFreshIndex_ReturnsInterruptedJson`、`Run_CancelDuringDryRunScan_ReturnsInterruptedJson`、`Run_CancelBeforeFreshScan_ReturnsInterruptedJson`
   Ctrl-C/SIGINT 配線後に使われる in-process cancellation 経路を、scan 中のキャンセルも含めて検証し、interrupted index run が標準の JSON error contract を返し続けることを固定する。
 - `IndexCommandRunnerTests.SymbolExtractionWorker_LegacyEnvironmentHooksAreIgnored_Issue3398`

--- a/changelog.d/unreleased/4160.added.md
+++ b/changelog.d/unreleased/4160.added.md
@@ -1,0 +1,16 @@
+---
+category: added
+issues:
+  - 4160
+affected:
+  - TESTING_GUIDE.md
+  - tests/CodeIndex.Tests/DocumentationDriftTests.cs
+---
+
+## English
+
+- **Documentation drift checks now cover guide and workflow references (#4160)** — the test suite now verifies workflow index consistency, documented `cdidx` command examples, release/changelog workflow snippets, and representative English/Japanese guide sections.
+
+## 日本語
+
+- **guide と workflow 参照の documentation drift チェックを追加しました (#4160)** — テストスイートが workflow index の整合性、文書化された `cdidx` コマンド例、release/changelog workflow の snippet、代表的な英日 guide セクションを検証するようになりました。

--- a/tests/CodeIndex.Tests/DocumentationDriftTests.cs
+++ b/tests/CodeIndex.Tests/DocumentationDriftTests.cs
@@ -12,16 +12,24 @@ public sealed class DocumentationDriftTests
         @"`(?<file>[A-Za-z0-9_.-]+\.md)`",
         RegexOptions.Compiled);
 
-    private static readonly Regex CdidxCommandReferenceRegex = new(
-        @"(?:^|[`|>\s])(?<prefix>cdidx|dotnet\s+\./src/CodeIndex/bin/Debug/net8\.0/cdidx\.dll|dotnet\s+run\s+--project\s+src/CodeIndex\s+--)\s+(?<token>[^\s`|;&]+)",
+    private static readonly Regex CdidxCommandLineRegex = new(
+        @"^\s*(?:[$>]\s*)?(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?<prefix>cdidx|dotnet\s+\./src/CodeIndex/bin/Debug/net8\.0/cdidx\.dll|dotnet\s+run\s+--project\s+src/CodeIndex\s+--)\s+(?<token>[^\s`|;&]+)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex InlineCdidxCommandReferenceRegex = new(
+        @"`(?:[A-Z_][A-Z0-9_]*=\S+\s+)*(?<prefix>cdidx|dotnet\s+\./src/CodeIndex/bin/Debug/net8\.0/cdidx\.dll|dotnet\s+run\s+--project\s+src/CodeIndex\s+--)\s+(?<token>[^\s`|;&]+)[^`]*`",
         RegexOptions.Compiled);
 
     private static readonly HashSet<string> KnownCdidxEntrypointTokens = new(StringComparer.Ordinal)
     {
         "--completions",
+        "--check-updates",
+        "--debug-unsafe",
         "--help",
         "--help-all",
         "--help-flags",
+        "--strict-version",
+        "--sushi",
         "--version",
         "audit",
         "backfill-fold",
@@ -60,6 +68,7 @@ public sealed class DocumentationDriftTests
         "status",
         "suggestions",
         "symbols",
+        "test-extractor",
         "unused",
         "upgrade",
         "vacuum",
@@ -104,10 +113,18 @@ public sealed class DocumentationDriftTests
         {
             var content = RepositoryTestPaths.ReadText(relativePath.Split('/'));
             var lines = content.ReplaceLineEndings("\n").Split('\n');
+            var inFencedCodeBlock = false;
 
             for (var lineNumber = 0; lineNumber < lines.Length; lineNumber++)
             {
-                foreach (Match match in CdidxCommandReferenceRegex.Matches(lines[lineNumber]))
+                var line = lines[lineNumber];
+                if (line.TrimStart().StartsWith("```", StringComparison.Ordinal))
+                {
+                    inFencedCodeBlock = !inFencedCodeBlock;
+                    continue;
+                }
+
+                foreach (var match in EnumerateCdidxCommandMatches(line, inFencedCodeBlock))
                 {
                     var token = NormalizeCdidxToken(match.Groups["token"].Value);
                     if (ShouldSkipCdidxEntrypointToken(token))
@@ -211,6 +228,19 @@ public sealed class DocumentationDriftTests
             yield return ToRepositoryRelativePath(docsPath);
     }
 
+    private static IEnumerable<Match> EnumerateCdidxCommandMatches(string line, bool includeCommandLineMatches)
+    {
+        if (includeCommandLineMatches)
+        {
+            var lineMatch = CdidxCommandLineRegex.Match(line);
+            if (lineMatch.Success)
+                yield return lineMatch;
+        }
+
+        foreach (Match match in InlineCdidxCommandReferenceRegex.Matches(line))
+            yield return match;
+    }
+
     private static string NormalizeCdidxToken(string token)
     {
         return token.Trim().TrimEnd('.', ',', ':', ')', ']');
@@ -219,6 +249,9 @@ public sealed class DocumentationDriftTests
     private static bool ShouldSkipCdidxEntrypointToken(string token)
     {
         if (string.IsNullOrWhiteSpace(token))
+            return true;
+
+        if (token.StartsWith('v') && token.Length > 1 && char.IsDigit(token[1]))
             return true;
 
         return token[0] is '.' or '/' or '\\' or '~' or '$' or '%' or '<' or '[' or '{' or '"';

--- a/tests/CodeIndex.Tests/DocumentationDriftTests.cs
+++ b/tests/CodeIndex.Tests/DocumentationDriftTests.cs
@@ -1,0 +1,232 @@
+using System.Text.RegularExpressions;
+
+namespace CodeIndex.Tests;
+
+public sealed class DocumentationDriftTests
+{
+    private static readonly Regex WorkflowPathReferenceRegex = new(
+        @"(?<path>\.codex/workflows/[A-Za-z0-9_.-]+\.md)",
+        RegexOptions.Compiled);
+
+    private static readonly Regex MarkdownFileReferenceRegex = new(
+        @"`(?<file>[A-Za-z0-9_.-]+\.md)`",
+        RegexOptions.Compiled);
+
+    private static readonly Regex CdidxCommandReferenceRegex = new(
+        @"(?:^|[`|>\s])(?<prefix>cdidx|dotnet\s+\./src/CodeIndex/bin/Debug/net8\.0/cdidx\.dll|dotnet\s+run\s+--project\s+src/CodeIndex\s+--)\s+(?<token>[^\s`|;&]+)",
+        RegexOptions.Compiled);
+
+    private static readonly HashSet<string> KnownCdidxEntrypointTokens = new(StringComparer.Ordinal)
+    {
+        "--completions",
+        "--help",
+        "--help-all",
+        "--help-flags",
+        "--version",
+        "audit",
+        "backfill-fold",
+        "batch",
+        "callees",
+        "callers",
+        "completions",
+        "config",
+        "db",
+        "definition",
+        "deps",
+        "diff",
+        "doctor",
+        "excerpt",
+        "export",
+        "files",
+        "find",
+        "goto",
+        "hooks",
+        "hotspots",
+        "impact",
+        "import",
+        "index",
+        "inspect",
+        "languages",
+        "license",
+        "lsp",
+        "map",
+        "mcp",
+        "optimize",
+        "outline",
+        "recipes",
+        "references",
+        "report",
+        "search",
+        "status",
+        "suggestions",
+        "symbols",
+        "unused",
+        "upgrade",
+        "vacuum",
+        "validate",
+        "validate-config",
+        "workspace",
+    };
+
+    [Fact]
+    public void WorkflowIndexAndDirectoryMap_StaySynchronized_Issue4160()
+    {
+        var workflowPaths = Directory
+            .EnumerateFiles(RepositoryTestPaths.Combine(".codex", "workflows"), "*.md")
+            .Select(ToRepositoryRelativePath)
+            .Where(path => !StringComparer.Ordinal.Equals(path, ".codex/workflows/README.md"))
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        var workflowFileNames = workflowPaths
+            .Select(path => Path.GetFileName(path) ?? throw new InvalidOperationException($"Missing file name for {path}."))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var guideReferences = ExtractWorkflowPathReferences("AGENT_GUIDE.md");
+        var workflowReadmeReferences = ExtractWorkflowReadmeReferences(workflowFileNames);
+
+        foreach (var reference in guideReferences.Concat(workflowReadmeReferences).Distinct(StringComparer.Ordinal))
+        {
+            var absolutePath = RepositoryTestPaths.Combine(reference.Split('/'));
+            Assert.True(File.Exists(absolutePath), $"{reference} is referenced but does not exist.");
+            Assert.NotEqual(0, new FileInfo(absolutePath).Length);
+        }
+
+        Assert.Empty(workflowPaths.Except(guideReferences, StringComparer.Ordinal));
+        Assert.Empty(workflowPaths.Except(workflowReadmeReferences, StringComparer.Ordinal));
+    }
+
+    [Fact]
+    public void DocumentedCdidxExamples_UseKnownEntrypointTokens_Issue4160()
+    {
+        var failures = new List<string>();
+
+        foreach (var relativePath in EnumerateDocumentationCommandReferenceFiles())
+        {
+            var content = RepositoryTestPaths.ReadText(relativePath.Split('/'));
+            var lines = content.ReplaceLineEndings("\n").Split('\n');
+
+            for (var lineNumber = 0; lineNumber < lines.Length; lineNumber++)
+            {
+                foreach (Match match in CdidxCommandReferenceRegex.Matches(lines[lineNumber]))
+                {
+                    var token = NormalizeCdidxToken(match.Groups["token"].Value);
+                    if (ShouldSkipCdidxEntrypointToken(token))
+                        continue;
+
+                    if (!KnownCdidxEntrypointTokens.Contains(token))
+                    {
+                        failures.Add(
+                            $"{relativePath}:{lineNumber + 1}: unknown cdidx command/reference token '{token}' in '{match.Value.Trim()}'.");
+                    }
+                }
+            }
+        }
+
+        Assert.Empty(failures);
+    }
+
+    [Theory]
+    [InlineData("README.md", "## Quick Start", "## すぐに試す")]
+    [InlineData("USER_GUIDE.md", "## Why cdidx", "## なぜ cdidx なのか")]
+    [InlineData("DEVELOPER_GUIDE.md", "## Build & Test", "## ビルド・テスト")]
+    [InlineData("TESTING_GUIDE.md", "## Test Layout", "## テスト構成")]
+    [InlineData("docs/large-file-decomposition-plan.md", "## Baseline", "## ベースライン")]
+    public void BilingualGuides_KeepRepresentativeEnglishAndJapaneseSections_Issue4160(
+        string relativePath,
+        string englishHeading,
+        string japaneseHeading)
+    {
+        var content = RepositoryTestPaths.ReadText(relativePath.Split('/'));
+
+        Assert.Contains("日本語版はこちら / Japanese version", content, StringComparison.Ordinal);
+        Assert.Contains(englishHeading, content, StringComparison.Ordinal);
+        Assert.Contains(japaneseHeading, content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ReleaseAndChangelogWorkflowDocs_KeepFragmentContractsVisible_Issue4160()
+    {
+        var issueFix = RepositoryTestPaths.ReadText(".codex", "workflows", "issue-fix.md");
+        var fragment = RepositoryTestPaths.ReadText(".codex", "workflows", "changelog-fragment.md");
+        var release = RepositoryTestPaths.ReadText(".codex", "workflows", "release-changelog.md");
+
+        Assert.Contains("changelog.d/unreleased/", issueFix, StringComparison.Ordinal);
+        Assert.Contains("changelog.d/unreleased/", fragment, StringComparison.Ordinal);
+        Assert.Contains("## English", fragment, StringComparison.Ordinal);
+        Assert.Contains("## 日本語", fragment, StringComparison.Ordinal);
+        Assert.Contains(
+            "dotnet run --project tools/CodeIndex.Changelog -- check",
+            fragment,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "dotnet run --project tools/CodeIndex.Changelog -- prepare",
+            release,
+            StringComparison.Ordinal);
+        Assert.Contains("aggregate fragments into both the English and 日本語 sections", release, StringComparison.Ordinal);
+        Assert.Contains("CHANGELOG.md", release, StringComparison.Ordinal);
+    }
+
+    private static HashSet<string> ExtractWorkflowPathReferences(string relativePath)
+    {
+        var content = RepositoryTestPaths.ReadText(relativePath.Split('/'));
+        return WorkflowPathReferenceRegex
+            .Matches(content)
+            .Select(match => match.Groups["path"].Value)
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static HashSet<string> ExtractWorkflowReadmeReferences(HashSet<string> workflowFileNames)
+    {
+        var content = RepositoryTestPaths.ReadText(".codex", "workflows", "README.md");
+        return MarkdownFileReferenceRegex
+            .Matches(content)
+            .Select(match => match.Groups["file"].Value)
+            .Where(workflowFileNames.Contains)
+            .Select(fileName => $".codex/workflows/{fileName}")
+            .ToHashSet(StringComparer.Ordinal);
+    }
+
+    private static IEnumerable<string> EnumerateDocumentationCommandReferenceFiles()
+    {
+        var rootFiles = new[]
+        {
+            "AGENT_GUIDE.md",
+            "README.md",
+            "USER_GUIDE.md",
+            "DEVELOPER_GUIDE.md",
+            "TESTING_GUIDE.md",
+            "SELF_IMPROVEMENT.md",
+            "INTEGRATION_POLICY.md",
+            "DISTRIBUTION.md",
+            "CLOUD_BOOTSTRAP_PROMPT.md",
+        };
+
+        foreach (var relativePath in rootFiles)
+            yield return relativePath;
+
+        foreach (var workflowPath in Directory.EnumerateFiles(RepositoryTestPaths.Combine(".codex", "workflows"), "*.md"))
+            yield return ToRepositoryRelativePath(workflowPath);
+
+        foreach (var docsPath in Directory.EnumerateFiles(RepositoryTestPaths.Combine("docs"), "*.md"))
+            yield return ToRepositoryRelativePath(docsPath);
+    }
+
+    private static string NormalizeCdidxToken(string token)
+    {
+        return token.Trim().TrimEnd('.', ',', ':', ')', ']');
+    }
+
+    private static bool ShouldSkipCdidxEntrypointToken(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return true;
+
+        return token[0] is '.' or '/' or '\\' or '~' or '$' or '%' or '<' or '[' or '{' or '"';
+    }
+
+    private static string ToRepositoryRelativePath(string absolutePath)
+    {
+        return Path.GetRelativePath(RepositoryTestPaths.Root, absolutePath)
+            .Replace(Path.DirectorySeparatorChar, '/');
+    }
+}


### PR DESCRIPTION
## Summary

- Add `DocumentationDriftTests` to catch guide/workflow drift across workflow indexes, documented `cdidx` command examples, release/changelog workflow snippets, and representative bilingual guide sections.
- Update `TESTING_GUIDE.md` in both English and Japanese sections to document the new checked-in documentation contract tests.
- Add changelog fragment `changelog.d/unreleased/4160.added.md`.

## Validation

- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-restore --disable-build-servers /m:1 /nr:false -p:BuildInParallel=false -p:UseSharedCompilation=false -p:NuGetAudit=false` passed.
- `dotnet tools/CodeIndex.Changelog/bin/Debug/net8.0/CodeIndex.Changelog.dll check` passed.
- Manual command-token check using the same fenced/inline extraction logic returned `NO_FAILURES` against the current checkout.
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --filter "FullyQualifiedName~DocumentationDriftTests" --no-build --no-restore --disable-build-servers /m:1 /nr:false -p:BuildInParallel=false -p:UseSharedCompilation=false -p:NuGetAudit=false` could not run in this sandbox because VSTest failed to bind its localhost communication socket with `System.Net.Sockets.SocketException (13): Permission denied`.
- `dotnet format CodeIndex.sln --verify-no-changes --no-restore --verbosity minimal` could not run in this sandbox because Roslyn/MSBuild build host pipe connection timed out.

## Documentation and changelog

- Updated `TESTING_GUIDE.md` English and Japanese sections.
- Added changelog fragment `changelog.d/unreleased/4160.added.md`.

## Follow-up candidates

None.

Fixes #4160