### PR TITLE
Harden MCP HTTP transport disposal

### DIFF
--- a/changelog.d/unreleased/4176.internal.md
+++ b/changelog.d/unreleased/4176.internal.md
@@ -1,0 +1,18 @@
+---
+category: internal
+issues:
+  - 4176
+affected:
+  - src/CodeIndex/Mcp/IMcpTransport.cs
+  - src/CodeIndex/Mcp/HttpMcpTransport.cs
+  - src/CodeIndex/Mcp/HttpMcpTransport.Lifetime.cs
+  - tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+---
+
+## English
+
+- **Hardened MCP HTTP transport lifetime contracts (#4176)** - split HTTP transport shutdown into a dedicated lifetime partial and pinned concurrent disposal plus open SSE stream cleanup with regression coverage.
+
+## 日本語
+
+- **MCP HTTP transport の lifetime 契約を強化しました (#4176)** - HTTP transport の shutdown を専用 lifetime partial に分離し、並行 dispose と開いた SSE stream の cleanup を回帰テストで固定しました。

--- a/src/CodeIndex/Mcp/HttpMcpTransport.Lifetime.cs
+++ b/src/CodeIndex/Mcp/HttpMcpTransport.Lifetime.cs
@@ -1,0 +1,117 @@
+namespace CodeIndex.Mcp;
+
+internal sealed partial class HttpMcpTransport
+{
+    public ValueTask DisposeAsync()
+    {
+        Task disposeTask;
+        lock (_disposeSync)
+        {
+            disposeTask = _disposeTask ?? StartDisposeLocked();
+        }
+
+        return new ValueTask(disposeTask);
+    }
+
+    private Task StartDisposeLocked()
+    {
+        Volatile.Write(ref _disposeStarted, 1);
+        var disposeTask = DisposeCoreAsync();
+        _disposeTask = disposeTask;
+        return disposeTask;
+    }
+
+    private async Task DisposeCoreAsync()
+    {
+        CancelAcceptLoopForDispose();
+        StopListenerForDispose();
+        var acceptLoopCompleted = await WaitForAcceptLoopForDisposeAsync().ConfigureAwait(false);
+
+        if (acceptLoopCompleted)
+            _acceptCts.Dispose();
+
+        await CompleteRequestLogQueueForDisposeAsync().ConfigureAwait(false);
+
+        if (acceptLoopCompleted && await WaitForOwnedSemaphoreGatesIdleAsync().ConfigureAwait(false))
+        {
+            _queueSlots.Dispose();
+            _handlerSemaphore.Dispose();
+            Volatile.Write(ref _ownedSemaphoreGatesDisposed, true);
+        }
+    }
+
+    private void CancelAcceptLoopForDispose()
+    {
+        try { _acceptCts.Cancel(); } catch { /* ignore */ }
+    }
+
+    private void StopListenerForDispose()
+    {
+        try
+        {
+            if (_pendingRequest is not null)
+            {
+                AbortResponseBestEffort(_pendingRequest.Context.Response, "pending request disposal");
+                _pendingRequest = null;
+            }
+
+            _listener.Close();
+        }
+        catch
+        {
+            // Disposal must not throw; parent server shutdown is already in progress.
+            // dispose は例外を投げない方針。親サーバーは既に終了処理中なので。
+        }
+    }
+
+    private async Task<bool> WaitForAcceptLoopForDisposeAsync()
+    {
+        try
+        {
+            await _acceptLoop.WaitAsync(DisposeAcceptLoopTimeout).ConfigureAwait(false);
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            // Best-effort disposal must not hang on platform-delayed listener teardown.
+            // best-effort な dispose は、プラットフォーム都合の listener 終了遅延で停止しない。
+            return false;
+        }
+        catch
+        {
+            return true;
+        }
+    }
+
+    private async Task CompleteRequestLogQueueForDisposeAsync()
+    {
+        if (_requestLogQueue is null)
+            return;
+
+        _requestLogQueue.Writer.TryComplete();
+        try
+        {
+            if (_requestLogTask is not null)
+                await _requestLogTask.WaitAsync(DisposeAcceptLoopTimeout).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Request logging is best-effort; shutdown must not wait indefinitely.
+            // request log は best-effort。shutdown を無期限に待たせない。
+        }
+    }
+
+    private async Task<bool> WaitForOwnedSemaphoreGatesIdleAsync()
+    {
+        var deadline = DateTimeOffset.UtcNow.Add(DisposeAcceptLoopTimeout);
+        while (_queueSlots.CurrentCount != _maxQueuedRequests
+            || _handlerSemaphore.CurrentCount != _maxConcurrentHandlers)
+        {
+            if (DateTimeOffset.UtcNow >= deadline)
+                return false;
+            await Task.Delay(10).ConfigureAwait(false);
+        }
+
+        return true;
+    }
+}

--- a/src/CodeIndex/Mcp/HttpMcpTransport.cs
+++ b/src/CodeIndex/Mcp/HttpMcpTransport.cs
@@ -26,7 +26,7 @@ namespace CodeIndex.Mcp;
 /// サーバー起点の JSON-RPC 通知は `/events` で bounded な multi-client SSE fan-out channel
 /// として公開する。
 /// </summary>
-internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
+internal sealed partial class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
 {
     internal const int DefaultMaxRequestBodyBytes = 1_000_000;
     internal const int DefaultMaxResponseBodyBytes = 1_000_000;
@@ -88,6 +88,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     private readonly int _maxEventStreams;
     private readonly TimeSpan _eventStreamWriteTimeout;
     private readonly Task _acceptLoop;
+    private readonly object _disposeSync = new();
     // The configured bearer token's SHA-256 digest, precomputed once at construction so the
     // per-request auth path never hashes the secret. Storing the digest (not the token) keeps the
     // per-request work proportional only to the attacker-supplied input length, eliminating the
@@ -115,12 +116,13 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     private long _authDenialMalformedTokenCount;
     private long _authDenialOversizedTokenCount;
     private long _authDenialWrongTokenCount;
+    private Task? _disposeTask;
     private string? _lastResponseAbortCleanupFailure;
     private string? _lastResponseCloseCleanupFailure;
     private string? _lastEventStreamDropReason;
     private string? _lastAuthDenialReason;
     private string? _lastRequestLogDropReason;
-    private bool _disposed;
+    private int _disposeStarted;
     private bool _ownedSemaphoreGatesDisposed;
 
     /// <summary>
@@ -249,6 +251,8 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
     internal string? AuthDisabledWarning => AuthDisabled ? LoopbackAuthDisabledWarning : null;
 
     internal bool OwnedSemaphoreGatesDisposedForTests => Volatile.Read(ref _ownedSemaphoreGatesDisposed);
+
+    private bool IsDisposed => Volatile.Read(ref _disposeStarted) != 0;
 
     internal Func<string, CancellationToken, Task<string?>>? OutOfBandFrameHandler { get; set; }
 
@@ -491,7 +495,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
 
     public async Task<string?> ReadFrameAsync(CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
         if (_pendingRequest is not null)
             throw new InvalidOperationException("HttpMcpTransport: ReadFrameAsync called twice without an intervening WriteFrameAsync.");
 
@@ -520,7 +524,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
                 {
                     context = await _listener.GetContextAsync().ConfigureAwait(false);
                 }
-                catch (HttpListenerException) when (cancellationToken.IsCancellationRequested || _disposed)
+                catch (HttpListenerException) when (cancellationToken.IsCancellationRequested || IsDisposed)
                 {
                     break;
                 }
@@ -777,7 +781,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
 
     public async Task WriteFrameAsync(string? frame, CancellationToken cancellationToken)
     {
-        ObjectDisposedException.ThrowIf(_disposed, this);
+        ObjectDisposedException.ThrowIf(IsDisposed, this);
         var request = _pendingRequest
             ?? throw new InvalidOperationException("HttpMcpTransport: WriteFrameAsync called without a pending ReadFrameAsync.");
         _pendingRequest = null;
@@ -1493,80 +1497,6 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
         Volatile.Write(ref _lastEventStreamDropReason, $"{reason}:{category}:{exception.GetType().Name}");
     }
 
-    public async ValueTask DisposeAsync()
-    {
-        if (_disposed)
-            return;
-        _disposed = true;
-        try { _acceptCts.Cancel(); } catch { /* ignore */ }
-        try
-        {
-            if (_pendingRequest is not null)
-            {
-                AbortResponseBestEffort(_pendingRequest.Context.Response, "pending request disposal");
-                _pendingRequest = null;
-            }
-            _listener.Close();
-        }
-        catch
-        {
-            // Disposal must not throw — the parent server is already on its way down.
-            // dispose は例外を投げない方針: 親サーバーは既に終了処理中なので。
-        }
-        var acceptLoopCompleted = false;
-        try
-        {
-            await _acceptLoop.WaitAsync(DisposeAcceptLoopTimeout).ConfigureAwait(false);
-            acceptLoopCompleted = true;
-        }
-        catch (TimeoutException)
-        {
-            // Disposal is best-effort; a platform-delayed listener teardown must not hang shutdown.
-            // dispose は best-effort。プラットフォーム都合で listener 終了が遅れても shutdown を止めない。
-        }
-        catch
-        {
-            acceptLoopCompleted = true;
-        }
-
-        if (acceptLoopCompleted)
-            _acceptCts.Dispose();
-        if (_requestLogQueue is not null)
-        {
-            _requestLogQueue.Writer.TryComplete();
-            try
-            {
-                if (_requestLogTask is not null)
-                    await _requestLogTask.WaitAsync(DisposeAcceptLoopTimeout).ConfigureAwait(false);
-            }
-            catch
-            {
-                // Request logging is best-effort; shutdown must not wait indefinitely.
-                // request log は best-effort。shutdown を無期限に待たせない。
-            }
-        }
-        if (acceptLoopCompleted && await WaitForOwnedSemaphoreGatesIdleAsync().ConfigureAwait(false))
-        {
-            _queueSlots.Dispose();
-            _handlerSemaphore.Dispose();
-            Volatile.Write(ref _ownedSemaphoreGatesDisposed, true);
-        }
-    }
-
-    private async Task<bool> WaitForOwnedSemaphoreGatesIdleAsync()
-    {
-        var deadline = DateTimeOffset.UtcNow.Add(DisposeAcceptLoopTimeout);
-        while (_queueSlots.CurrentCount != _maxQueuedRequests
-            || _handlerSemaphore.CurrentCount != _maxConcurrentHandlers)
-        {
-            if (DateTimeOffset.UtcNow >= deadline)
-                return false;
-            await Task.Delay(10).ConfigureAwait(false);
-        }
-
-        return true;
-    }
-
     private void MarkRejected(PendingRequest request, string reason)
     {
         request.RejectionReason = reason;
@@ -1673,7 +1603,7 @@ internal sealed class HttpMcpTransport : IMcpTransport, IOutOfBandMcpTransport
             return;
 
         Interlocked.Decrement(ref _pendingRequestLogCount);
-        if (!_disposed)
+        if (!IsDisposed)
             RecordRequestLogDrop("queue_full", null);
     }
 

--- a/src/CodeIndex/Mcp/IMcpTransport.cs
+++ b/src/CodeIndex/Mcp/IMcpTransport.cs
@@ -7,12 +7,16 @@ namespace CodeIndex.Mcp;
 /// call carries the server's response, or null when the request was a notification that yields
 /// no response. The contract is strictly one read followed by one write — the MCP loop is
 /// single-threaded today, and pluggable transports rely on that pairing to map a request body
-/// to its response on connection-oriented transports such as HTTP.
+/// to its response on connection-oriented transports such as HTTP. Implementations must make
+/// <see cref="IAsyncDisposable.DisposeAsync"/> idempotent and use it to release/cancel pending
+/// transport work without requiring additional server-loop calls.
 /// MCP サーバーが扱う JSON-RPC フレームの読み書きを抽象化する (issue #1558)。<see cref="ReadFrameAsync"/>
 /// で 1 件のクライアント→サーバーメッセージを受け取り（クローズで null）、対応する
 /// <see cref="WriteFrameAsync"/> でサーバー応答を返す（通知の場合は null）。MCP ループは現状
 /// 単一スレッドであり、HTTP のようにリクエストとレスポンスを紐付ける必要があるため、
-/// 「読み 1 回 → 書き 1 回」のペアリングを厳密に守る。
+/// 「読み 1 回 → 書き 1 回」のペアリングを厳密に守る。実装は
+/// <see cref="IAsyncDisposable.DisposeAsync"/> を冪等にし、追加の server loop 呼び出しなしに
+/// 未完了の transport 作業を解放またはキャンセルする。
 /// </summary>
 internal interface IMcpTransport : IAsyncDisposable
 {

--- a/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
+++ b/tests/CodeIndex.Tests/HttpMcpTransportTests.cs
@@ -75,6 +75,38 @@ public class HttpMcpTransportTests : IDisposable
     }
 
     [Fact]
+    public async Task HttpTransport_DisposeAsync_IsIdempotentForConcurrentCallers_Issue4176()
+    {
+        await using var harness = await McpHttpHarness.StartAsync(_dbPath);
+
+        var disposeTasks = new Task[8];
+        for (var i = 0; i < disposeTasks.Length; i++)
+            disposeTasks[i] = Task.Run(async () => await harness.DisposeTransportAsync());
+
+        await Task.WhenAll(disposeTasks).WaitAsync(TimeSpan.FromSeconds(10));
+        await harness.DisposeTransportAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await harness.WaitForServerLoopAsync();
+
+        Assert.True(harness.OwnedSemaphoreGatesDisposed);
+    }
+
+    [Fact]
+    public async Task HttpTransport_DisposeAsync_CancelsOpenEventStreams_Issue4176()
+    {
+        await using var harness = await McpHttpHarness.StartAsync(_dbPath);
+
+        using var client = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
+        using var events = await client.GetAsync(new Uri(new Uri(harness.Endpoint), "events"), HttpCompletionOption.ResponseHeadersRead);
+        Assert.Equal(HttpStatusCode.OK, events.StatusCode);
+        await WaitUntilAsync(() => harness.HasEventStreams, "the event stream to be registered before disposal");
+
+        await harness.DisposeTransportAsync().AsTask().WaitAsync(TimeSpan.FromSeconds(10));
+        await WaitUntilAsync(() => !harness.HasEventStreams, "disposal to remove the event stream");
+
+        Assert.True(harness.OwnedSemaphoreGatesDisposed);
+    }
+
+    [Fact]
     public void HttpTransport_TimeoutDiagnosticsUseStableCategories_Issue3990()
     {
         Assert.Equal(
@@ -1833,6 +1865,12 @@ public class HttpMcpTransportTests : IDisposable
             var content = new StringContent(body, Encoding.UTF8, "application/json");
             return await client.PostAsync(Endpoint, content);
         }
+
+        public ValueTask DisposeTransportAsync()
+            => _transport.DisposeAsync();
+
+        public Task WaitForServerLoopAsync()
+            => _loopTask.WaitAsync(TimeSpan.FromSeconds(5));
 
         public async ValueTask DisposeAsync()
         {


### PR DESCRIPTION
## Summary

- Split `HttpMcpTransport` shutdown/disposal into a dedicated lifetime partial.
- Make HTTP transport disposal idempotent for concurrent callers by sharing the in-flight disposal task.
- Add regression coverage for concurrent disposal and cleanup of open SSE event streams.

## Validation

- `dotnet build src/CodeIndex/CodeIndex.csproj --no-restore --disable-build-servers -p:UseSharedCompilation=false -v:minimal`
- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore --disable-build-servers -p:UseSharedCompilation=false -v:minimal`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter FullyQualifiedName~HttpTransport_DisposeAsync --logger "console;verbosity=normal"`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-build --filter FullyQualifiedName~HttpMcpTransportTests --logger "console;verbosity=minimal"`
- `dotnet run --project tools/CodeIndex.Changelog --no-restore -- check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`

## Documentation / Changelog

- Added `changelog.d/unreleased/4176.internal.md`.
- Updated `IMcpTransport` contract comments in English and Japanese.

## Review

- Codex adversarial review found no actionable defects.

## Follow-up

- None.

Fixes #4176