### PR TITLE
Harden MCP contract tests

### DIFF
--- a/changelog.d/unreleased/4177.security.md
+++ b/changelog.d/unreleased/4177.security.md
@@ -1,0 +1,17 @@
+---
+category: security
+issues:
+  - 4177
+affected:
+  - tests/CodeIndex.Tests/McpToolContractTests.cs
+  - tests/CodeIndex.Tests/McpServerTests.cs
+  - tests/CodeIndex.Tests/McpServerToolsCallTests.cs
+---
+
+## English
+
+- **Hardened MCP contract regression coverage (#4177)** — Added tests that pin tool catalog metadata, schema alias/deprecation metadata, rate-limit config/status alignment, token-auth failure categories, and bounded rate-limit error diagnostics.
+
+## 日本語
+
+- **MCP contract の回帰テストを強化しました (#4177)** — tool catalog metadata、schema alias/deprecation metadata、rate-limit config/status の同期、token 認証の失敗カテゴリ、bounded な rate-limit error 診断を固定するテストを追加しました。

--- a/tests/CodeIndex.Tests/McpServerTests.cs
+++ b/tests/CodeIndex.Tests/McpServerTests.cs
@@ -1764,6 +1764,43 @@ public sealed class Caller
         Assert.Equal("Unauthorized", response["error"]!["message"]!.GetValue<string>());
     }
 
+    [Fact]
+    public void TokenAuthenticator_FailureReasonsStayStable_Issue4177()
+    {
+        var authenticator = new TokenMcpAuthenticator("s3cret");
+
+        var nonObject = authenticator.Authenticate(JsonNode.Parse("\"not-an-object\"")!);
+        Assert.False(nonObject.IsAuthenticated);
+        Assert.Equal("request is not a JSON object", nonObject.FailureReason);
+
+        var missing = authenticator.Authenticate(JsonNode.Parse(
+            """{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}""")!);
+        Assert.False(missing.IsAuthenticated);
+        Assert.Equal("missing auth token", missing.FailureReason);
+
+        var mismatch = authenticator.Authenticate(JsonNode.Parse(
+            """{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"auth":{"token":"wrong"}}}""")!);
+        Assert.False(mismatch.IsAuthenticated);
+        Assert.Equal("auth token mismatch", mismatch.FailureReason);
+
+        var oversizedToken = new string('x', McpAuthenticationLimits.MaxTokenCharacters + 1);
+        var oversizedRequest = new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = 1,
+            ["method"] = "tools/list",
+            ["params"] = new JsonObject
+            {
+                ["auth"] = new JsonObject
+                {
+                    ["token"] = oversizedToken,
+                },
+            },
+        };
+        var oversized = authenticator.Authenticate(oversizedRequest);
+        Assert.False(oversized.IsAuthenticated);
+        Assert.Equal(McpAuthenticationLimits.OversizedTokenFailureReason, oversized.FailureReason);
+    }
 
     [Fact]
     public void TokenAuthenticator_EmptyTokenInCtor_Rejected()

--- a/tests/CodeIndex.Tests/McpServerToolsCallTests.cs
+++ b/tests/CodeIndex.Tests/McpServerToolsCallTests.cs
@@ -3398,6 +3398,51 @@ public partial class McpServerTests
     }
 
     [Fact]
+    public void ToolsCall_Status_RateLimitEnvironmentInventoryStaysAligned_Issue4177()
+    {
+        var rateLimitInventory = EnvironmentVariableInventory.Items
+            .Where(item => item.Name is RateLimiterOptions.RpsEnvVar or RateLimiterOptions.BurstEnvVar or RateLimiterOptions.BucketIdleSecondsEnvVar)
+            .ToDictionary(item => item.Name, StringComparer.Ordinal);
+
+        foreach (var name in new[] { RateLimiterOptions.RpsEnvVar, RateLimiterOptions.BurstEnvVar, RateLimiterOptions.BucketIdleSecondsEnvVar })
+        {
+            var item = rateLimitInventory[name];
+            Assert.Equal(EnvironmentVariableInventory.DomainConfig, item.Domain);
+            Assert.Equal("mcp", item.Category);
+            Assert.Equal(EnvironmentVariableInventory.SensitivityPublic, item.Sensitivity);
+            Assert.Equal("performance", item.Policy);
+            Assert.Equal("yes", item.ConfigFileSupported);
+        }
+
+        using var env = EnvironmentVariableScope.Capture(
+            RateLimiterOptions.RpsEnvVar,
+            RateLimiterOptions.BurstEnvVar,
+            RateLimiterOptions.BucketIdleSecondsEnvVar);
+        env.Set(RateLimiterOptions.RpsEnvVar, "2.5");
+        env.Set(RateLimiterOptions.BurstEnvVar, "4");
+        env.Set(RateLimiterOptions.BucketIdleSecondsEnvVar, "30");
+
+        using var server = new McpServer(_dbPath, "1.0", dbPathExplicit: true);
+        var response = server.HandleMessage(JsonNode.Parse(
+            """{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"status"}}""")!)!;
+
+        var mcp = response["result"]!["structuredContent"]!["mcp"]!;
+        var limits = mcp["limits"]!;
+        Assert.Equal(RateLimiterOptions.MaxRefillTokensPerSecond, limits["rate_limit_max_rps"]!.GetValue<double>());
+        Assert.Equal(RateLimiterOptions.MaxBurstCapacity, limits["rate_limit_max_burst"]!.GetValue<double>());
+        Assert.Equal(RateLimiterOptions.DefaultMaxBucketCount, limits["rate_limit_max_buckets"]!.GetValue<int>());
+
+        var rateLimit = mcp["rate_limit"]!;
+        Assert.True(rateLimit["enabled"]!.GetValue<bool>());
+        Assert.Equal(2.5, rateLimit["rps"]!.GetValue<double>());
+        Assert.Equal(4.0, rateLimit["burst"]!.GetValue<double>());
+        Assert.Equal(30.0, rateLimit["bucket_idle_ttl_seconds"]!.GetValue<double>());
+        Assert.Equal(RateLimiterOptions.DefaultMaxBucketCount, rateLimit["bucket_limit"]!.GetValue<int>());
+        Assert.Equal(0, rateLimit["bucket_limit_rejection_count"]!.GetValue<int>());
+        Assert.True(rateLimit["next_prune_in_ms"]!.GetValue<long>() >= 0);
+    }
+
+    [Fact]
     public void ToolsCall_Search_RejectsFalseExactNameAlias()
     {
         InsertIndexedFile("src/search_false_alias.cs", "csharp", "void Run() { }\n");
@@ -9229,6 +9274,35 @@ public partial class McpServerTests
         Assert.Equal("client-a/1.2.3", data["caller"]!.GetValue<string>());
         Assert.True(data["retry_after_ms"]!.GetValue<long>() >= 1);
         Assert.Equal(2, second["id"]!.GetValue<int>());
+    }
+
+    [Fact]
+    public void CreateRateLimitedErrorResponse_BoundsToolAndCallerMetadata_Issue4177()
+    {
+        var tool = new string('t', McpBoundedText.MaxToolNameChars + 8);
+        var caller = new string('c', McpBoundedText.MaxClientIdentityChars + 8);
+        var toolDisplay = McpBoundedText.ForDisplay(tool, McpBoundedText.MaxToolNameChars);
+        var callerDisplay = McpBoundedText.ForDisplay(caller, McpBoundedText.MaxClientIdentityChars);
+
+        var response = McpServer.CreateRateLimitedErrorResponse(JsonValue.Create(7), tool, caller, retryAfterMs: 250);
+        var serialized = response.ToJsonString();
+
+        Assert.DoesNotContain(tool, serialized, StringComparison.Ordinal);
+        Assert.DoesNotContain(caller, serialized, StringComparison.Ordinal);
+        var error = response["error"]!;
+        Assert.Equal(McpErrorEnvelope.CodeRateLimited, error["code"]!.GetValue<int>());
+        Assert.Contains(toolDisplay.Text, error["message"]!.GetValue<string>(), StringComparison.Ordinal);
+        var data = error["data"]!;
+        Assert.Equal(McpErrorEnvelope.CategoryRateLimited, data["category"]!.GetValue<string>());
+        Assert.True(data["retry_safe"]!.GetValue<bool>());
+        Assert.Equal("rate_limited", data["error_category"]!.GetValue<string>());
+        Assert.Equal(toolDisplay.Text, data["tool"]!.GetValue<string>());
+        Assert.Equal(tool.Length, data["tool_length"]!.GetValue<int>());
+        Assert.True(data["tool_truncated"]!.GetValue<bool>());
+        Assert.Equal(callerDisplay.Text, data["caller"]!.GetValue<string>());
+        Assert.Equal(caller.Length, data["caller_length"]!.GetValue<int>());
+        Assert.True(data["caller_truncated"]!.GetValue<bool>());
+        Assert.Equal(250, data["retry_after_ms"]!.GetValue<long>());
     }
 
     [Fact]

--- a/tests/CodeIndex.Tests/McpToolContractTests.cs
+++ b/tests/CodeIndex.Tests/McpToolContractTests.cs
@@ -19,6 +19,13 @@ public class McpToolContractTests
         ("suggest_improvement", "evidence_paths"),
     ];
 
+    private static readonly HashSet<string> KnownStabilityValues = new(StringComparer.Ordinal)
+    {
+        "stable",
+        "experimental",
+        "deprecated",
+    };
+
     [Fact]
     public void ToolsList_AdvertisedInputPropertiesMatchArgumentAllowlist_Issue3199()
     {
@@ -171,6 +178,122 @@ public class McpToolContractTests
     }
 
     [Fact]
+    public void ToolsList_CatalogAndSchemaMetadataContractsStaySynchronized_Issue4177()
+    {
+        var result = GetToolsListResult();
+        var tools = GetAdvertisedTools(result);
+        var advertisedNames = tools.Keys.ToHashSet(StringComparer.Ordinal);
+        var failures = new List<string>();
+
+        Assert.Equal(
+            McpToolFilter.KnownToolNames.Order(StringComparer.Ordinal),
+            advertisedNames.Order(StringComparer.Ordinal));
+
+        var meta = result["_meta"]!.AsObject();
+        Assert.Equal("cdidx.mcp.tools.v1", meta["catalog_version"]!.GetValue<string>());
+        var discoveryContract = meta["discovery_contract"]!.AsObject();
+        foreach (var contractField in new[]
+                 {
+                     "tools_list_is_authoritative",
+                     "disabled_tools_are_omitted",
+                     "input_schemas_are_authoritative",
+                     "annotations_describe_read_only_or_mutating_behavior",
+                     "respect_tool_filtering",
+                 })
+        {
+            Assert.True(discoveryContract[contractField]!.GetValue<bool>(), contractField);
+        }
+
+        foreach (var (toolName, tool) in tools.OrderBy(pair => pair.Key, StringComparer.Ordinal))
+        {
+            var inputSchema = tool["inputSchema"]!.AsObject();
+            Assert.Equal("object", inputSchema["type"]!.GetValue<string>());
+            Assert.False(inputSchema["additionalProperties"]!.GetValue<bool>(), toolName);
+            Assert.Contains(tool["x-stability"]!.GetValue<string>(), KnownStabilityValues);
+
+            var annotations = tool["annotations"]!.AsObject();
+            foreach (var annotationField in new[] { "readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint" })
+            {
+                Assert.NotNull(annotations[annotationField]);
+                _ = annotations[annotationField]!.GetValue<bool>();
+            }
+
+            var properties = inputSchema["properties"]!.AsObject();
+            foreach (var (argumentName, node) in properties.OrderBy(pair => pair.Key, StringComparer.Ordinal))
+            {
+                if (node is not JsonObject schema)
+                {
+                    failures.Add($"{toolName}.{argumentName}: schema is not an object");
+                    continue;
+                }
+
+                var (hasValidator, validatorType) = TryGetExpectedJsonType(toolName, argumentName);
+                if (hasValidator && schema["x-expectedType"]?.GetValue<string>() != validatorType)
+                {
+                    failures.Add(
+                        $"{toolName}.{argumentName}: x-expectedType={schema["x-expectedType"]?.GetValue<string>() ?? "<missing>"}; "
+                        + $"validator={validatorType}");
+                }
+
+                if (schema["x-aliasOf"]?.GetValue<string>() is { } aliasTarget
+                    && !properties.ContainsKey(aliasTarget))
+                {
+                    failures.Add($"{toolName}.{argumentName}: x-aliasOf target '{aliasTarget}' is not advertised");
+                }
+
+                if (schema["deprecated"]?.GetValue<bool>() == true)
+                {
+                    if (schema["x-aliasOf"] == null)
+                        failures.Add($"{toolName}.{argumentName}: deprecated schema is missing x-aliasOf");
+                    if (string.IsNullOrWhiteSpace(schema["x-deprecationReason"]?.GetValue<string>()))
+                        failures.Add($"{toolName}.{argumentName}: deprecated schema is missing x-deprecationReason");
+                }
+            }
+        }
+
+        Assert.True(
+            failures.Count == 0,
+            "MCP tools/list schema metadata contract drift detected:\n" + string.Join('\n', failures));
+    }
+
+    [Fact]
+    public void ToolsList_FilteredCatalogMetaReferencesOnlyAdvertisedTools_Issue4177()
+    {
+        var result = GetToolsListResult(McpToolFilter.Parse(null, "index,backfill_fold,suggest_improvement"));
+        var tools = GetAdvertisedTools(result);
+        var advertisedNames = tools.Keys.ToHashSet(StringComparer.Ordinal);
+        var failures = new List<string>();
+
+        Assert.DoesNotContain("index", advertisedNames);
+        Assert.DoesNotContain("backfill_fold", advertisedNames);
+        Assert.DoesNotContain("suggest_improvement", advertisedNames);
+
+        var meta = result["_meta"]!.AsObject();
+        foreach (var (groupName, groupNode) in meta["capability_groups"]!.AsObject())
+        {
+            foreach (var toolName in groupNode!.AsArray().Select(item => item!.GetValue<string>()))
+            {
+                if (!advertisedNames.Contains(toolName))
+                    failures.Add($"capability_groups.{groupName}: '{toolName}' is not advertised");
+            }
+        }
+
+        foreach (var workflow in meta["recommended_workflows"]!.AsArray())
+        {
+            var workflowName = workflow!["name"]!.GetValue<string>();
+            foreach (var toolName in workflow["tools"]!.AsArray().Select(item => item!.GetValue<string>()))
+            {
+                if (!advertisedNames.Contains(toolName))
+                    failures.Add($"recommended_workflows.{workflowName}: '{toolName}' is not advertised");
+            }
+        }
+
+        Assert.True(
+            failures.Count == 0,
+            "Filtered MCP tools/list catalog metadata references disabled tools:\n" + string.Join('\n', failures));
+    }
+
+    [Fact]
     public void ToolsList_OutlineAndValidateDoNotExposeHiddenNoopArguments_Issue3198()
     {
         var advertisedSchemas = GetAdvertisedToolSchemas();
@@ -211,26 +334,11 @@ public class McpToolContractTests
 
     private static Dictionary<string, Dictionary<string, JsonObject>> GetAdvertisedToolSchemas()
     {
-        using var server = new McpServer("unused.db", "test", dbPathExplicit: false, McpToolFilter.AllowAll());
-        var request = new JsonObject
-        {
-            ["jsonrpc"] = "2.0",
-            ["id"] = 1,
-            ["method"] = "tools/list",
-        };
-        var response = server.HandleMessage(request)
-            ?? throw new InvalidOperationException("tools/list returned no response.");
-
-        var tools = response["result"]?["tools"]?.AsArray()
-            ?? throw new InvalidOperationException("tools/list response did not contain result.tools.");
+        var tools = GetAdvertisedTools();
         var result = new Dictionary<string, Dictionary<string, JsonObject>>(StringComparer.Ordinal);
 
-        foreach (var tool in tools)
+        foreach (var (toolName, toolObject) in tools)
         {
-            var toolObject = tool?.AsObject()
-                ?? throw new InvalidOperationException("tools/list returned a non-object tool entry.");
-            var toolName = toolObject["name"]?.GetValue<string>()
-                ?? throw new InvalidOperationException("tools/list returned a tool without a name.");
             var properties = toolObject["inputSchema"]?["properties"]?.AsObject()
                 ?? throw new InvalidOperationException($"Tool '{toolName}' did not expose inputSchema.properties.");
 
@@ -242,6 +350,43 @@ public class McpToolContractTests
             }
 
             result.Add(toolName, propertySchemas);
+        }
+
+        return result;
+    }
+
+    private static JsonObject GetToolsListResult(McpToolFilter? filter = null)
+    {
+        using var server = new McpServer("unused.db", "test", dbPathExplicit: false, filter ?? McpToolFilter.AllowAll());
+        var request = new JsonObject
+        {
+            ["jsonrpc"] = "2.0",
+            ["id"] = 1,
+            ["method"] = "tools/list",
+        };
+        var response = server.HandleMessage(request)
+            ?? throw new InvalidOperationException("tools/list returned no response.");
+
+        return response["result"]?.AsObject()
+            ?? throw new InvalidOperationException("tools/list response did not contain a result object.");
+    }
+
+    private static Dictionary<string, JsonObject> GetAdvertisedTools()
+        => GetAdvertisedTools(GetToolsListResult());
+
+    private static Dictionary<string, JsonObject> GetAdvertisedTools(JsonObject resultObject)
+    {
+        var tools = resultObject["tools"]?.AsArray()
+            ?? throw new InvalidOperationException("tools/list response did not contain result.tools.");
+        var result = new Dictionary<string, JsonObject>(StringComparer.Ordinal);
+
+        foreach (var tool in tools)
+        {
+            var toolObject = tool?.AsObject()
+                ?? throw new InvalidOperationException("tools/list returned a non-object tool entry.");
+            var toolName = toolObject["name"]?.GetValue<string>()
+                ?? throw new InvalidOperationException("tools/list returned a tool without a name.");
+            result.Add(toolName, toolObject);
         }
 
         return result;


### PR DESCRIPTION
## Summary
- Add MCP tool catalog contract tests for schema metadata, alias/deprecation metadata, stability annotations, and filtered catalog meta.
- Add rate-limit status/config inventory and bounded error metadata regression tests.
- Add token authenticator failure-reason coverage.

## Validation
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-restore --filter "FullyQualifiedName~RateLimiterTests|FullyQualifiedName~McpToolContractTests|FullyQualifiedName~ToolsList_|FullyQualifiedName~ToolsCall_Status_|FullyQualifiedName~ToolsCall_RateLimit|FullyQualifiedName~TokenAuthenticator" -m:1 -nr:false -p:UseSharedCompilation=false -p:BuildInParallel=false`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore -m:1 -nr:false -p:UseSharedCompilation=false -p:BuildInParallel=false`
- `dotnet tools/CodeIndex.Changelog/bin/Debug/net8.0/CodeIndex.Changelog.dll check`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- `codex exec --ignore-rules ...` adversarial review: no blocking/actionable issues found. Initial `codex exec` without `--ignore-rules` failed because the existing `.codex/rules/codeindex.rules` file contains `invalid decision: allowed`.

## Documentation and changelog
- Added `changelog.d/unreleased/4177.security.md`.
- No developer guide changes were needed because this is regression coverage for existing MCP contracts.

Fixes #4177