### PR TITLE
Document JSON compatibility alias lifecycle for #4182

### DIFF
--- a/changelog.d/unreleased/4182.changed.md
+++ b/changelog.d/unreleased/4182.changed.md
@@ -1,0 +1,17 @@
+---
+category: changed
+issues:
+  - 4182
+affected:
+  - src/CodeIndex/Cli/JsonCompatibilityAliasLifecycles.cs
+  - tests/CodeIndex.Tests/QueryCommandRunnerJsonCompatibilityAliasTests.cs
+  - docs/json-compatibility-alias-lifecycle.md
+---
+
+## English
+
+- **Documented the JSON compatibility alias deprecation lifecycle (#4182)** — `find --count --json` keeps serializing the deprecated `file_count` alias, and new `JsonCompatibilityAliasLifecycles` metadata, alias serialization tests, production-scoped audit search tests, and bilingual documentation track future removals.
+
+## 日本語
+
+- **JSON compatibility alias の deprecation lifecycle を文書化しました (#4182)** — `find --count --json` は非推奨の `file_count` alias を引き続き serialize しつつ、明示的な `JsonCompatibilityAliasLifecycles` metadata、alias serialization と production-scoped audit search の test、将来の削除に向けた bilingual documentation を追加しました。

--- a/docs/json-compatibility-alias-lifecycle.md
+++ b/docs/json-compatibility-alias-lifecycle.md
@@ -1,0 +1,41 @@
+# JSON Compatibility Alias Lifecycle
+
+## English
+
+JSON compatibility aliases are deprecated JSON fields that stay serialized after a contract field is renamed, split, or replaced. Add one only when removing or renaming the field immediately would break machine-readable CLI or MCP consumers.
+
+When a JSON alias is added, the alias property must:
+
+- keep the alias `JsonPropertyName` so existing consumers still receive the old field;
+- be marked `[Obsolete]` with the replacement field name and affected contract;
+- be represented in `JsonCompatibilityAliasLifecycles` metadata with the alias field, replacement field, contract, JSON contract type, property name, and removal criteria;
+- have serialization tests that assert the alias still appears until removal is intentional.
+
+Removal requires an intentional PR after at least one minor release has announced the deprecation. That PR must update serialization tests, documentation, changelog fragments, and any audit commands that scan production JSON contracts. Use production-scoped searches such as:
+
+```bash
+cdidx search "JsonCompatibilityAliasLifecycle" --source-only --origin code --path src/CodeIndex/Cli/JsonCompatibilityAliasLifecycles.cs --json=array
+cdidx search "Obsolete" --source-only --origin code --path src/CodeIndex/Cli/JsonOutputContracts.cs --json=array
+```
+
+Those searches intentionally exclude docs, tests, changelog fragments, and fixtures so reviewers can separate live contract metadata from explanatory mentions.
+
+## 日本語
+
+JSON compatibility alias は、contract field の rename、分割、置き換え後も serialized output に残す非推奨 JSON field です。すぐに削除または rename すると CLI / MCP の machine-readable consumer を壊す場合にだけ追加します。
+
+JSON alias を追加するときは、alias property で次を満たしてください。
+
+- 既存 consumer が古い field を受け取れるよう alias の `JsonPropertyName` を維持する。
+- replacement field 名と対象 contract を含む `[Obsolete]` を付ける。
+- alias field、replacement field、contract、JSON contract type、property name、removal criteria を持つ `JsonCompatibilityAliasLifecycles` metadata に登録する。
+- intentional removal まで alias が serialized output に残ることを serialization test で確認する。
+
+削除には、少なくとも 1 minor release で deprecation を告知した後の intentional PR が必要です。その PR では serialization test、documentation、changelog fragment、production JSON contract を監査する command を更新してください。production code に scope した検索には次を使います。
+
+```bash
+cdidx search "JsonCompatibilityAliasLifecycle" --source-only --origin code --path src/CodeIndex/Cli/JsonCompatibilityAliasLifecycles.cs --json=array
+cdidx search "Obsolete" --source-only --origin code --path src/CodeIndex/Cli/JsonOutputContracts.cs --json=array
+```
+
+これらの検索は docs、tests、changelog fragment、fixture を意図的に除外するため、reviewer は実際の contract metadata と説明上の言及を分けて確認できます。

--- a/src/CodeIndex/Cli/JsonCompatibilityAliasLifecycles.cs
+++ b/src/CodeIndex/Cli/JsonCompatibilityAliasLifecycles.cs
@@ -1,0 +1,23 @@
+namespace CodeIndex.Cli;
+
+internal sealed record JsonCompatibilityAliasLifecycle(
+    string AliasName,
+    string ReplacementName,
+    string Contract,
+    string JsonContractType,
+    string PropertyName,
+    string RemovalCriteria);
+
+internal static class JsonCompatibilityAliasLifecycles
+{
+    internal static IReadOnlyList<JsonCompatibilityAliasLifecycle> All { get; } =
+    [
+        new(
+            "file_count",
+            "files",
+            "find --count --json",
+            nameof(QueryFindCountJsonResult),
+            "FileCount",
+            "Keep serialized until at least one minor release has announced the deprecation and targeted serialization tests, documentation, changelog fragments, and production-code deprecation scans are intentionally updated.")
+    ];
+}

--- a/tests/CodeIndex.Tests/QueryCommandRunnerJsonCompatibilityAliasTests.cs
+++ b/tests/CodeIndex.Tests/QueryCommandRunnerJsonCompatibilityAliasTests.cs
@@ -1,0 +1,94 @@
+using System.Text.Json;
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+public partial class QueryCommandRunnerTests
+{
+    [Fact]
+    public void QueryFindCountJsonResult_DeprecatedAliasHasLifecycleRegistryAndStillSerializes_Issue4182()
+    {
+        var result = new QueryFindCountJsonResult(3, 1, 1);
+
+        var json = JsonSerializer.Serialize(result, CliJsonSerializerContext.Default.QueryFindCountJsonResult);
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.Equal(3, root.GetProperty("count").GetInt32());
+        Assert.Equal(1, root.GetProperty("files").GetInt32());
+        Assert.Equal(1, root.GetProperty("file_count").GetInt32());
+
+        var alias = Assert.Single(JsonCompatibilityAliasLifecycles.All, item => item.AliasName == "file_count");
+        Assert.Equal("files", alias.ReplacementName);
+        Assert.Equal("find --count --json", alias.Contract);
+        Assert.Equal(nameof(QueryFindCountJsonResult), alias.JsonContractType);
+        Assert.Equal("FileCount", alias.PropertyName);
+        Assert.Contains("one minor release", alias.RemovalCriteria, StringComparison.OrdinalIgnoreCase);
+
+        var property = typeof(QueryFindCountJsonResult).GetProperty(alias.PropertyName);
+        Assert.NotNull(property);
+        var obsolete = Assert.Single(property!.GetCustomAttributes(typeof(ObsoleteAttribute), inherit: false).Cast<ObsoleteAttribute>());
+        Assert.Contains("files", obsolete.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RunSearch_JsonCompatibilityAliasAuditCanStayProductionScoped_Issue4182()
+    {
+        var projectRoot = TestProjectHelper.CreateTempProject("cdidx_json_alias_audit_4182");
+        try
+        {
+            var dbPath = TestProjectHelper.CreateProjectDb(projectRoot);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "src/CodeIndex/Cli/JsonCompatibilityAliasLifecycles.cs",
+                "csharp",
+                """
+                using System;
+                using System.Text.Json.Serialization;
+
+                namespace CodeIndex.Cli;
+
+                internal sealed record JsonCompatibilityAliasLifecycle(
+                    string AliasName,
+                    string ReplacementName,
+                    string Contract,
+                    string JsonContractType,
+                    string PropertyName,
+                    string RemovalCriteria);
+
+                internal static class JsonCompatibilityAliasLifecycles
+                {
+                    internal static IReadOnlyList<JsonCompatibilityAliasLifecycle> All { get; } =
+                    [
+                        new("file_count", "files", "find --count --json", "QueryFindCountJsonResult", "FileCount", "Keep serialized.")
+                    ];
+                }
+                """);
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "docs/json-compatibility-alias-lifecycle.md",
+                "markdown",
+                "Docs mention Obsolete and JsonCompatibilityAliasLifecycle for reviewers.\n");
+            TestProjectHelper.InsertIndexedFile(
+                dbPath,
+                "tests/CodeIndex.Tests/JsonOutputContractsTests.cs",
+                "csharp",
+                "var fixture = \"Obsolete JsonCompatibilityAliasLifecycle\";\n");
+
+            var (exitCode, stdout, stderr) = CaptureConsole(() => QueryCommandRunner.RunSearch(
+                ["JsonCompatibilityAliasLifecycle", "--db", dbPath, "--source-only", "--origin", "code", "--json=array", "--limit", "10"],
+                _jsonOptions));
+
+            Assert.Equal(CommandExitCodes.Success, exitCode);
+            Assert.Equal(string.Empty, stderr);
+            using var document = ParseJsonOutput(stdout);
+            var result = Assert.Single(document.RootElement.EnumerateArray());
+            Assert.Equal("src/CodeIndex/Cli/JsonCompatibilityAliasLifecycles.cs", result.GetProperty("path").GetString());
+            Assert.Contains(result.GetProperty("match_origins").EnumerateArray(), origin => origin.GetString() == "code");
+        }
+        finally
+        {
+            TestProjectHelper.DeleteDirectory(projectRoot);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add production-code lifecycle metadata for deprecated JSON compatibility aliases, starting with `find --count --json` `file_count` -> `files`.
- Add regression coverage that `file_count` remains serialized, is tied to the lifecycle registry, and can be audited with production-scoped search filters.
- Add bilingual lifecycle documentation and an unreleased changelog fragment.

## Validation
- `TMPDIR=/Users/widthdom/Projects/mine/cdidx/CodeIndex21st/tmp-codex-msbuild dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --no-restore -m:1 -nr:false -p:BuildInParallel=false`
- `TMPDIR=/Users/widthdom/Projects/mine/cdidx/CodeIndex21st/tmp-codex-msbuild dotnet run --project tools/CodeIndex.Changelog --no-restore -- check`
- `dotnet test ... --filter FullyQualifiedName~Issue4182` built the test assemblies, then VSTest aborted because this environment rejects local socket bind (`System.Net.Sockets.SocketException (13): Permission denied`).

## Review
- Adversarial review: No blocking/actionable issues found.
- `codex exec` adversarial review could not start in this environment because the Codex state DB is readonly and the in-process app-server client initialization returns `Operation not permitted`.

Fixes #4182