### PR TITLE
Fix package normalize redaction test timeout fallback

### DIFF
--- a/changelog.d/unreleased/4257.fixed.md
+++ b/changelog.d/unreleased/4257.fixed.md
@@ -1,0 +1,15 @@
+---
+category: fixed
+issues:
+  - 4257
+affected:
+  - tests/CodeIndex.Tests/PackageNormalizeDiagnosticsTests.cs
+---
+
+## English
+
+- **Package normalization redaction tests now accept the safe timeout fallback (#4257)** - the package normalization diagnostic redaction test still verifies that paths, tokens, and passwords are not leaked, while allowing the all-redacted fallback produced when regex redaction times out under full Release suite load.
+
+## 日本語
+
+- **package normalization の redaction test が安全な timeout fallback を許容するようになりました (#4257)** - package normalization diagnostic redaction test は path、token、password が漏れないことを引き続き検証しつつ、Release 全体テスト負荷で regex redaction が timeout した場合の全体 `<redacted>` fallback を許容します。

--- a/tests/CodeIndex.Tests/PackageNormalizeDiagnosticsTests.cs
+++ b/tests/CodeIndex.Tests/PackageNormalizeDiagnosticsTests.cs
@@ -12,11 +12,20 @@ public class PackageNormalizeDiagnosticsTests
 
         var message = PackageNormalizeDiagnostics.FormatException("/tmp/package.nupkg", exception);
 
-        Assert.Contains("<path>", message, StringComparison.Ordinal);
-        Assert.Contains("--token=<redacted>", message, StringComparison.Ordinal);
-        Assert.Contains("password=<redacted>", message, StringComparison.Ordinal);
+        AssertRedactsSensitiveExceptionMessage(message);
+    }
+
+    private static void AssertRedactsSensitiveExceptionMessage(string message)
+    {
         Assert.DoesNotContain("/tmp/private", message, StringComparison.Ordinal);
         Assert.DoesNotContain("ghp_", message, StringComparison.Ordinal);
         Assert.DoesNotContain("hunter2", message, StringComparison.Ordinal);
+
+        if (message == "<redacted>")
+            return;
+
+        Assert.Contains("<path>", message, StringComparison.Ordinal);
+        Assert.Contains("--token=<redacted>", message, StringComparison.Ordinal);
+        Assert.Contains("password=<redacted>", message, StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
## Summary

- Adjusted the package normalization diagnostic redaction test so it still rejects leaked path/token/password values while accepting the safe all-redacted timeout fallback.
- Added a changelog fragment for #4257.

## Documentation / changelog

- Added `changelog.d/unreleased/4257.fixed.md`.
- No other documentation changes were required.

Fixes #4257

## Validation

- Compared `main...fix-issue4257`; branch is 2 commits ahead, 0 behind, and only changes `tests/CodeIndex.Tests/PackageNormalizeDiagnosticsTests.cs` plus `changelog.d/unreleased/4257.fixed.md`.
- Attempted targeted `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj -c Release -f net9.0 --filter FullyQualifiedName~PackageNormalizeDiagnosticsTests.FormatException_RedactsExceptionMessages_Issue4124`; blocked in the sandbox by MSBuild named-pipe/socket permission errors.
- Retried with escalated permissions and isolated temp state; restore/test could not complete because NuGet access failed (`NU1301`/`NU1801` against `https://api.nuget.org/v3/index.json`).
- Attempted `dotnet run --project tools/CodeIndex.Changelog -- check`; first blocked by a NuGet lock permission error, then retried with isolated temp state and failed on NuGet signature-source access (`NU1301`).

## Adversarial review

Result: No blocking/actionable issues found.

- The fallback acceptance is intentionally exact-match only for `<redacted>` and all known leak checks run before that return, so the test still fails if the observed path, token prefix, or password leak.
- The change does not alter production redaction behavior; it only aligns the assertion with the existing fail-closed timeout behavior reported in #4257.
- `codex exec` review was attempted with the fetched PR diff, but the local environment could not resolve `api.openai.com`; the review result above is from the in-thread Codex review against the same PR diff.

## Follow-up candidates

None.