### PR TITLE
Allow Codex normal GitHub CLI workflow commands

### DIFF
--- a/.agent_harness/command_guard_core.py
+++ b/.agent_harness/command_guard_core.py
@@ -618,10 +618,19 @@ def _tokenized_gh_reason(args: list[str]) -> str | None:
         return _HIGH_RISK_UNKNOWN_GLOBAL_OPTION_REASON
     if subcommand in {"auth", "api", "secret", "release"}:
         return "GitHub CLI high-risk operation is blocked"
-    if subcommand == "repo" and rest and rest[0] in {"create", "fork"}:
-        return "GitHub CLI high-risk operation is blocked"
+    if subcommand == "repo":
+        repo_subcommand, _ = _subcommand_args(
+            rest,
+            {"-R", "--repo", "--hostname", "--config"},
+            valueless_options={"--help", "-h"},
+            fail_on_unknown_option=True,
+        )
+        if repo_subcommand == _UNKNOWN_GLOBAL_OPTION_SUBCOMMAND:
+            return _HIGH_RISK_UNKNOWN_GLOBAL_OPTION_REASON
+        if repo_subcommand in {"create", "fork", "delete"}:
+            return "GitHub CLI high-risk operation is blocked"
     if subcommand == "pr":
-        pr_subcommand, pr_rest = _subcommand_args(
+        pr_subcommand, _ = _subcommand_args(
             rest,
             {"-R", "--repo", "--hostname", "--config"},
             valueless_options={"--help", "-h", "--web"},

--- a/.agent_harness/tests/test_command_guard_core.py
+++ b/.agent_harness/tests/test_command_guard_core.py
@@ -234,18 +234,45 @@ class CommandGuardCoreTests(TestCase):
                 decision = core.evaluate_bash_command(command, cwd=root, project_root=root)
                 self.assertFalse(decision.allowed)
 
-    def test_allows_forbidden_command_words_inside_gh_arguments(self) -> None:
+    def test_allows_normal_development_gh_commands(self) -> None:
         root = Path("/tmp")
         for command in (
-            'gh issue create --title "cdidx" --body "plain issue text"',
-            'gh issue create --title "find and open are issue words" --body "cdidx find appears in docs"',
-            'gh issue list --state open --search "grep in the issue body"',
-            'gh pr create --title "search: find hint" --body "users may type git grep or open here"',
+            'gh issue list --repo Widthdom/CodeIndex --state open --limit 10 --search "grep in the issue body"',
+            "gh issue view 123 --repo Widthdom/CodeIndex",
+            'gh issue create --repo Widthdom/CodeIndex --title "find and open are issue words" --body "cdidx find appears in docs"',
+            "gh issue edit 123 --repo Widthdom/CodeIndex --add-label bug",
+            'gh issue comment 123 --repo Widthdom/CodeIndex --body "Working on this"',
+            "gh pr list --repo Widthdom/CodeIndex --state open",
+            "gh pr view 123 --repo Widthdom/CodeIndex",
+            'gh pr create --repo Widthdom/CodeIndex --title "search: find hint" --body "users may type git grep or open here"',
+            "gh pr edit 123 --repo Widthdom/CodeIndex --title update",
+            'gh pr comment 123 --repo Widthdom/CodeIndex --body "Updated"',
+            "gh pr ready 123 --repo Widthdom/CodeIndex",
+            "gh pr close 123 --repo Widthdom/CodeIndex",
+            "gh repo view Widthdom/CodeIndex",
+            "gh status",
         ):
             with self.subTest(command=command):
                 decision = core.evaluate_bash_command(command, cwd=root, project_root=root)
 
                 self.assertTrue(decision.allowed, decision.reason)
+
+    def test_denies_high_risk_gh_commands(self) -> None:
+        root = Path("/tmp")
+        for command in (
+            "gh auth login",
+            "gh api repos/Widthdom/CodeIndex/issues",
+            "gh secret list",
+            "gh release create v0.0.0",
+            "gh repo create demo",
+            "gh repo fork Widthdom/CodeIndex",
+            "gh repo delete Widthdom/CodeIndex",
+            "gh pr merge 123",
+        ):
+            with self.subTest(command=command):
+                decision = core.evaluate_bash_command(command, cwd=root, project_root=root)
+
+                self.assertFalse(decision.allowed)
 
     def test_denies_forbidden_commands_inside_shell_constructs(self) -> None:
         root = Path("/tmp")

--- a/.codex/README.md
+++ b/.codex/README.md
@@ -23,6 +23,15 @@ dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll inspect src/CodeIndex/Indexer/
 The guard hooks block grep-like search escape hatches, global `cdidx`, and
 high-risk commands so Codex stays inside the repository policy.
 
+The `codeindex_workspace` permission profile permits GitHub network access only
+to `github.com` and `api.github.com` for normal development GitHub CLI work.
+Codex may use `gh issue list/view/create/edit/comment`,
+`gh pr list/view/create/edit/comment/ready/close`, `gh repo view`, and
+`gh status`. Authentication, arbitrary `gh api` calls, secrets, releases,
+repository create/fork/delete, and PR merges stay blocked; `gh api` is too broad
+for command-level policy, and `gh pr merge` mutates remote PR state in a
+high-risk way.
+
 ## No-SDK cloud bootstrap
 
 For SDK-less Codex cloud sessions, use `CLOUD_BOOTSTRAP_PROMPT.md`. The guard

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -2,7 +2,6 @@
 # Project-local Codex config loads only after the project is trusted.
 
 project_doc_fallback_filenames = ["AGENTS.md", "CLAUDE.md"]
-sandbox_mode = "workspace-write"
 approval_policy = "on-request"
 web_search = "disabled"
 default_permissions = "codeindex_workspace"
@@ -10,13 +9,9 @@ default_permissions = "codeindex_workspace"
 [features]
 codex_hooks = true
 
-[sandbox_workspace_write]
-network_access = false
-exclude_slash_tmp = true
-exclude_tmpdir_env_var = true
-
-[permissions.codeindex_workspace.filesystem]
-glob_scan_max_depth = 3
+[permissions.codeindex_workspace]
+extends = ":workspace"
+description = "CodeIndex workspace editing with limited GitHub CLI access."
 
 [permissions.codeindex_workspace.filesystem.":workspace_roots"]
 "." = "write"
@@ -31,4 +26,8 @@ glob_scan_max_depth = 3
 "**/*secrets*" = "deny"
 
 [permissions.codeindex_workspace.network]
-enabled = false
+enabled = true
+
+[permissions.codeindex_workspace.network.domains]
+"github.com" = "allow"
+"api.github.com" = "allow"

--- a/.codex/rules/codeindex.rules
+++ b/.codex/rules/codeindex.rules
@@ -412,51 +412,156 @@ prefix_rule(
 )
 
 prefix_rule(
+    pattern = ["gh", "issue", "list"],
+    decision = "allowed",
+    justification = "GitHub CLI issue investigation is part of the normal CodeIndex development workflow.",
+    match = ["gh issue list --repo Widthdom/CodeIndex --state open --limit 10"],
+)
+
+prefix_rule(
+    pattern = ["gh", "issue", "view"],
+    decision = "allowed",
+    justification = "GitHub CLI issue investigation is part of the normal CodeIndex development workflow.",
+    match = ["gh issue view 123 --repo Widthdom/CodeIndex"],
+)
+
+prefix_rule(
+    pattern = ["gh", "issue", "create"],
+    decision = "allowed",
+    justification = "GitHub CLI issue creation is part of the normal CodeIndex development workflow.",
+    match = ["gh issue create --repo Widthdom/CodeIndex --title 'Follow-up' --body 'Details'"],
+)
+
+prefix_rule(
+    pattern = ["gh", "issue", "edit"],
+    decision = "allowed",
+    justification = "GitHub CLI issue editing is part of the normal CodeIndex development workflow.",
+    match = ["gh issue edit 123 --repo Widthdom/CodeIndex --add-label bug"],
+)
+
+prefix_rule(
+    pattern = ["gh", "issue", "comment"],
+    decision = "allowed",
+    justification = "GitHub CLI issue comments are part of the normal CodeIndex development workflow.",
+    match = ["gh issue comment 123 --repo Widthdom/CodeIndex --body 'Working on this'"],
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", "list"],
+    decision = "allowed",
+    justification = "GitHub CLI pull request investigation is part of the normal CodeIndex development workflow.",
+    match = ["gh pr list --repo Widthdom/CodeIndex --state open"],
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", "view"],
+    decision = "allowed",
+    justification = "GitHub CLI pull request investigation is part of the normal CodeIndex development workflow.",
+    match = ["gh pr view 123 --repo Widthdom/CodeIndex"],
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", "create"],
+    decision = "allowed",
+    justification = "GitHub CLI pull request creation is part of the normal CodeIndex development workflow.",
+    match = ["gh pr create --repo Widthdom/CodeIndex --title 'Update' --body 'Details'"],
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", "edit"],
+    decision = "allowed",
+    justification = "GitHub CLI pull request editing is part of the normal CodeIndex development workflow.",
+    match = ["gh pr edit 123 --repo Widthdom/CodeIndex --title 'Updated title'"],
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", "comment"],
+    decision = "allowed",
+    justification = "GitHub CLI pull request comments are part of the normal CodeIndex development workflow.",
+    match = ["gh pr comment 123 --repo Widthdom/CodeIndex --body 'Updated'"],
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", "ready"],
+    decision = "allowed",
+    justification = "GitHub CLI pull request readiness changes are part of the normal CodeIndex development workflow.",
+    match = ["gh pr ready 123 --repo Widthdom/CodeIndex"],
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", "close"],
+    decision = "allowed",
+    justification = "GitHub CLI pull request closing is part of the normal CodeIndex development workflow.",
+    match = ["gh pr close 123 --repo Widthdom/CodeIndex"],
+)
+
+prefix_rule(
+    pattern = ["gh", "repo", "view"],
+    decision = "allowed",
+    justification = "GitHub CLI repository metadata investigation is part of the normal CodeIndex development workflow.",
+    match = ["gh repo view Widthdom/CodeIndex"],
+)
+
+prefix_rule(
+    pattern = ["gh", "status"],
+    decision = "allowed",
+    justification = "GitHub CLI status inspection is part of the normal CodeIndex development workflow.",
+    match = ["gh status"],
+)
+
+prefix_rule(
     pattern = ["gh", "auth"],
     decision = "forbidden",
-    justification = "High-risk GitHub CLI operations are blocked.",
+    justification = "GitHub CLI authentication changes are blocked.",
     match = ["gh auth login"],
 )
 
 prefix_rule(
     pattern = ["gh", "api"],
     decision = "forbidden",
-    justification = "High-risk GitHub CLI operations are blocked.",
+    justification = "Arbitrary GitHub API calls are too powerful for normal development command policy.",
     match = ["gh api repos/Widthdom/CodeIndex"],
 )
 
 prefix_rule(
     pattern = ["gh", "secret"],
     decision = "forbidden",
-    justification = "High-risk GitHub CLI operations are blocked.",
+    justification = "GitHub secret operations are blocked.",
     match = ["gh secret set TOKEN"],
 )
 
 prefix_rule(
     pattern = ["gh", "release"],
     decision = "forbidden",
-    justification = "High-risk GitHub CLI operations are blocked.",
+    justification = "GitHub release publishing operations are blocked.",
     match = ["gh release create v1.0.0"],
 )
 
 prefix_rule(
     pattern = ["gh", "repo", "create"],
     decision = "forbidden",
-    justification = "High-risk GitHub CLI operations are blocked.",
+    justification = "GitHub repository creation is blocked.",
     match = ["gh repo create demo"],
 )
 
 prefix_rule(
     pattern = ["gh", "repo", "fork"],
     decision = "forbidden",
-    justification = "High-risk GitHub CLI operations are blocked.",
+    justification = "GitHub repository forking is blocked.",
     match = ["gh repo fork Widthdom/CodeIndex"],
+)
+
+prefix_rule(
+    pattern = ["gh", "repo", "delete"],
+    decision = "forbidden",
+    justification = "GitHub repository deletion is blocked.",
+    match = ["gh repo delete Widthdom/CodeIndex"],
 )
 
 prefix_rule(
     pattern = ["gh", "pr", "merge"],
     decision = "forbidden",
-    justification = "High-risk GitHub CLI operations are blocked.",
+    justification = "GitHub pull request merge changes remote state and is blocked.",
     match = ["gh pr merge 123"],
 )
 

--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -61,6 +61,9 @@ Command-search enforcement is tool-specific and adapter-driven:
 - Codex uses `.codex/hooks.json`, which invokes `.codex/hooks/bash_guard.py` and `.codex/hooks/permission_request_guard.py`.
 - Claude Code uses `.claude/settings.json`, which invokes `.claude/hooks/bash-guard.py`.
 - Both Bash guard adapters delegate shared command policy to `.agent_harness/command_guard_core.py`; update the shared core for common command policy and review both adapters only when tool-specific behavior changes.
+- Codex uses the `codeindex_workspace` permission profile for workspace writes plus limited GitHub CLI network access to `github.com` and `api.github.com`.
+- Codex may use normal development GitHub CLI commands including `gh issue list/view/create/edit/comment`, `gh pr list/view/create/edit/comment/ready/close`, `gh repo view`, and `gh status`.
+- Keep `gh auth`, `gh api`, `gh secret`, `gh release`, `gh repo create`, `gh repo fork`, `gh repo delete`, and `gh pr merge` blocked. `gh api` is blocked because arbitrary REST/GraphQL calls can bypass subcommand-level policy intent; `gh pr merge` is blocked because it mutates remote PR state in a high-risk way.
 
 ### Claude Code
 

--- a/changelog.d/unreleased/+codex-gh-permissions.changed.md
+++ b/changelog.d/unreleased/+codex-gh-permissions.changed.md
@@ -1,0 +1,16 @@
+---
+category: changed
+affected:
+  - .codex/config.toml
+  - .codex/README.md
+  - .codex/rules/codeindex.rules
+  - .agent_harness/command_guard_core.py
+  - .agent_harness/tests/test_command_guard_core.py
+  - AGENT_GUIDE.md
+---
+
+## English
+- **Codex can use normal-development GitHub CLI commands safely** - The `codeindex_workspace` permission profile now allows network access only to `github.com` and `api.github.com`, while command guards explicitly allow normal Issue/PR development commands such as `gh issue/pr list/view/create/edit/comment`, `gh pr ready`, `gh pr close`, `gh repo view`, and `gh status`, and continue blocking authentication, secrets, releases, repo creation/forking/deletion, arbitrary `gh api`, and PR merges.
+
+## 日本語
+- **Codex が通常開発用の GitHub CLI コマンドを安全に使えるようになりました** - `codeindex_workspace` permission profile は `github.com` と `api.github.com` だけに network access を許可し、command guard は `gh issue/pr list/view/create/edit/comment`、`gh pr ready`、`gh pr close`、`gh repo view`、`gh status` など通常の Issue / PR 開発コマンドを明示的に許可しつつ、認証、secret、release、repo 作成 / fork / delete、任意の `gh api`、PR merge は引き続き禁止します。


### PR DESCRIPTION
## Summary

- Move Codex project config fully to the `codeindex_workspace` permission profile, extending `:workspace` and allowing network access only to `github.com` and `api.github.com`.
- Allow normal development GitHub CLI commands for Issue/PR investigation, creation, editing, comments, PR ready/close, repo view, and status.
- Keep high-risk GitHub CLI operations blocked, including auth, arbitrary `gh api`, secrets, releases, repo create/fork/delete, and PR merge.
- Update Codex docs, shared command guard behavior/tests, agent guidance, and the changelog fragment.

## Validation

- `python3 -m unittest discover -s .agent_harness/tests`
- `python3 -m unittest discover -s .agent_harness/tests -p 'test_command_guard_core.py'`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Live shell `gh repo view Widthdom/CodeIndex --json nameWithOwner,defaultBranchRef` could not complete in this environment because connecting to `api.github.com` failed even after escalation; repository/PR operations were completed through the GitHub connector.

## Documentation and Changelog

- Updated `.codex/README.md` and `AGENT_GUIDE.md` for the allowed/forbidden `gh` command policy and network allowlist.
- Added `changelog.d/unreleased/+codex-gh-permissions.changed.md`.

## Follow-up Candidates

- None.
