### PR TITLE
Split GitHelper and diagnostic report orchestration hotspots

### DIFF
--- a/changelog.d/unreleased/4179.internal.md
+++ b/changelog.d/unreleased/4179.internal.md
@@ -1,0 +1,21 @@
+---
+category: internal
+issues:
+  - 4179
+affected:
+  - src/CodeIndex/Cli/GitHelper.cs
+  - src/CodeIndex/Cli/GitProcessRunner.cs
+  - src/CodeIndex/Cli/ReportBundleWriter.cs
+  - src/CodeIndex/Cli/ReportCommandRunner.cs
+  - src/CodeIndex/Cli/ReportLogTailBuilder.cs
+  - tests/CodeIndex.Tests/GitProcessRunnerTests.cs
+  - tests/CodeIndex.Tests/ReportLogTailBuilderTests.cs
+---
+
+## English
+
+- Split git process capture and report bundle/log-tail orchestration into focused internal helpers, with direct contract coverage for diagnostic redaction and log truncation (#4179).
+
+## 日本語
+
+- git process capture と report bundle/log-tail の orchestration を専用の内部ヘルパーへ分割し、diagnostic redaction と log truncation の contract を直接検証するテストを追加しました (#4179)。

--- a/src/CodeIndex/Cli/GitHelper.cs
+++ b/src/CodeIndex/Cli/GitHelper.cs
@@ -1,6 +1,4 @@
 using System.Diagnostics;
-using System.Globalization;
-using System.Text;
 using CodeIndex.Diagnostics;
 using CodeIndex.Indexer;
 using Regex = CodeIndex.Indexer.BoundedRegex;
@@ -79,10 +77,8 @@ public static class GitHelper
         "UU",
     };
 
-    internal const int MaxCapturedGitOutputChars = 1024 * 1024;
-    internal const int MaxGitFailureDiagnosticChars = 512;
-    private const int MaxGitDiagnosticRedactionInputChars = 4096;
-    private const int GitCaptureReadBufferChars = 8192;
+    internal const int MaxCapturedGitOutputChars = GitProcessRunner.MaxCapturedGitOutputChars;
+    internal const int MaxGitFailureDiagnosticChars = GitProcessRunner.MaxGitFailureDiagnosticChars;
     private static readonly TimeSpan DefaultGitCommandTimeout = TimeSpan.FromSeconds(60);
     private static readonly AsyncLocal<TimeSpan?> GitCommandTimeoutOverride = new();
     internal static TimeSpan GitCommandTimeout
@@ -99,8 +95,6 @@ public static class GitHelper
         set => GitExecutablePathOverrideValue.Value = value;
     }
 
-    private static readonly TimeSpan GitKillWaitTimeout = TimeSpan.FromSeconds(5);
-    private const int GitProcessFailureExitCode = -1;
     private const string TrustedGitUnavailableMessage =
         "Could not resolve a trusted git executable path. Install git in a standard system location. / 信頼済みの git 実行ファイルパスを解決できませんでした。標準のシステム場所に git をインストールしてください。";
 
@@ -899,13 +893,6 @@ public static class GitHelper
             => new(null, failureKind, diagnostic);
     }
 
-    private readonly record struct GitProcessCaptureResult(
-        int? ExitCode,
-        string Output,
-        string Error,
-        GitCommandFailureKind FailureKind,
-        string? Diagnostic);
-
     private static string? TryRunGit(
         string projectRoot,
         IReadOnlyDictionary<string, string?>? gitEnvironmentOverrides,
@@ -1022,297 +1009,18 @@ public static class GitHelper
             || reason.Contains("ambiguous argument 'HEAD", StringComparison.OrdinalIgnoreCase)
             || reason.Contains("bad revision 'HEAD", StringComparison.OrdinalIgnoreCase);
 
-    // Drain stdout and stderr concurrently at stream level so a newline-free chunk is capped
-    // before framework line buffering can accumulate unbounded data. Returns null if the
-    // process fails to start; otherwise the caller decides how to interpret the exit code.
-    // stdout/stderr を stream level で同時に汲み出し、改行なしの巨大 chunk でも framework の
-    // 行バッファに溜まる前に上限を強制する。
     private static (int ExitCode, string Output, string Error)? RunProcessCapturingOutput(
         ProcessStartInfo psi,
         CancellationToken cancellationToken = default)
-    {
-        var result = RunProcessCapturingResult(psi, cancellationToken);
-        if (result == null || result.Value.FailureKind == GitCommandFailureKind.StartFailed)
-            return null;
+        => GitProcessRunner.RunCapturingOutput(psi, GitCommandTimeout, cancellationToken);
 
-        return (result.Value.ExitCode ?? GitProcessFailureExitCode, result.Value.Output, result.Value.Error);
-    }
-
-    private static GitProcessCaptureResult? RunProcessCapturingResult(
+    private static GitProcessRunner.CaptureResult? RunProcessCapturingResult(
         ProcessStartInfo psi,
         CancellationToken cancellationToken = default)
-        => RunProcessCapturingResultAsync(psi, cancellationToken).GetAwaiter().GetResult();
+        => GitProcessRunner.RunCapturingResult(psi, GitCommandTimeout, cancellationToken);
 
-    private static async Task<GitProcessCaptureResult?> RunProcessCapturingResultAsync(
-        ProcessStartInfo psi,
-        CancellationToken cancellationToken = default)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        using var process = new Process { StartInfo = psi };
-        var stdout = new StringBuilder();
-        var stderr = new StringBuilder();
-        GitCommandFailureKind failureKind = GitCommandFailureKind.None;
-        string? failureDiagnostic = null;
-        var failureLock = new object();
-
-        void MarkFailure(GitCommandFailureKind kind, string diagnostic)
-        {
-            lock (failureLock)
-            {
-                if (failureKind != GitCommandFailureKind.None)
-                    return;
-                failureKind = kind;
-                failureDiagnostic = FormatGitDiagnostic(diagnostic);
-            }
-            TryKillProcessTree(process);
-        }
-
-        try
-        {
-            if (!process.Start())
-            {
-                var diagnostic = FormatGitDiagnostic("git process did not start.");
-                return new GitProcessCaptureResult(
-                    null,
-                    string.Empty,
-                    diagnostic,
-                    GitCommandFailureKind.StartFailed,
-                    diagnostic);
-            }
-        }
-        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception or IOException or UnauthorizedAccessException)
-        {
-            var diagnostic = FormatGitDiagnostic($"git process start failed: {DiagnosticRedactor.ClassifyException(ex)}: {CommandErrorWriter.FormatSanitizedExceptionMessage(ex)}");
-            return new GitProcessCaptureResult(
-                null,
-                string.Empty,
-                diagnostic,
-                GitCommandFailureKind.StartFailed,
-                diagnostic);
-        }
-
-        var stdoutTask = ReadCapturedStreamAsync(process.StandardOutput, stdout, "stdout", MarkFailure);
-        var stderrTask = ReadCapturedStreamAsync(process.StandardError, stderr, "stderr", MarkFailure);
-        var waitResult = await WaitForGitExitAsync(process, GitCommandTimeout, cancellationToken).ConfigureAwait(false);
-        var cancelled = waitResult.Cancelled;
-        var exited = waitResult.Exited;
-        if (!exited)
-        {
-            MarkFailure(
-                cancelled ? GitCommandFailureKind.Cancelled : GitCommandFailureKind.TimedOut,
-                cancelled
-                ? "git command cancelled."
-                : $"git command timed out after {FormatDuration(GitCommandTimeout)}.");
-            if (!await WaitForGitExitAfterKillAsync(process, GitKillWaitTimeout).ConfigureAwait(false))
-            {
-                if (cancelled)
-                    cancellationToken.ThrowIfCancellationRequested();
-                return new GitProcessCaptureResult(
-                    GitProcessFailureExitCode,
-                    ReadCaptured(stdout),
-                    CombineCapturedError(ReadCaptured(stderr), failureDiagnostic!),
-                    failureKind,
-                    failureDiagnostic);
-            }
-        }
-
-        if (!await WaitForCaptureReadersAsync(stdoutTask, stderrTask).ConfigureAwait(false))
-            MarkFailure(GitCommandFailureKind.OutputCaptureIncomplete, "git command output capture did not finish.");
-
-        var output = ReadCaptured(stdout);
-        var error = ReadCaptured(stderr);
-        if (cancelled)
-            cancellationToken.ThrowIfCancellationRequested();
-        if (failureKind != GitCommandFailureKind.None)
-            return new GitProcessCaptureResult(
-                GitProcessFailureExitCode,
-                output,
-                CombineCapturedError(error, failureDiagnostic!),
-                failureKind,
-                failureDiagnostic);
-
-        var exitCode = process.ExitCode;
-        if (exitCode != 0)
-        {
-            var diagnostic = FormatGitDiagnostic(string.IsNullOrWhiteSpace(error)
-                ? $"git command exited with {exitCode.ToString(CultureInfo.InvariantCulture)} and no stderr."
-                : error);
-            return new GitProcessCaptureResult(
-                exitCode,
-                output,
-                diagnostic,
-                GitCommandFailureKind.ExitCode,
-                diagnostic);
-        }
-
-        return new GitProcessCaptureResult(exitCode, output, error, GitCommandFailureKind.None, null);
-    }
-
-    private readonly record struct GitExitWaitResult(bool Exited, bool Cancelled);
-
-    private static async Task<GitExitWaitResult> WaitForGitExitAsync(
-        Process process,
-        TimeSpan timeout,
-        CancellationToken cancellationToken)
-    {
-        var exitTask = process.WaitForExitAsync(cancellationToken);
-        var timeoutTask = Task.Delay(NormalizePositiveTimeout(timeout), CancellationToken.None);
-        var cancellationTask = Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
-        var completed = await Task.WhenAny(exitTask, timeoutTask, cancellationTask).ConfigureAwait(false);
-        if (completed == exitTask)
-        {
-            try
-            {
-                await exitTask.ConfigureAwait(false);
-                return new GitExitWaitResult(true, false);
-            }
-            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-            {
-                return new GitExitWaitResult(false, true);
-            }
-        }
-
-        return new GitExitWaitResult(false, completed == cancellationTask || cancellationToken.IsCancellationRequested);
-    }
-
-    private static string ReadCaptured(StringBuilder builder)
-    {
-        lock (builder)
-            return builder.ToString();
-    }
-
-    private static async Task<bool> WaitForGitExitAfterKillAsync(Process process, TimeSpan timeout)
-    {
-        try
-        {
-            await process.WaitForExitAsync(CancellationToken.None)
-                .WaitAsync(NormalizePositiveTimeout(timeout))
-                .ConfigureAwait(false);
-            return true;
-        }
-        catch (InvalidOperationException)
-        {
-            return true;
-        }
-        catch (TimeoutException)
-        {
-            return false;
-        }
-    }
-
-    private static async Task<bool> WaitForCaptureReadersAsync(Task stdoutTask, Task stderrTask)
-    {
-        try
-        {
-            await Task.WhenAll(stdoutTask, stderrTask)
-                .WaitAsync(NormalizePositiveTimeout(GitKillWaitTimeout))
-                .ConfigureAwait(false);
-            return true;
-        }
-        catch (Exception ex) when (ex is IOException or ObjectDisposedException or TimeoutException)
-        {
-            return false;
-        }
-    }
-
-    private static async Task ReadCapturedStreamAsync(
-        TextReader reader,
-        StringBuilder builder,
-        string streamName,
-        Action<GitCommandFailureKind, string> markFailure)
-    {
-        var buffer = new char[GitCaptureReadBufferChars];
-        try
-        {
-            while (true)
-            {
-                var read = await reader.ReadAsync(buffer.AsMemory(0, buffer.Length)).ConfigureAwait(false);
-                if (read == 0)
-                    return;
-                if (!AppendBoundedCapturedChars(builder, buffer.AsSpan(0, read), streamName, markFailure))
-                    return;
-            }
-        }
-        catch (IOException ex)
-        {
-            markFailure(
-                GitCommandFailureKind.CaptureFailed,
-                $"git command {streamName} read failed: {DiagnosticRedactor.ClassifyException(ex)}");
-        }
-        catch (ObjectDisposedException)
-        {
-            // Process cleanup closed the stream after another failure path.
-        }
-    }
-
-    private static bool AppendBoundedCapturedChars(
-        StringBuilder builder,
-        ReadOnlySpan<char> data,
-        string streamName,
-        Action<GitCommandFailureKind, string> markFailure)
-    {
-        lock (builder)
-        {
-            var remaining = MaxCapturedGitOutputChars - builder.Length;
-            if (remaining <= 0)
-            {
-                markFailure(GitCommandFailureKind.CaptureLimitExceeded, BuildCaptureLimitMessage(streamName));
-                return false;
-            }
-
-            if (data.Length <= remaining)
-            {
-                builder.Append(data);
-                return true;
-            }
-
-            builder.Append(data[..Math.Min(data.Length, remaining)]);
-        }
-
-        markFailure(GitCommandFailureKind.CaptureLimitExceeded, BuildCaptureLimitMessage(streamName));
-        return false;
-    }
-
-    private static string BuildCaptureLimitMessage(string streamName)
-        => $"git command captured {streamName} exceeded {MaxCapturedGitOutputChars.ToString(CultureInfo.InvariantCulture)} characters.";
-
-    private static string FormatGitDiagnostic(string diagnostic)
-    {
-        var boundedBeforeRedaction = DiagnosticRedactor.BoundDiagnosticText(
-            diagnostic,
-            MaxGitDiagnosticRedactionInputChars);
-        return DiagnosticRedactor.BoundDiagnosticText(
-            DiagnosticRedactor.RedactSensitiveText(boundedBeforeRedaction, "[redacted]", redactPaths: true),
-            MaxGitFailureDiagnosticChars);
-    }
-
-    private static string CombineCapturedError(string stderr, string diagnostic)
-        => FormatGitDiagnostic(string.IsNullOrWhiteSpace(stderr)
-            ? diagnostic
-            : diagnostic + "\n" + stderr.TrimEnd('\r', '\n'));
-
-    private static TimeSpan NormalizePositiveTimeout(TimeSpan timeout)
-    {
-        if (timeout <= TimeSpan.Zero)
-            return TimeSpan.FromMilliseconds(1);
-        return timeout;
-    }
-
-    private static string FormatDuration(TimeSpan timeout)
-        => timeout.TotalSeconds.ToString("0.###", CultureInfo.InvariantCulture) + "s";
-
-    private static void TryKillProcessTree(Process process)
-    {
-        try
-        {
-            if (!process.HasExited)
-                process.Kill(entireProcessTree: true);
-        }
-        catch
-        {
-            // Best-effort cleanup only; callers receive the timeout/capture diagnostic.
-        }
-    }
+    private static string FormatGitDiagnostic(string diagnostic) =>
+        GitProcessRunner.FormatDiagnostic(diagnostic);
 
     private static bool ProbeFileSystemIgnoreCase(string projectRoot)
     {

--- a/src/CodeIndex/Cli/GitProcessRunner.cs
+++ b/src/CodeIndex/Cli/GitProcessRunner.cs
@@ -1,0 +1,318 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Text;
+using CodeIndex.Diagnostics;
+
+namespace CodeIndex.Cli;
+
+internal static class GitProcessRunner
+{
+    internal const int MaxCapturedGitOutputChars = 1024 * 1024;
+    internal const int MaxGitFailureDiagnosticChars = 512;
+    private const int MaxGitDiagnosticRedactionInputChars = 4096;
+    private const int GitCaptureReadBufferChars = 8192;
+    private const int GitProcessFailureExitCode = -1;
+    private static readonly TimeSpan GitKillWaitTimeout = TimeSpan.FromSeconds(5);
+
+    internal readonly record struct CaptureResult(
+        int? ExitCode,
+        string Output,
+        string Error,
+        GitCommandFailureKind FailureKind,
+        string? Diagnostic);
+
+    // Drain stdout and stderr concurrently at stream level so a newline-free chunk is capped
+    // before framework line buffering can accumulate unbounded data. Returns null if the
+    // process fails to start; otherwise the caller decides how to interpret the exit code.
+    // stdout/stderr を stream level で同時に汲み出し、改行なしの巨大 chunk でも framework の
+    // 行バッファに溜まる前に上限を強制する。
+    internal static (int ExitCode, string Output, string Error)? RunCapturingOutput(
+        ProcessStartInfo psi,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        var result = RunCapturingResult(psi, timeout, cancellationToken);
+        if (result == null || result.Value.FailureKind == GitCommandFailureKind.StartFailed)
+            return null;
+
+        return (result.Value.ExitCode ?? GitProcessFailureExitCode, result.Value.Output, result.Value.Error);
+    }
+
+    internal static CaptureResult? RunCapturingResult(
+        ProcessStartInfo psi,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+        => RunCapturingResultAsync(psi, timeout, cancellationToken).GetAwaiter().GetResult();
+
+    internal static string FormatDiagnostic(string diagnostic)
+    {
+        var boundedBeforeRedaction = DiagnosticRedactor.BoundDiagnosticText(
+            diagnostic,
+            MaxGitDiagnosticRedactionInputChars);
+        return DiagnosticRedactor.BoundDiagnosticText(
+            DiagnosticRedactor.RedactSensitiveText(boundedBeforeRedaction, "[redacted]", redactPaths: true),
+            MaxGitFailureDiagnosticChars);
+    }
+
+    private static async Task<CaptureResult?> RunCapturingResultAsync(
+        ProcessStartInfo psi,
+        TimeSpan timeout,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        using var process = new Process { StartInfo = psi };
+        var stdout = new StringBuilder();
+        var stderr = new StringBuilder();
+        GitCommandFailureKind failureKind = GitCommandFailureKind.None;
+        string? failureDiagnostic = null;
+        var failureLock = new object();
+
+        void MarkFailure(GitCommandFailureKind kind, string diagnostic)
+        {
+            lock (failureLock)
+            {
+                if (failureKind != GitCommandFailureKind.None)
+                    return;
+                failureKind = kind;
+                failureDiagnostic = FormatDiagnostic(diagnostic);
+            }
+            TryKillProcessTree(process);
+        }
+
+        try
+        {
+            if (!process.Start())
+            {
+                var diagnostic = FormatDiagnostic("git process did not start.");
+                return new CaptureResult(
+                    null,
+                    string.Empty,
+                    diagnostic,
+                    GitCommandFailureKind.StartFailed,
+                    diagnostic);
+            }
+        }
+        catch (Exception ex) when (ex is InvalidOperationException or System.ComponentModel.Win32Exception or IOException or UnauthorizedAccessException)
+        {
+            var diagnostic = FormatDiagnostic($"git process start failed: {DiagnosticRedactor.ClassifyException(ex)}: {CommandErrorWriter.FormatSanitizedExceptionMessage(ex)}");
+            return new CaptureResult(
+                null,
+                string.Empty,
+                diagnostic,
+                GitCommandFailureKind.StartFailed,
+                diagnostic);
+        }
+
+        var stdoutTask = ReadCapturedStreamAsync(process.StandardOutput, stdout, "stdout", MarkFailure);
+        var stderrTask = ReadCapturedStreamAsync(process.StandardError, stderr, "stderr", MarkFailure);
+        var waitResult = await WaitForGitExitAsync(process, timeout, cancellationToken).ConfigureAwait(false);
+        var cancelled = waitResult.Cancelled;
+        var exited = waitResult.Exited;
+        if (!exited)
+        {
+            MarkFailure(
+                cancelled ? GitCommandFailureKind.Cancelled : GitCommandFailureKind.TimedOut,
+                cancelled
+                ? "git command cancelled."
+                : $"git command timed out after {FormatDuration(timeout)}.");
+            if (!await WaitForGitExitAfterKillAsync(process, GitKillWaitTimeout).ConfigureAwait(false))
+            {
+                if (cancelled)
+                    cancellationToken.ThrowIfCancellationRequested();
+                return new CaptureResult(
+                    GitProcessFailureExitCode,
+                    ReadCaptured(stdout),
+                    CombineCapturedError(ReadCaptured(stderr), failureDiagnostic!),
+                    failureKind,
+                    failureDiagnostic);
+            }
+        }
+
+        if (!await WaitForCaptureReadersAsync(stdoutTask, stderrTask).ConfigureAwait(false))
+            MarkFailure(GitCommandFailureKind.OutputCaptureIncomplete, "git command output capture did not finish.");
+
+        var output = ReadCaptured(stdout);
+        var error = ReadCaptured(stderr);
+        if (cancelled)
+            cancellationToken.ThrowIfCancellationRequested();
+        if (failureKind != GitCommandFailureKind.None)
+            return new CaptureResult(
+                GitProcessFailureExitCode,
+                output,
+                CombineCapturedError(error, failureDiagnostic!),
+                failureKind,
+                failureDiagnostic);
+
+        var exitCode = process.ExitCode;
+        if (exitCode != 0)
+        {
+            var diagnostic = FormatDiagnostic(string.IsNullOrWhiteSpace(error)
+                ? $"git command exited with {exitCode.ToString(CultureInfo.InvariantCulture)} and no stderr."
+                : error);
+            return new CaptureResult(
+                exitCode,
+                output,
+                diagnostic,
+                GitCommandFailureKind.ExitCode,
+                diagnostic);
+        }
+
+        return new CaptureResult(exitCode, output, error, GitCommandFailureKind.None, null);
+    }
+
+    private readonly record struct GitExitWaitResult(bool Exited, bool Cancelled);
+
+    private static async Task<GitExitWaitResult> WaitForGitExitAsync(
+        Process process,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        var exitTask = process.WaitForExitAsync(cancellationToken);
+        var timeoutTask = Task.Delay(NormalizePositiveTimeout(timeout), CancellationToken.None);
+        var cancellationTask = Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+        var completed = await Task.WhenAny(exitTask, timeoutTask, cancellationTask).ConfigureAwait(false);
+        if (completed == exitTask)
+        {
+            try
+            {
+                await exitTask.ConfigureAwait(false);
+                return new GitExitWaitResult(true, false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                return new GitExitWaitResult(false, true);
+            }
+        }
+
+        return new GitExitWaitResult(false, completed == cancellationTask || cancellationToken.IsCancellationRequested);
+    }
+
+    private static string ReadCaptured(StringBuilder builder)
+    {
+        lock (builder)
+            return builder.ToString();
+    }
+
+    private static async Task<bool> WaitForGitExitAfterKillAsync(Process process, TimeSpan timeout)
+    {
+        try
+        {
+            await process.WaitForExitAsync(CancellationToken.None)
+                .WaitAsync(NormalizePositiveTimeout(timeout))
+                .ConfigureAwait(false);
+            return true;
+        }
+        catch (InvalidOperationException)
+        {
+            return true;
+        }
+        catch (TimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task<bool> WaitForCaptureReadersAsync(Task stdoutTask, Task stderrTask)
+    {
+        try
+        {
+            await Task.WhenAll(stdoutTask, stderrTask)
+                .WaitAsync(NormalizePositiveTimeout(GitKillWaitTimeout))
+                .ConfigureAwait(false);
+            return true;
+        }
+        catch (Exception ex) when (ex is IOException or ObjectDisposedException or TimeoutException)
+        {
+            return false;
+        }
+    }
+
+    private static async Task ReadCapturedStreamAsync(
+        TextReader reader,
+        StringBuilder builder,
+        string streamName,
+        Action<GitCommandFailureKind, string> markFailure)
+    {
+        var buffer = new char[GitCaptureReadBufferChars];
+        try
+        {
+            while (true)
+            {
+                var read = await reader.ReadAsync(buffer.AsMemory(0, buffer.Length)).ConfigureAwait(false);
+                if (read == 0)
+                    return;
+                if (!AppendBoundedCapturedChars(builder, buffer.AsSpan(0, read), streamName, markFailure))
+                    return;
+            }
+        }
+        catch (IOException ex)
+        {
+            markFailure(
+                GitCommandFailureKind.CaptureFailed,
+                $"git command {streamName} read failed: {DiagnosticRedactor.ClassifyException(ex)}");
+        }
+        catch (ObjectDisposedException)
+        {
+            // Process cleanup closed the stream after another failure path.
+        }
+    }
+
+    private static bool AppendBoundedCapturedChars(
+        StringBuilder builder,
+        ReadOnlySpan<char> data,
+        string streamName,
+        Action<GitCommandFailureKind, string> markFailure)
+    {
+        lock (builder)
+        {
+            var remaining = MaxCapturedGitOutputChars - builder.Length;
+            if (remaining <= 0)
+            {
+                markFailure(GitCommandFailureKind.CaptureLimitExceeded, BuildCaptureLimitMessage(streamName));
+                return false;
+            }
+
+            if (data.Length <= remaining)
+            {
+                builder.Append(data);
+                return true;
+            }
+
+            builder.Append(data[..Math.Min(data.Length, remaining)]);
+        }
+
+        markFailure(GitCommandFailureKind.CaptureLimitExceeded, BuildCaptureLimitMessage(streamName));
+        return false;
+    }
+
+    private static string BuildCaptureLimitMessage(string streamName)
+        => $"git command captured {streamName} exceeded {MaxCapturedGitOutputChars.ToString(CultureInfo.InvariantCulture)} characters.";
+
+    private static string CombineCapturedError(string stderr, string diagnostic)
+        => FormatDiagnostic(string.IsNullOrWhiteSpace(stderr)
+            ? diagnostic
+            : diagnostic + "\n" + stderr.TrimEnd('\r', '\n'));
+
+    private static TimeSpan NormalizePositiveTimeout(TimeSpan timeout)
+    {
+        if (timeout <= TimeSpan.Zero)
+            return TimeSpan.FromMilliseconds(1);
+        return timeout;
+    }
+
+    private static string FormatDuration(TimeSpan timeout)
+        => timeout.TotalSeconds.ToString("0.###", CultureInfo.InvariantCulture) + "s";
+
+    private static void TryKillProcessTree(Process process)
+    {
+        try
+        {
+            if (!process.HasExited)
+                process.Kill(entireProcessTree: true);
+        }
+        catch
+        {
+            // Best-effort cleanup only; callers receive the timeout/capture diagnostic.
+        }
+    }
+}

--- a/src/CodeIndex/Cli/ReportBundleWriter.cs
+++ b/src/CodeIndex/Cli/ReportBundleWriter.cs
@@ -1,0 +1,42 @@
+using System.Formats.Tar;
+using System.IO.Compression;
+
+namespace CodeIndex.Cli;
+
+internal static class ReportBundleWriter
+{
+    internal static void Write(string outputPath, ReportBundle bundle, Action? beforeWriteEntries = null)
+    {
+        var fullOutputPath = Path.GetFullPath(outputPath);
+        var dir = Path.GetDirectoryName(fullOutputPath);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+
+        AtomicFileWriter.Write(
+            fullOutputPath,
+            stream =>
+            {
+                using var gz = new GZipStream(stream, CompressionLevel.Optimal, leaveOpen: true);
+                using var tar = new TarWriter(gz, TarEntryFormat.Pax, leaveOpen: true);
+                beforeWriteEntries?.Invoke();
+
+                foreach (var (name, bytes) in bundle.Files)
+                {
+                    var entry = new PaxTarEntry(TarEntryType.RegularFile, name)
+                    {
+                        DataStream = new MemoryStream(bytes, writable: false),
+                        Mode = ReportCommandRunner.BundleFileMode,
+                        ModificationTime = ReportCommandRunner.BundleEntryModificationTime,
+                    };
+                    tar.WriteEntry(entry);
+                }
+            },
+            ApplyBundleFileMode);
+    }
+
+    private static void ApplyBundleFileMode(string path)
+    {
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(path, ReportCommandRunner.BundleFileMode);
+    }
+}

--- a/src/CodeIndex/Cli/ReportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ReportCommandRunner.cs
@@ -1,5 +1,3 @@
-using System.Formats.Tar;
-using System.IO.Compression;
 using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.Json;
@@ -39,7 +37,6 @@ public static class ReportCommandRunner
     internal const UnixFileMode BundleFileMode = UnixFileMode.UserRead | UnixFileMode.UserWrite;
     internal static readonly DateTimeOffset BundleEntryModificationTime = DateTimeOffset.UnixEpoch;
     private const string SchemaTableLabelPrefix = "table_";
-    private const string TruncatedLogLineSuffix = "...[line truncated]";
     private const int SupportManifestVersion = 2;
 
     public static int Run(string[] cmdArgs, JsonSerializerOptions jsonOptions, string? appVersion = null)
@@ -373,68 +370,13 @@ public static class ReportCommandRunner
         out ReportRedactionSummary redactions,
         out bool logTailTruncated,
         out bool logLineCharsTruncated)
-    {
-        linesIncluded = 0;
-        logTailTruncated = false;
-        logLineCharsTruncated = false;
-        var redactionCounter = new ReportRedactionCounter();
-        var logDir = GlobalToolLog.ResolveLogDirectoryForReport();
-        if (string.IsNullOrWhiteSpace(logDir) || !Directory.Exists(logDir))
-        {
-            redactions = redactionCounter.ToSummary();
-            return $"no cdidx lifecycle log directory found (looked at: {RedactedPlaceholder}).\n";
-        }
-
-        var logFiles = SelectRecentLogFiles(
-            new DirectoryInfo(logDir).EnumerateFiles("stderr-*.log", SearchOption.TopDirectoryOnly),
-            out var olderLogFilesOmitted);
-        logTailTruncated = olderLogFilesOmitted;
-        if (logFiles.Count == 0)
-        {
-            redactions = redactionCounter.ToSummary();
-            return $"no cdidx lifecycle log files found in: {RedactedPlaceholder}\n";
-        }
-
-        var collected = new LinkedList<string>();
-        foreach (var file in logFiles)
-        {
-            if (collected.Count >= maxLines)
-            {
-                logTailTruncated = true;
-                break;
-            }
-            ReportLogTailReadResult result;
-            try
-            {
-                result = ReadLogFileTailLinesResult(file.FullName, maxLines - collected.Count);
-            }
-            catch (IOException)
-            {
-                continue;
-            }
-            if (result.LinesTruncated || result.BytesTruncated)
-                logTailTruncated = true;
-            if (result.LineCharsTruncated)
-                logLineCharsTruncated = true;
-            var lines = result.Lines;
-            for (var i = lines.Count - 1; i >= 0 && collected.Count < maxLines; i--)
-                collected.AddFirst(lines[i]);
-        }
-
-        var sb = new StringBuilder();
-        sb.AppendLine($"# cdidx lifecycle log (last {collected.Count} lines, newest last)");
-        sb.AppendLine($"# source directory: {RedactedPlaceholder}");
-        sb.AppendLine();
-        foreach (var line in collected)
-        {
-            var redacted = RedactLogLine(line, includeArgs);
-            redactionCounter.Observe(line, redacted);
-            sb.AppendLine(redacted);
-        }
-        linesIncluded = collected.Count;
-        redactions = redactionCounter.ToSummary();
-        return sb.ToString();
-    }
+        => ReportLogTailBuilder.BuildRecentLogTail(
+            maxLines,
+            includeArgs,
+            out linesIncluded,
+            out redactions,
+            out logTailTruncated,
+            out logLineCharsTruncated);
 
     internal static ReportSupportManifest BuildSupportManifest(
         ReportCommandOptions options,
@@ -678,106 +620,8 @@ public static class ReportCommandRunner
             degradedFields.Add(field);
     }
 
-    private static IReadOnlyList<FileInfo> SelectRecentLogFiles(IEnumerable<FileInfo> files, out bool olderLogFilesOmitted)
-    {
-        var recent = new List<FileInfo>(MaxRecentLogFiles);
-        olderLogFilesOmitted = false;
-        foreach (var file in files)
-        {
-            var insertAt = recent.FindIndex(
-                existing => string.Compare(file.Name, existing.Name, StringComparison.Ordinal) > 0);
-            if (insertAt < 0)
-            {
-                if (recent.Count < MaxRecentLogFiles)
-                    recent.Add(file);
-                else
-                    olderLogFilesOmitted = true;
-                continue;
-            }
-
-            recent.Insert(insertAt, file);
-            if (recent.Count > MaxRecentLogFiles)
-            {
-                olderLogFilesOmitted = true;
-                recent.RemoveAt(recent.Count - 1);
-            }
-        }
-
-        return recent;
-    }
-
     internal static IReadOnlyList<string> ReadLogFileTailLines(string path, int maxLines)
-        => ReadLogFileTailLinesResult(path, maxLines).Lines;
-
-    private static ReportLogTailReadResult ReadLogFileTailLinesResult(string path, int maxLines)
-    {
-        if (maxLines <= 0)
-            return new ReportLogTailReadResult([], LinesTruncated: false, BytesTruncated: false, LineCharsTruncated: false);
-
-        using var stream = BoundedFile.OpenReadForTailWindow(path, MaxLogFileTailBytes, out var bytesTruncated);
-        using var reader = new StreamReader(
-            stream,
-            Encoding.UTF8,
-            detectEncodingFromByteOrderMarks: !bytesTruncated,
-            bufferSize: 8192,
-            leaveOpen: false);
-        if (bytesTruncated)
-        {
-            if (ReadBoundedLogLine(reader, out _) == null)
-                return new ReportLogTailReadResult([], LinesTruncated: false, BytesTruncated: true, LineCharsTruncated: false);
-        }
-
-        var lines = new Queue<string>(maxLines + 1);
-        var lineCharsTruncated = false;
-        string? line;
-        while ((line = ReadBoundedLogLine(reader, out var lineTruncated)) != null)
-        {
-            lineCharsTruncated |= lineTruncated;
-            if (lines.Count == maxLines + 1)
-                lines.Dequeue();
-            lines.Enqueue(line);
-        }
-
-        var linesTruncated = lines.Count > maxLines;
-        if (linesTruncated)
-            lines.Dequeue();
-        return new ReportLogTailReadResult(lines.ToArray(), linesTruncated, bytesTruncated, lineCharsTruncated);
-    }
-
-    private static string? ReadBoundedLogLine(StreamReader reader, out bool lineTruncated)
-    {
-        lineTruncated = false;
-        var displayLimit = MaxLogTailLineChars - TruncatedLogLineSuffix.Length;
-        var sb = new StringBuilder(Math.Min(MaxLogTailLineChars, 1024));
-        while (true)
-        {
-            var next = reader.Read();
-            if (next < 0)
-                return sb.Length == 0 && !lineTruncated ? null : sb.ToString();
-
-            var c = (char)next;
-            if (c == '\n')
-                return sb.ToString();
-            if (c == '\r')
-            {
-                if (reader.Peek() == '\n')
-                    reader.Read();
-                return sb.ToString();
-            }
-
-            if (lineTruncated)
-                continue;
-
-            if (sb.Length < displayLimit)
-            {
-                sb.Append(c);
-                continue;
-            }
-
-            sb.Append(TruncatedLogLineSuffix);
-            lineTruncated = true;
-        }
-    }
+        => ReportLogTailBuilder.ReadLogFileTailLines(path, maxLines);
 
     internal static string RedactSensitiveFields(string line)
     {
@@ -788,39 +632,7 @@ public static class ReportCommandRunner
         DiagnosticRedactor.RedactReportLogLine(line, includeArgs, RedactedPlaceholder);
 
     internal static void WriteBundle(string outputPath, ReportBundle bundle, Action? beforeWriteEntries = null)
-    {
-        var fullOutputPath = Path.GetFullPath(outputPath);
-        var dir = Path.GetDirectoryName(fullOutputPath);
-        if (!string.IsNullOrEmpty(dir))
-            Directory.CreateDirectory(dir);
-
-        AtomicFileWriter.Write(
-            fullOutputPath,
-            stream =>
-            {
-                using var gz = new GZipStream(stream, CompressionLevel.Optimal, leaveOpen: true);
-                using var tar = new TarWriter(gz, TarEntryFormat.Pax, leaveOpen: true);
-                beforeWriteEntries?.Invoke();
-
-                foreach (var (name, bytes) in bundle.Files)
-                {
-                    var entry = new PaxTarEntry(TarEntryType.RegularFile, name)
-                    {
-                        DataStream = new MemoryStream(bytes, writable: false),
-                        Mode = BundleFileMode,
-                        ModificationTime = BundleEntryModificationTime,
-                    };
-                    tar.WriteEntry(entry);
-                }
-            },
-            ApplyBundleFileMode);
-    }
-
-    private static void ApplyBundleFileMode(string path)
-    {
-        if (!OperatingSystem.IsWindows())
-            File.SetUnixFileMode(path, BundleFileMode);
-    }
+        => ReportBundleWriter.Write(outputPath, bundle, beforeWriteEntries);
 
     internal static ReportCommandOptions ParseArgs(string[] args)
     {

--- a/src/CodeIndex/Cli/ReportLogTailBuilder.cs
+++ b/src/CodeIndex/Cli/ReportLogTailBuilder.cs
@@ -1,0 +1,179 @@
+using System.Text;
+
+namespace CodeIndex.Cli;
+
+internal static class ReportLogTailBuilder
+{
+    private const string TruncatedLogLineSuffix = "...[line truncated]";
+
+    internal static string BuildRecentLogTail(
+        int maxLines,
+        bool includeArgs,
+        out int linesIncluded,
+        out ReportRedactionSummary redactions,
+        out bool logTailTruncated,
+        out bool logLineCharsTruncated)
+    {
+        linesIncluded = 0;
+        logTailTruncated = false;
+        logLineCharsTruncated = false;
+        var redactionCounter = new ReportRedactionCounter();
+        var logDir = GlobalToolLog.ResolveLogDirectoryForReport();
+        if (string.IsNullOrWhiteSpace(logDir) || !Directory.Exists(logDir))
+        {
+            redactions = redactionCounter.ToSummary();
+            return $"no cdidx lifecycle log directory found (looked at: {ReportCommandRunner.RedactedPlaceholder}).\n";
+        }
+
+        var logFiles = SelectRecentLogFiles(
+            new DirectoryInfo(logDir).EnumerateFiles("stderr-*.log", SearchOption.TopDirectoryOnly),
+            out var olderLogFilesOmitted);
+        logTailTruncated = olderLogFilesOmitted;
+        if (logFiles.Count == 0)
+        {
+            redactions = redactionCounter.ToSummary();
+            return $"no cdidx lifecycle log files found in: {ReportCommandRunner.RedactedPlaceholder}\n";
+        }
+
+        var collected = new LinkedList<string>();
+        foreach (var file in logFiles)
+        {
+            if (collected.Count >= maxLines)
+            {
+                logTailTruncated = true;
+                break;
+            }
+            ReportLogTailReadResult result;
+            try
+            {
+                result = ReadLogFileTailLinesResult(file.FullName, maxLines - collected.Count);
+            }
+            catch (IOException)
+            {
+                continue;
+            }
+            if (result.LinesTruncated || result.BytesTruncated)
+                logTailTruncated = true;
+            if (result.LineCharsTruncated)
+                logLineCharsTruncated = true;
+            var lines = result.Lines;
+            for (var i = lines.Count - 1; i >= 0 && collected.Count < maxLines; i--)
+                collected.AddFirst(lines[i]);
+        }
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"# cdidx lifecycle log (last {collected.Count} lines, newest last)");
+        sb.AppendLine($"# source directory: {ReportCommandRunner.RedactedPlaceholder}");
+        sb.AppendLine();
+        foreach (var line in collected)
+        {
+            var redacted = ReportCommandRunner.RedactLogLine(line, includeArgs);
+            redactionCounter.Observe(line, redacted);
+            sb.AppendLine(redacted);
+        }
+        linesIncluded = collected.Count;
+        redactions = redactionCounter.ToSummary();
+        return sb.ToString();
+    }
+
+    internal static IReadOnlyList<string> ReadLogFileTailLines(string path, int maxLines)
+        => ReadLogFileTailLinesResult(path, maxLines).Lines;
+
+    internal static ReportLogTailReadResult ReadLogFileTailLinesResult(string path, int maxLines)
+    {
+        if (maxLines <= 0)
+            return new ReportLogTailReadResult([], LinesTruncated: false, BytesTruncated: false, LineCharsTruncated: false);
+
+        using var stream = BoundedFile.OpenReadForTailWindow(path, ReportCommandRunner.MaxLogFileTailBytes, out var bytesTruncated);
+        using var reader = new StreamReader(
+            stream,
+            Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: !bytesTruncated,
+            bufferSize: 8192,
+            leaveOpen: false);
+        if (bytesTruncated)
+        {
+            if (ReadBoundedLogLine(reader, out _) == null)
+                return new ReportLogTailReadResult([], LinesTruncated: false, BytesTruncated: true, LineCharsTruncated: false);
+        }
+
+        var lines = new Queue<string>(maxLines + 1);
+        var lineCharsTruncated = false;
+        string? line;
+        while ((line = ReadBoundedLogLine(reader, out var lineTruncated)) != null)
+        {
+            lineCharsTruncated |= lineTruncated;
+            if (lines.Count == maxLines + 1)
+                lines.Dequeue();
+            lines.Enqueue(line);
+        }
+
+        var linesTruncated = lines.Count > maxLines;
+        if (linesTruncated)
+            lines.Dequeue();
+        return new ReportLogTailReadResult(lines.ToArray(), linesTruncated, bytesTruncated, lineCharsTruncated);
+    }
+
+    private static IReadOnlyList<FileInfo> SelectRecentLogFiles(IEnumerable<FileInfo> files, out bool olderLogFilesOmitted)
+    {
+        var recent = new List<FileInfo>(ReportCommandRunner.MaxRecentLogFiles);
+        olderLogFilesOmitted = false;
+        foreach (var file in files)
+        {
+            var insertAt = recent.FindIndex(
+                existing => string.Compare(file.Name, existing.Name, StringComparison.Ordinal) > 0);
+            if (insertAt < 0)
+            {
+                if (recent.Count < ReportCommandRunner.MaxRecentLogFiles)
+                    recent.Add(file);
+                else
+                    olderLogFilesOmitted = true;
+                continue;
+            }
+
+            recent.Insert(insertAt, file);
+            if (recent.Count > ReportCommandRunner.MaxRecentLogFiles)
+            {
+                olderLogFilesOmitted = true;
+                recent.RemoveAt(recent.Count - 1);
+            }
+        }
+
+        return recent;
+    }
+
+    private static string? ReadBoundedLogLine(StreamReader reader, out bool lineTruncated)
+    {
+        lineTruncated = false;
+        var displayLimit = ReportCommandRunner.MaxLogTailLineChars - TruncatedLogLineSuffix.Length;
+        var sb = new StringBuilder(Math.Min(ReportCommandRunner.MaxLogTailLineChars, 1024));
+        while (true)
+        {
+            var next = reader.Read();
+            if (next < 0)
+                return sb.Length == 0 && !lineTruncated ? null : sb.ToString();
+
+            var c = (char)next;
+            if (c == '\n')
+                return sb.ToString();
+            if (c == '\r')
+            {
+                if (reader.Peek() == '\n')
+                    reader.Read();
+                return sb.ToString();
+            }
+
+            if (lineTruncated)
+                continue;
+
+            if (sb.Length < displayLimit)
+            {
+                sb.Append(c);
+                continue;
+            }
+
+            sb.Append(TruncatedLogLineSuffix);
+            lineTruncated = true;
+        }
+    }
+}

--- a/tests/CodeIndex.Tests/GitProcessRunnerTests.cs
+++ b/tests/CodeIndex.Tests/GitProcessRunnerTests.cs
@@ -1,0 +1,67 @@
+using System.Diagnostics;
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+[Collection("SQLite pool sensitive")]
+public sealed class GitProcessRunnerTests : IDisposable
+{
+    private readonly string tempDir;
+
+    public GitProcessRunnerTests()
+    {
+        tempDir = Path.Combine(Path.GetTempPath(), $"cdidx_git_process_runner_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(tempDir))
+            TestProjectHelper.DeleteDirectory(tempDir);
+    }
+
+    [Fact]
+    public void RunCapturingResult_PreservesExitDiagnosticContract_Issue4179()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var repoDir = Path.Combine(tempDir, "repo");
+        Directory.CreateDirectory(repoDir);
+        var fakeGitDir = Path.Combine(tempDir, "fake-git");
+        Directory.CreateDirectory(fakeGitDir);
+        var fakeGit = WriteFakeGitThatFailsWithLongSensitiveStderr(fakeGitDir);
+        var psi = new ProcessStartInfo
+        {
+            FileName = fakeGit,
+            WorkingDirectory = repoDir,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+
+        var result = GitProcessRunner.RunCapturingResult(psi, TimeSpan.FromSeconds(5), CancellationToken.None);
+
+        Assert.True(result.HasValue);
+        var value = result.Value;
+        Assert.Equal(23, value.ExitCode);
+        Assert.Equal(GitCommandFailureKind.ExitCode, value.FailureKind);
+        Assert.Equal(value.Diagnostic, value.Error);
+        Assert.Contains("[redacted]", value.Diagnostic!);
+        Assert.DoesNotContain("/Users/example/private", value.Diagnostic!);
+    }
+
+    private static string WriteFakeGitThatFailsWithLongSensitiveStderr(string directory)
+    {
+        var script = Path.Combine(directory, "git");
+        File.WriteAllText(script, """
+#!/bin/sh
+perl -e 'print STDERR "/Users/example/private/repo/.git/config " . ("x" x 2000)'
+exit 23
+""");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(script, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        return script;
+    }
+}

--- a/tests/CodeIndex.Tests/ReportLogTailBuilderTests.cs
+++ b/tests/CodeIndex.Tests/ReportLogTailBuilderTests.cs
@@ -1,0 +1,30 @@
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+public sealed class ReportLogTailBuilderTests
+{
+    [Fact]
+    public void ReadResultReportsLineCharTruncation_Issue4179()
+    {
+        var workDir = Path.Combine(Path.GetTempPath(), $"cdidx_report_log_tail_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDir);
+        var path = Path.Combine(workDir, "stderr-20260629.log");
+        try
+        {
+            File.WriteAllText(path, "prefix " + new string('x', ReportCommandRunner.MaxLogTailLineChars * 2));
+
+            var result = ReportLogTailBuilder.ReadLogFileTailLinesResult(path, 1);
+
+            var line = Assert.Single(result.Lines);
+            Assert.True(result.LineCharsTruncated);
+            Assert.False(result.LinesTruncated);
+            Assert.True(line.Length <= ReportCommandRunner.MaxLogTailLineChars);
+            Assert.Contains("[line truncated]", line);
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(workDir);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Split git process capture from GitHelper into GitProcessRunner.
- Split report bundle writing and log-tail orchestration into focused helpers.
- Added contract tests and changelog fragment.

## Verification
- dotnet build CodeIndex.sln -m:1 -nr:false -p:BuildInParallel=false -p:UseSharedCompilation=false -p:UseAppHost=false --no-restore
- dotnet tools/CodeIndex.Changelog/bin/Debug/net8.0/CodeIndex.Changelog.dll check
- git diff --check

Fixes #4179