### PR TITLE
Add guard policy contract tests

### DIFF
--- a/.agent_harness/README.md
+++ b/.agent_harness/README.md
@@ -5,3 +5,8 @@ and Codex hook adapters in this repository.
 
 Policy logic lives in `command_guard_core.py`.
 Adapter entrypoints live in `.claude/hooks/` and `.codex/hooks/`.
+
+`guard_policy_contract.json` is the shared inventory for high-value guard
+policy cases and tool surfaces. The contract tests load it and run the same
+allow/deny cases through the shared core, Codex hook adapters, Claude hook
+adapter, and settings/hook registrations so drift is visible during review.

--- a/.agent_harness/guard_policy_contract.json
+++ b/.agent_harness/guard_policy_contract.json
@@ -1,0 +1,63 @@
+{
+  "version": 1,
+  "surfaces": {
+    "shared_core": ".agent_harness/command_guard_core.py",
+    "codex_pre_tool": ".codex/hooks/bash_guard.py",
+    "codex_permission_request": ".codex/hooks/permission_request_guard.py",
+    "codex_hooks": ".codex/hooks.json",
+    "claude_pre_tool": ".claude/hooks/bash-guard.py",
+    "claude_settings": ".claude/settings.json"
+  },
+  "command_cases": [
+    {
+      "name": "local_cdidx_query",
+      "command": "dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll search SymbolExtractor",
+      "expected": "allow"
+    },
+    {
+      "name": "repo_local_installer_doctor",
+      "command": "bash ./install.sh --doctor v1.2.3",
+      "expected": "allow"
+    },
+    {
+      "name": "normal_gh_issue_read",
+      "command": "gh issue list --repo Widthdom/CodeIndex --state open --limit 10",
+      "expected": "allow"
+    },
+    {
+      "name": "normal_gh_pr_create",
+      "command": "gh pr create --repo Widthdom/CodeIndex --title Update --body Details",
+      "expected": "allow"
+    },
+    {
+      "name": "search_escape_hatch",
+      "command": "rg SymbolExtractor src",
+      "expected": "deny"
+    },
+    {
+      "name": "git_grep_global_option",
+      "command": "git -c color.ui=false grep SymbolExtractor",
+      "expected": "deny"
+    },
+    {
+      "name": "env_chdir_wrapper",
+      "command": "env -C tools bash guard.sh",
+      "expected": "deny"
+    },
+    {
+      "name": "inline_interpreter",
+      "command": "python3 -c 'print(1)'",
+      "expected": "deny"
+    },
+    {
+      "name": "high_risk_gh_pr_merge",
+      "command": "gh pr merge 123",
+      "expected": "deny"
+    },
+    {
+      "name": "high_risk_gh_repo_delete",
+      "command": "gh repo delete Widthdom/CodeIndex",
+      "expected": "deny"
+    }
+  ]
+}

--- a/.agent_harness/tests/test_guard_policy_contract.py
+++ b/.agent_harness/tests/test_guard_policy_contract.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest import TestCase
+
+
+def load_core():
+    root = Path(__file__).resolve().parents[2]
+    path = root / ".agent_harness" / "command_guard_core.py"
+    spec = importlib.util.spec_from_file_location("command_guard_core", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load guard core from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+core = load_core()
+
+
+class GuardPolicyContractTests(TestCase):
+    @property
+    def repo_root(self) -> Path:
+        return Path(__file__).resolve().parents[2]
+
+    @property
+    def contract(self) -> dict[str, Any]:
+        path = self.repo_root / ".agent_harness" / "guard_policy_contract.json"
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def hook_payload(self, command: str) -> str:
+        return json.dumps({"cwd": str(self.repo_root), "tool_input": {"command": command}})
+
+    def run_hook(
+        self, relative_path: str, command_or_payload: str, *, raw_payload: bool = False, env: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        payload = command_or_payload if raw_payload else self.hook_payload(command_or_payload)
+        return subprocess.run(
+            [sys.executable, str(self.repo_root / relative_path)],
+            input=payload,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=10,
+            check=False,
+            env=env,
+        )
+
+    def hook_decision(self, relative_path: str, proc: subprocess.CompletedProcess[str]) -> str:
+        if not proc.stdout:
+            return "allow" if proc.returncode == 0 else "deny"
+
+        data = json.loads(proc.stdout)
+        hook_output = data["hookSpecificOutput"]
+        if relative_path.endswith("permission_request_guard.py"):
+            return "allow" if hook_output["decision"]["behavior"] == "allow" else "deny"
+        return "allow" if hook_output["permissionDecision"] == "allow" else "deny"
+
+    def hook_reason(self, relative_path: str, proc: subprocess.CompletedProcess[str]) -> str:
+        if not proc.stdout:
+            return ""
+        data = json.loads(proc.stdout)
+        hook_output = data["hookSpecificOutput"]
+        if relative_path.endswith("permission_request_guard.py"):
+            return hook_output["decision"]["message"]
+        return hook_output["permissionDecisionReason"]
+
+    def assert_core_decision(self, command: str, expected: str) -> None:
+        decision = core.evaluate_bash_command(command, cwd=self.repo_root, project_root=self.repo_root)
+        self.assertEqual(expected == "allow", decision.allowed, decision.reason)
+
+    def test_contract_inventory_paths_exist(self) -> None:
+        for name, relative_path in self.contract["surfaces"].items():
+            with self.subTest(surface=name):
+                self.assertTrue((self.repo_root / relative_path).exists(), relative_path)
+
+    def test_settings_register_expected_guard_surfaces(self) -> None:
+        codex_hooks = json.loads((self.repo_root / ".codex" / "hooks.json").read_text(encoding="utf-8"))
+        codex_pre = codex_hooks["hooks"]["PreToolUse"][0]
+        codex_permission = codex_hooks["hooks"]["PermissionRequest"][0]
+        self.assertEqual("^Bash$", codex_pre["matcher"])
+        self.assertEqual("^Bash$", codex_permission["matcher"])
+        self.assertIn(".codex/hooks/bash_guard.py", codex_pre["hooks"][0]["command"])
+        self.assertIn(".codex/hooks/permission_request_guard.py", codex_permission["hooks"][0]["command"])
+
+        claude_settings = json.loads((self.repo_root / ".claude" / "settings.json").read_text(encoding="utf-8"))
+        claude_pre = claude_settings["hooks"]["PreToolUse"][0]
+        self.assertEqual("Bash", claude_pre["matcher"])
+        self.assertIn(".claude/hooks/bash-guard.py", claude_pre["hooks"][0]["command"])
+        self.assertIn("Bash(gh *)", claude_settings["permissions"]["allow"])
+        self.assertIn("./.claude/hooks/bash-guard.py", claude_settings["sandbox"]["filesystem"]["denyWrite"])
+
+    def test_policy_command_cases_match_core_and_all_bash_adapters(self) -> None:
+        adapters = (
+            ".codex/hooks/bash_guard.py",
+            ".codex/hooks/permission_request_guard.py",
+            ".claude/hooks/bash-guard.py",
+        )
+        env = dict(os.environ)
+        env["CLAUDE_PROJECT_DIR"] = str(self.repo_root)
+
+        for case in self.contract["command_cases"]:
+            command = case["command"]
+            expected = case["expected"]
+            with self.subTest(surface="shared_core", case=case["name"]):
+                self.assert_core_decision(command, expected)
+            for adapter in adapters:
+                with self.subTest(surface=adapter, case=case["name"]):
+                    proc = self.run_hook(adapter, command, env=env)
+                    self.assertEqual(expected, self.hook_decision(adapter, proc), self.hook_reason(adapter, proc))
+
+    def test_pre_tool_adapters_scan_script_contents_consistently(self) -> None:
+        adapters = (".codex/hooks/bash_guard.py", ".claude/hooks/bash-guard.py")
+        env = dict(os.environ)
+        env["CLAUDE_PROJECT_DIR"] = str(self.repo_root)
+
+        with tempfile.TemporaryDirectory(dir=self.repo_root / ".agent_harness") as tmp:
+            script = Path(tmp) / "guard.sh"
+            script.write_text("rg SymbolExtractor src\n", encoding="utf-8")
+            command = f"bash {script}"
+
+            for adapter in adapters:
+                with self.subTest(adapter=adapter):
+                    proc = self.run_hook(adapter, command, env=env)
+
+                    self.assertEqual("deny", self.hook_decision(adapter, proc))
+                    self.assertIn("script contains blocked command", self.hook_reason(adapter, proc))
+
+    def test_pre_tool_adapters_fail_closed_when_secret_scanner_is_unavailable(self) -> None:
+        adapters = (".codex/hooks/bash_guard.py", ".claude/hooks/bash-guard.py")
+        with tempfile.TemporaryDirectory(dir=self.repo_root / ".agent_harness") as tmp:
+            bin_dir = Path(tmp) / "bin"
+            bin_dir.mkdir()
+            fake_git = bin_dir / "git"
+            fake_git.write_text(
+                "#!/bin/sh\n"
+                "if [ \"$1\" = \"rev-parse\" ]; then\n"
+                f"  printf '%s\\n' '{self.repo_root}'\n"
+                "  exit 0\n"
+                "fi\n"
+                "exit 0\n",
+                encoding="utf-8",
+            )
+            fake_git.chmod(0o700)
+
+            env = dict(os.environ)
+            env["CLAUDE_PROJECT_DIR"] = str(self.repo_root)
+            env["PATH"] = str(bin_dir)
+
+            for adapter in adapters:
+                with self.subTest(adapter=adapter):
+                    proc = self.run_hook(adapter, "git -c user.name=Codex commit -m test", env=env)
+
+                    self.assertEqual("deny", self.hook_decision(adapter, proc))
+                    self.assertIn("gitleaks is unavailable", self.hook_reason(adapter, proc))
+
+    def test_adapters_fail_closed_on_malformed_payloads(self) -> None:
+        adapters = (
+            ".codex/hooks/bash_guard.py",
+            ".codex/hooks/permission_request_guard.py",
+            ".claude/hooks/bash-guard.py",
+        )
+        env = dict(os.environ)
+        env["CLAUDE_PROJECT_DIR"] = str(self.repo_root)
+
+        for adapter in adapters:
+            with self.subTest(adapter=adapter):
+                proc = self.run_hook(adapter, "{", raw_payload=True, env=env)
+
+                self.assertEqual("deny", self.hook_decision(adapter, proc))
+                self.assertIn("failed to parse", self.hook_reason(adapter, proc))

--- a/changelog.d/unreleased/4173.security.md
+++ b/changelog.d/unreleased/4173.security.md
@@ -1,0 +1,17 @@
+---
+category: security
+issues:
+  - 4173
+affected:
+  - .agent_harness/guard_policy_contract.json
+  - .agent_harness/tests/test_guard_policy_contract.py
+  - .agent_harness/README.md
+---
+
+## English
+
+- **Codex and Claude guard policy contracts now share parity tests (#4173)** - A single guard-policy inventory now drives contract tests across the shared command core, Codex hook adapters, Claude hook adapter, and settings registrations so allow/deny drift, script-scan gaps, malformed payload handling, and missing secret-scanner fail-closed behavior are caught together.
+
+## 日本語
+
+- **Codex と Claude の guard policy contract を parity test で共有するようになりました (#4173)** - 単一の guard-policy inventory から shared command core、Codex hook adapter、Claude hook adapter、settings registration を横断する contract test を実行し、allow/deny の drift、script scan の抜け、malformed payload handling、secret scanner 不在時の fail-closed 挙動をまとめて検出できるようにしました。

--- a/tests/CodeIndex.Tests/SymbolExtractorTests.cs
+++ b/tests/CodeIndex.Tests/SymbolExtractorTests.cs
@@ -115,6 +115,20 @@ public partial class SymbolExtractorTests
     }
 
     [Fact]
+    public void EnumerateRegexValues_SnapshotsEnumerableBeforeRecursing_Issue4173()
+    {
+        var fixture = new MutatingEnumerableReflectionFixture();
+
+        var regexes = EnumerateRegexValues(
+                fixture.Values,
+                "fixture.Values",
+                new HashSet<object>(ReferenceEqualityComparer.Instance))
+            .ToList();
+
+        Assert.Contains(regexes, item => item.Path == "fixture.Values[0].Regex");
+    }
+
+    [Fact]
     public void BuiltInSymbolRegexes_WithIgnoreCaseUseCultureInvariant_Issue3516()
     {
         var regexes = EnumerateStaticRegexValues(
@@ -14031,12 +14045,14 @@ public partial class SymbolExtractorTests
 
         if (value is IEnumerable enumerable)
         {
-            var index = 0;
+            var items = new List<object?>();
             foreach (var item in enumerable)
+                items.Add(item);
+
+            for (var index = 0; index < items.Count; index++)
             {
-                foreach (var nested in EnumerateRegexValues(item, $"{path}[{index}]", seen))
+                foreach (var nested in EnumerateRegexValues(items[index], $"{path}[{index}]", seen))
                     yield return nested;
-                index++;
             }
 
             yield break;
@@ -14087,6 +14103,37 @@ public partial class SymbolExtractorTests
         public Regex ValidRegex { get; } = new BoundedRegex("valid");
 
         public object UnsupportedReadableProperty => throw new NotSupportedException("Synthetic unsupported property.");
+    }
+
+    private sealed class MutatingEnumerableReflectionFixture
+    {
+        private readonly List<object> _values = new();
+
+        public MutatingEnumerableReflectionFixture()
+        {
+            _values.Add(new MutatingRegexHolder(_values));
+        }
+
+        public IEnumerable<object> Values => _values;
+    }
+
+    private sealed class MutatingRegexHolder(List<object> values)
+    {
+        private bool _mutated;
+
+        public Regex Regex
+        {
+            get
+            {
+                if (!_mutated)
+                {
+                    _mutated = true;
+                    values.Add(new object());
+                }
+
+                return new BoundedRegex("valid");
+            }
+        }
     }
 
     private static string WriteFile(string projectRoot, string relativePath, string content)


### PR DESCRIPTION
## Summary
- Add a shared guard policy contract inventory for Codex and Claude guard surfaces.
- Add contract tests that run allow/deny cases through the shared core plus Codex and Claude hook adapters.
- Harden the regex reflection test helper after rebasing onto latest `origin/main`, fixing the Windows net8.0 CI failure caused by enumerating mutable collections while recursing.
- Document the contract inventory and add a security changelog fragment for the guard-policy parity coverage.

## Validation
- `dotnet restore tests/CodeIndex.Tests/CodeIndex.Tests.csproj -p:NuGetAudit=false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release --framework net8.0 --no-restore -p:NuGetAudit=false --filter "FullyQualifiedName~SymbolExtractorTests.BuiltInSymbolRegexes_WithIgnoreCaseUseCultureInvariant_Issue3516|FullyQualifiedName~EnumerateRegexValues_SnapshotsEnumerableBeforeRecursing_Issue4173"`
- `dotnet build CodeIndex.sln -c Release --no-restore -p:NuGetAudit=false`
- `python3 -m unittest discover -s .agent_harness/tests`
- `dotnet tools/CodeIndex.Changelog/bin/Release/net8.0/CodeIndex.Changelog.dll check`
- `git diff --check`

Note: local restore needed `NuGetAudit=false` because this environment could not reach NuGet vulnerability metadata, while the CI failure itself was the Windows net8.0 test failure above.

## Review
- Codex adversarial review: no blocking/actionable issues found.

Fixes #4173