### PR TITLE
Centralize CLI contract validation

### DIFF
--- a/changelog.d/unreleased/4166.internal.md
+++ b/changelog.d/unreleased/4166.internal.md
@@ -1,0 +1,18 @@
+---
+category: internal
+issues:
+  - 4166
+affected:
+  - src/CodeIndex/Cli/CliContractManifest.cs
+  - tests/CodeIndex.Tests/CliContractManifestTests.cs
+  - tests/CodeIndex.Tests/CliJsonSerializerContextTests.cs
+  - tests/CodeIndex.Tests/CodeIndexExceptionTests.cs
+---
+
+## English
+
+- **CLI machine-contract validation is centralized (#4166)** — tests now use a shared manifest for exit codes, structured error codes, JSON API versioning, source-generated CLI JSON roots, and golden JSON payload families so contract drift is caught in one place.
+
+## 日本語
+
+- **CLI の機械向け契約検証を一箇所に集約しました (#4166)** — exit code、構造化 error code、JSON API version、source-generated CLI JSON root、golden JSON payload family を共有 manifest で検証し、契約 drift を一箇所で検出できるようにしました。

--- a/src/CodeIndex/Cli/CliContractManifest.cs
+++ b/src/CodeIndex/Cli/CliContractManifest.cs
@@ -1,0 +1,99 @@
+using System.Reflection;
+using System.Text.Json.Serialization;
+using CodeIndex.Database;
+
+namespace CodeIndex.Cli;
+
+/// <summary>
+/// Central inventory for stable CLI machine contracts that are otherwise easy to
+/// update independently: process exit codes, structured error codes, JSON API
+/// versioning, source-generated JSON roots, and golden JSON payload families.
+/// CLI の機械向け契約を一箇所で棚卸しする manifest。終了コード、構造化エラーコード、
+/// JSON API version、source-generated JSON root、golden JSON payload family をまとめる。
+/// </summary>
+internal static class CliContractManifest
+{
+    public static string JsonApiVersion => JsonOutputContract.ApiVersion;
+
+    public static IReadOnlyList<CliExitCodeContract> ExitCodes { get; } =
+    [
+        new(nameof(CommandExitCodes.Success), CommandExitCodes.Success),
+        new(nameof(CommandExitCodes.UsageError), CommandExitCodes.UsageError),
+        new(nameof(CommandExitCodes.NotFound), CommandExitCodes.NotFound),
+        new(nameof(CommandExitCodes.DatabaseError), CommandExitCodes.DatabaseError),
+        new(nameof(CommandExitCodes.FeatureUnavailable), CommandExitCodes.FeatureUnavailable),
+        new(nameof(CommandExitCodes.StaleIndex), CommandExitCodes.StaleIndex),
+        new(nameof(CommandExitCodes.TransientDatabaseError), CommandExitCodes.TransientDatabaseError),
+        new(nameof(CommandExitCodes.InvalidArgument), CommandExitCodes.InvalidArgument),
+        new(nameof(CommandExitCodes.CancelledBySignal), CommandExitCodes.CancelledBySignal),
+        new(nameof(CommandExitCodes.InstallError), CommandExitCodes.InstallError),
+        new(nameof(CommandExitCodes.RuntimeError), CommandExitCodes.RuntimeError),
+        new(nameof(CommandExitCodes.UnhandledException), CommandExitCodes.UnhandledException),
+        new(nameof(CommandExitCodes.ExUsage), CommandExitCodes.ExUsage),
+        new(nameof(CommandExitCodes.Interrupted), CommandExitCodes.Interrupted, IsAlias: true, AliasOf: nameof(CommandExitCodes.CancelledBySignal)),
+        new(nameof(CommandExitCodes.LegacyInterrupted), CommandExitCodes.LegacyInterrupted),
+    ];
+
+    public static IReadOnlyList<CliErrorCodeContract> ErrorCodes { get; } =
+    [
+        new(nameof(CommandErrorCodes.DbNotFound), CommandErrorCodes.DbNotFound, CommandExitCodes.NotFound),
+        new(nameof(CommandErrorCodes.DbLocked), CommandErrorCodes.DbLocked, CommandExitCodes.TransientDatabaseError),
+        new(nameof(CommandErrorCodes.SchemaTooNew), CommandErrorCodes.SchemaTooNew, CommandExitCodes.DatabaseError),
+        new(nameof(CommandErrorCodes.DbNotWritable), CommandErrorCodes.DbNotWritable, CommandExitCodes.DatabaseError),
+        new(nameof(CommandErrorCodes.DbIntegrityFailed), CommandErrorCodes.DbIntegrityFailed, CommandExitCodes.DatabaseError),
+        new(nameof(CommandErrorCodes.FtsQuerySyntax), CommandErrorCodes.FtsQuerySyntax, null),
+        new(nameof(CommandErrorCodes.TempStoreExhausted), CommandErrorCodes.TempStoreExhausted, CommandExitCodes.DatabaseError),
+        new(nameof(CommandErrorCodes.DbError), CommandErrorCodes.DbError, CommandExitCodes.DatabaseError),
+        new(nameof(CommandErrorCodes.FeatureUnavailable), CommandErrorCodes.FeatureUnavailable, CommandExitCodes.FeatureUnavailable),
+        new(nameof(CommandErrorCodes.UsageError), CommandErrorCodes.UsageError, CommandExitCodes.InvalidArgument),
+        new(nameof(CommandErrorCodes.DirectoryNotFound), CommandErrorCodes.DirectoryNotFound, CommandExitCodes.NotFound),
+        new(nameof(CommandErrorCodes.Interrupted), CommandErrorCodes.Interrupted, CommandExitCodes.CancelledBySignal),
+        new(nameof(CommandErrorCodes.IndexExtractionStalled), CommandErrorCodes.IndexExtractionStalled, null),
+        new(nameof(CommandErrorCodes.RegexMatchTimeout), CommandErrorCodes.RegexMatchTimeout, null),
+        new(nameof(CommandErrorCodes.FileSystemCaseProbeFailed), CommandErrorCodes.FileSystemCaseProbeFailed, CommandExitCodes.DatabaseError),
+    ];
+
+    public static IReadOnlyList<Type> CliJsonRootTypes { get; } = LoadCliJsonRootTypes();
+
+    public static IReadOnlyList<CliGoldenJsonContract> GoldenJsonPayloads { get; } =
+    [
+        new("status", "status.json"),
+        new("search", "search.json"),
+        new("references", "references.json"),
+        new("impact", "impact.json"),
+        new("excerpt", "excerpt.json"),
+    ];
+
+    private static IReadOnlyList<Type> LoadCliJsonRootTypes() =>
+        typeof(CliJsonSerializerContext)
+            .GetCustomAttributesData()
+            .Where(attribute => attribute.AttributeType == typeof(JsonSerializableAttribute))
+            .Select(GetJsonSerializableRootType)
+            .ToArray();
+
+    private static Type GetJsonSerializableRootType(CustomAttributeData attribute)
+    {
+        if (attribute.ConstructorArguments.Count == 1
+            && attribute.ConstructorArguments[0].Value is Type type)
+        {
+            return type;
+        }
+
+        throw new InvalidOperationException("JsonSerializableAttribute is missing its root type constructor argument.");
+    }
+}
+
+internal sealed record CliExitCodeContract(
+    string Name,
+    int Value,
+    bool IsAlias = false,
+    string? AliasOf = null);
+
+internal sealed record CliErrorCodeContract(
+    string Name,
+    string Code,
+    int? CodeIndexExceptionExitCode);
+
+internal sealed record CliGoldenJsonContract(
+    string Command,
+    string GoldenFile);

--- a/tests/CodeIndex.Tests/CliContractManifestTests.cs
+++ b/tests/CodeIndex.Tests/CliContractManifestTests.cs
@@ -1,0 +1,138 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using CodeIndex.Cli;
+using CodeIndex.Database;
+
+namespace CodeIndex.Tests;
+
+public class CliContractManifestTests
+{
+    [Fact]
+    public void JsonApiVersion_MatchesCanonicalJsonOutputContract_Issue4166()
+    {
+        Assert.Equal(JsonOutputContract.ApiVersion, CliContractManifest.JsonApiVersion);
+        Assert.Equal("1", CliContractManifest.JsonApiVersion);
+    }
+
+    [Fact]
+    public void ExitCodes_CoverEveryDeclaredCommandExitCode_Issue4166()
+    {
+        var declared = GetConstantNames(typeof(CommandExitCodes));
+        var manifested = CliContractManifest.ExitCodes.Select(code => code.Name).Order(StringComparer.Ordinal).ToArray();
+
+        Assert.Equal(declared, manifested);
+    }
+
+    [Fact]
+    public void ExitCodes_AreUniqueExceptDeclaredAliases_Issue4166()
+    {
+        Assert.NotEmpty(CliContractManifest.ExitCodes);
+
+        var names = CliContractManifest.ExitCodes.Select(code => code.Name).ToList();
+        Assert.Equal(names.Count, names.Distinct(StringComparer.Ordinal).Count());
+
+        var canonicalValues = CliContractManifest.ExitCodes
+            .Where(code => !code.IsAlias)
+            .Select(code => code.Value)
+            .ToList();
+        Assert.Equal(canonicalValues.Count, canonicalValues.Distinct().Count());
+
+        foreach (var alias in CliContractManifest.ExitCodes.Where(code => code.IsAlias))
+        {
+            Assert.False(string.IsNullOrWhiteSpace(alias.AliasOf));
+            var target = Assert.Single(CliContractManifest.ExitCodes, code => code.Name == alias.AliasOf);
+            Assert.Equal(target.Value, alias.Value);
+        }
+    }
+
+    [Fact]
+    public void ErrorCodes_CoverEveryDeclaredCommandErrorCode_Issue4166()
+    {
+        var declared = GetConstantNames(typeof(CommandErrorCodes));
+        var manifested = CliContractManifest.ErrorCodes.Select(code => code.Name).Order(StringComparer.Ordinal).ToArray();
+
+        Assert.Equal(declared, manifested);
+    }
+
+    [Fact]
+    public void ErrorCodes_AreUniqueAndSequential_Issue4166()
+    {
+        Assert.NotEmpty(CliContractManifest.ErrorCodes);
+
+        var names = CliContractManifest.ErrorCodes.Select(code => code.Name).ToList();
+        Assert.Equal(names.Count, names.Distinct(StringComparer.Ordinal).Count());
+
+        var codes = CliContractManifest.ErrorCodes.Select(code => code.Code).ToList();
+        Assert.Equal(codes.Count, codes.Distinct(StringComparer.Ordinal).Count());
+
+        for (var index = 0; index < CliContractManifest.ErrorCodes.Count; index++)
+        {
+            var contract = CliContractManifest.ErrorCodes[index];
+            var expectedPrefix = $"E{index + 1:000}_";
+            Assert.StartsWith(expectedPrefix, contract.Code, StringComparison.Ordinal);
+            Assert.Matches(new Regex("^E[0-9]{3}_[A-Z0-9_]+$"), contract.Code);
+        }
+    }
+
+    [Fact]
+    public void ErrorCodes_WithExceptionExitCodesMatchProgramRunnerMapping_Issue4166()
+    {
+        foreach (var contract in CliContractManifest.ErrorCodes)
+        {
+            if (contract.CodeIndexExceptionExitCode is null)
+                continue;
+
+            Assert.Equal(
+                contract.CodeIndexExceptionExitCode.Value,
+                ProgramRunner.MapCodeIndexExceptionExitCode(contract.Code));
+        }
+    }
+
+    [Fact]
+    public void CliJsonRootTypes_AreUniqueAndSourceGenerated_Issue4166()
+    {
+        var types = CliContractManifest.CliJsonRootTypes;
+
+        Assert.NotEmpty(types);
+        Assert.Equal(types.Count, types.Distinct().Count());
+
+        foreach (var type in types)
+            Assert.NotNull(CliJsonSerializerContext.Default.GetTypeInfo(type));
+    }
+
+    [Fact]
+    public void GoldenJsonPayloads_AreUniqueAndCheckedIn_Issue4166()
+    {
+        var payloads = CliContractManifest.GoldenJsonPayloads;
+
+        Assert.NotEmpty(payloads);
+        Assert.Equal(payloads.Count, payloads.Select(payload => payload.Command).Distinct(StringComparer.Ordinal).Count());
+        Assert.Equal(payloads.Count, payloads.Select(payload => payload.GoldenFile).Distinct(StringComparer.Ordinal).Count());
+
+        var goldenDirectory = RepositoryTestPaths.Combine("tests", "CodeIndex.Tests", "golden");
+        var checkedInGoldens = Directory.GetFiles(goldenDirectory, "*.json")
+            .Select(path => Path.GetFileName(path)!)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        var manifestedGoldens = payloads
+            .Select(payload => payload.GoldenFile)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+        Assert.Equal(checkedInGoldens, manifestedGoldens);
+
+        foreach (var payload in payloads)
+        {
+            Assert.EndsWith(".json", payload.GoldenFile, StringComparison.Ordinal);
+            Assert.True(
+                File.Exists(Path.Combine(goldenDirectory, payload.GoldenFile)),
+                $"Missing golden JSON payload: {payload.GoldenFile}");
+        }
+    }
+
+    private static string[] GetConstantNames(Type type) =>
+        type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(field => field.IsLiteral && !field.IsInitOnly)
+            .Select(field => field.Name)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+}

--- a/tests/CodeIndex.Tests/CliJsonSerializerContextTests.cs
+++ b/tests/CodeIndex.Tests/CliJsonSerializerContextTests.cs
@@ -1,6 +1,4 @@
 using CodeIndex.Cli;
-using CodeIndex.Database;
-using CodeIndex.Models;
 
 namespace CodeIndex.Tests;
 
@@ -8,69 +6,8 @@ public class CliJsonSerializerContextTests
 {
     public static IEnumerable<object[]> CliJsonRootTypes()
     {
-        yield return [typeof(BackfillFoldJsonResult)];
-        yield return [typeof(CalleeResult)];
-        yield return [typeof(CallerResult)];
-        yield return [typeof(CliJsonMessage)];
-        yield return [typeof(CompactSearchResult)];
-        yield return [typeof(CommandErrorJsonResult)];
-        yield return [typeof(DefinitionResult)];
-        yield return [typeof(Dictionary<string, int>)];
-        yield return [typeof(Dictionary<string, long>)];
-        yield return [typeof(ExactZeroHintResult)];
-        yield return [typeof(FileDependencyResult)];
-        yield return [typeof(FileExcerptResult)];
-        yield return [typeof(FileFindResult)];
-        yield return [typeof(FileIssue)];
-        yield return [typeof(FileResult)];
-        yield return [typeof(FreshnessHintResult)];
-        yield return [typeof(GroupedHotspotResult)];
-        yield return [typeof(GroupedSymbolHotspotJsonResult)];
-        yield return [typeof(ImpactAnalysisResult)];
-        yield return [typeof(ImpactResult)];
-        yield return [typeof(IndexDryRunJsonResult)];
-        yield return [typeof(IndexFreshnessCheckResult)];
-        yield return [typeof(IndexFullScanJsonResult)];
-        yield return [typeof(IndexFullScanSummaryJsonResult)];
-        yield return [typeof(IndexUpdateJsonResult)];
-        yield return [typeof(IndexUpdateSummaryJsonResult)];
-        yield return [typeof(LanguageEntryJsonResult)];
-        yield return [typeof(LanguagesJsonResult)];
-        yield return [typeof(List<CalleeResult>)];
-        yield return [typeof(List<CallerResult>)];
-        yield return [typeof(List<CliJsonMessage>)];
-        yield return [typeof(List<DefinitionResult>)];
-        yield return [typeof(List<FileDependencyResult>)];
-        yield return [typeof(List<FileIssue>)];
-        yield return [typeof(List<GroupedSymbolHotspotJsonResult>)];
-        yield return [typeof(List<int>)];
-        yield return [typeof(List<ImpactResult>)];
-        yield return [typeof(List<ReferenceResult>)];
-        yield return [typeof(List<string>)];
-        yield return [typeof(List<SymbolHotspotJsonResult>)];
-        yield return [typeof(List<SymbolResult>)];
-        yield return [typeof(List<UnusedSymbolResult>)];
-        yield return [typeof(OutlineResult)];
-        yield return [typeof(OutlineSymbol)];
-        yield return [typeof(QueryCountFilesJsonResult)];
-        yield return [typeof(QueryCountJsonResult)];
-        yield return [typeof(QueryCountResult)];
-        yield return [typeof(QueryFindCountJsonResult)];
-        yield return [typeof(QueryPathErrorJsonResult)];
-        yield return [typeof(ReferenceResult)];
-        yield return [typeof(RepoEntrypointResult)];
-        yield return [typeof(RepoFileSummaryResult)];
-        yield return [typeof(RepoLanguageResult)];
-        yield return [typeof(RepoMapResult)];
-        yield return [typeof(RepoModuleResult)];
-        yield return [typeof(SearchHighlight)];
-        yield return [typeof(SearchResult)];
-        yield return [typeof(StatusHeadFreshness)];
-        yield return [typeof(StatusResult)];
-        yield return [typeof(SymbolAnalysisResult)];
-        yield return [typeof(SymbolHotspotJsonResult)];
-        yield return [typeof(SymbolResult)];
-        yield return [typeof(UnusedSymbolResult)];
+        foreach (var type in CliContractManifest.CliJsonRootTypes)
+            yield return [type];
     }
 
     [Theory]

--- a/tests/CodeIndex.Tests/CodeIndexExceptionTests.cs
+++ b/tests/CodeIndex.Tests/CodeIndexExceptionTests.cs
@@ -310,20 +310,19 @@ public class CodeIndexExceptionTests
         return exception ?? throw new InvalidOperationException("Failed to create SqliteException for retry test.");
     }
 
+    public static IEnumerable<object[]> CodeIndexExceptionExitCodes()
+    {
+        foreach (var contract in CliContractManifest.ErrorCodes)
+        {
+            if (contract.CodeIndexExceptionExitCode.HasValue)
+                yield return [contract.Code, contract.CodeIndexExceptionExitCode.Value];
+        }
+
+        yield return ["E999_UNKNOWN", CommandExitCodes.DatabaseError];
+    }
+
     [Theory]
-    [InlineData(CommandErrorCodes.DbNotFound, CommandExitCodes.NotFound)]
-    [InlineData(CommandErrorCodes.DirectoryNotFound, CommandExitCodes.NotFound)]
-    [InlineData(CommandErrorCodes.DbLocked, CommandExitCodes.TransientDatabaseError)]
-    [InlineData(CommandErrorCodes.DbNotWritable, CommandExitCodes.DatabaseError)]
-    [InlineData(CommandErrorCodes.DbIntegrityFailed, CommandExitCodes.DatabaseError)]
-    [InlineData(CommandErrorCodes.SchemaTooNew, CommandExitCodes.DatabaseError)]
-    [InlineData(CommandErrorCodes.TempStoreExhausted, CommandExitCodes.DatabaseError)]
-    [InlineData(CommandErrorCodes.DbError, CommandExitCodes.DatabaseError)]
-    [InlineData(CommandErrorCodes.FeatureUnavailable, CommandExitCodes.FeatureUnavailable)]
-    [InlineData(CommandErrorCodes.UsageError, CommandExitCodes.InvalidArgument)]
-    [InlineData(CommandErrorCodes.Interrupted, CommandExitCodes.CancelledBySignal)]
-    [InlineData(CommandErrorCodes.FileSystemCaseProbeFailed, CommandExitCodes.DatabaseError)]
-    [InlineData("E999_UNKNOWN", CommandExitCodes.DatabaseError)]
+    [MemberData(nameof(CodeIndexExceptionExitCodes))]
     public void MapCodeIndexExceptionExitCode_MapsKnownCodesToTaxonomy(string code, int expectedExitCode)
     {
         Assert.Equal(expectedExitCode, ProgramRunner.MapCodeIndexExceptionExitCode(code));


### PR DESCRIPTION
## Summary
- Add `CliContractManifest` for CLI exit codes, structured error codes, JSON API versioning, source-generated CLI JSON roots, and golden JSON payload families.
- Add tests that tie the manifest to `CommandExitCodes`, `CommandErrorCodes`, `ProgramRunner` exception exit-code mapping, `CliJsonSerializerContext`, and checked-in golden payloads.
- Move serializer-root coverage and `CodeIndexException` mapping expectations through the shared manifest.

## Validation
- `dotnet /Users/widthdom/Projects/mine/cdidx/CodeIndex2nd/tools/CodeIndex.Changelog/bin/Debug/net8.0/CodeIndex.Changelog.dll check` passed locally in the temp worktree: `Validated 50 changelog fragment(s).`
- `git diff --check` passed locally against the temp implementation.
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --filter "FullyQualifiedName~CliContractManifestTests|FullyQualifiedName~CliJsonSerializerContextTests|FullyQualifiedName~CodeIndexExceptionTests.MapCodeIndexExceptionExitCode_MapsKnownCodesToTaxonomy" -p:UseSharedCompilation=false --nologo -v:minimal` was attempted but blocked in this environment by missing restored assets plus MSBuild named-pipe permission errors, even when retried with escalation.
- GitHub compare `main...fix-issue4166`: branch is ahead of `main`, behind by 0, with the intended five files changed.

## Review
- Codex adversarial review: no blocking/actionable issues found.

Fixes #4166