### PR TITLE
Fix duplicated suggestions usage prefix

### DIFF
--- a/changelog.d/unreleased/4244.fixed.md
+++ b/changelog.d/unreleased/4244.fixed.md
@@ -1,0 +1,16 @@
+---
+category: fixed
+issues:
+  - 4244
+affected:
+  - src/CodeIndex/Cli/CommandErrorWriter.cs
+  - tests/CodeIndex.Tests/CommandErrorWriterTests.cs
+---
+
+## English
+
+- **Fixed duplicated `Usage:` prefixes in `cdidx suggestions` usage errors (#4244)** - invalid suggestions options now print a single `Usage: cdidx suggestions ...` line.
+
+## 日本語
+
+- **`cdidx suggestions` の usage error で `Usage:` が重複する問題を修正しました (#4244)** - 不正な suggestions option では `Usage: cdidx suggestions ...` 行を 1 回だけ出力します。

--- a/src/CodeIndex/Cli/CommandErrorWriter.cs
+++ b/src/CodeIndex/Cli/CommandErrorWriter.cs
@@ -23,7 +23,7 @@ internal static class CommandErrorWriter
         WriteStderr($"{prefix}: {message}");
         WriteStderr($"Hint: {hint ?? DefaultHint}");
         if (usage != null)
-            WriteStderr($"Usage: {usage}");
+            WriteStderr(FormatUsage(usage));
     }
 
     internal static int Write(
@@ -80,4 +80,7 @@ internal static class CommandErrorWriter
 
     internal static string FormatSanitizedExceptionDetail(Exception ex, int maxMessageChars = 240)
         => DiagnosticRedactor.FormatExceptionDetail(ex, maxMessageChars);
+
+    private static string FormatUsage(string usage)
+        => usage.StartsWith("Usage:", StringComparison.Ordinal) ? usage : $"Usage: {usage}";
 }

--- a/tests/CodeIndex.Tests/CommandErrorWriterTests.cs
+++ b/tests/CodeIndex.Tests/CommandErrorWriterTests.cs
@@ -1,0 +1,33 @@
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+public class CommandErrorWriterTests
+{
+    [Fact]
+    public void Write_DoesNotDuplicateExistingUsagePrefix_Issue4244()
+    {
+        lock (TestConsoleLock.Gate)
+        {
+            var originalError = Console.Error;
+            using var stderr = new StringWriter();
+            try
+            {
+                Console.SetError(stderr);
+
+                CommandErrorWriter.Write(
+                    "unsupported suggestions option.",
+                    hint: "retry with a supported option.",
+                    usage: "Usage: cdidx suggestions <list|show|export>");
+            }
+            finally
+            {
+                Console.SetError(originalError);
+            }
+
+            var output = stderr.ToString();
+            Assert.Contains("Usage: cdidx suggestions <list|show|export>", output);
+            Assert.DoesNotContain("Usage: Usage:", output);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Normalize `CommandErrorWriter` usage output so callers that already include `Usage:` do not produce `Usage: Usage:`.
- Add a focused regression test for the existing-prefix case.
- Add changelog fragment for #4244.

## Validation
- `dotnet build src/CodeIndex/CodeIndex.csproj --no-restore --disable-build-servers -p:UseSharedCompilation=false -v:minimal`
- `dotnet run --project tools/CodeIndex.Changelog --no-restore -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll suggestions list --unknown` (expected usage error; verified single `Usage:` prefix)
- `cdidx status --check` with the clone-local data dir
- Codex adversarial review: No blocking/actionable issues found.

## Not run
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --filter "FullyQualifiedName~CommandErrorWriterTests.Write_DoesNotDuplicateExistingUsagePrefix_Issue4244" -p:UseSharedCompilation=false --logger "console;verbosity=normal"` failed in this environment with `System.Net.Sockets.SocketException (13): Permission denied` while MSBuild tried to create its named pipe node.

Fixes #4244