### PR TITLE
[codex] Split diff and export/import helpers

### DIFF
--- a/changelog.d/unreleased/4181.internal.md
+++ b/changelog.d/unreleased/4181.internal.md
@@ -1,0 +1,22 @@
+---
+category: internal
+issues:
+  - 4181
+affected:
+  - src/CodeIndex/Cli/ExportImportCommandRunner.cs
+  - src/CodeIndex/Cli/ExportImportManifestCodec.cs
+  - src/CodeIndex/Cli/ExportImportSqliteRow.cs
+  - src/CodeIndex/Cli/DiffCommandRunner.cs
+  - src/CodeIndex/Cli/DiffCommandOptionsParser.cs
+  - src/CodeIndex/Cli/DiffResultWriter.cs
+  - tests/CodeIndex.Tests/DiffCommandHelpersTests.cs
+  - tests/CodeIndex.Tests/ExportImportManifestCodecTests.cs
+---
+
+## English
+
+- **Split diff and export/import helpers out of command runners (#4181)** — diff option parsing/rendering, manifest JSON decoding, header validation, and nullable SQLite row reads now live in focused helpers with direct regression coverage, reducing the CLI orchestration hotspots.
+
+## 日本語
+
+- **diff と export/import の helper を command runner から分離しました (#4181)** — diff のオプション解析と出力整形、manifest JSON のデコード、ヘッダー検証、nullable SQLite 行読み取りを専用 helper に移し、直接の回帰テストを追加することで CLI の orchestration hotspot を縮小しました。

--- a/src/CodeIndex/Cli/DiffCommandOptionsParser.cs
+++ b/src/CodeIndex/Cli/DiffCommandOptionsParser.cs
@@ -1,0 +1,72 @@
+namespace CodeIndex.Cli;
+
+internal static class DiffCommandOptionsParser
+{
+    internal const int DefaultLimit = 20;
+
+    internal static DiffCommandOptions Parse(string[] args, int maxLimit)
+    {
+        var dbs = new List<string>(2);
+        var json = false;
+        var detailed = false;
+        var summaryOnly = false;
+        var limit = DefaultLimit;
+        string? parseError = null;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            var arg = args[i];
+            switch (arg)
+            {
+                case "--help" or "-h":
+                    return new DiffCommandOptions { ShowHelp = true };
+                case "--json":
+                    json = true;
+                    break;
+                case "--detailed":
+                    detailed = true;
+                    break;
+                case "--summary-only":
+                    summaryOnly = true;
+                    break;
+                case "--limit" when i + 1 < args.Length:
+                    if (!int.TryParse(args[++i], out limit) || limit < 0)
+                        parseError = "--limit requires a non-negative integer";
+                    else if (limit > maxLimit)
+                    {
+                        parseError = $"--limit must be less than or equal to {maxLimit}";
+                        limit = DefaultLimit;
+                    }
+                    break;
+                case "--limit":
+                    parseError = "--limit requires a value";
+                    break;
+                default:
+                    if (arg.StartsWith('-'))
+                        parseError = $"diff does not support option: '{arg}'";
+                    else if (dbs.Count >= 2)
+                        parseError = $"diff accepts exactly two database paths; unexpected argument: '{arg}'";
+                    else
+                        dbs.Add(arg);
+                    break;
+            }
+
+            if (parseError is not null)
+                break;
+        }
+
+        if (parseError is null && dbs.Count != 2)
+            parseError = "diff requires exactly two database paths";
+
+        return new DiffCommandOptions
+        {
+            LeftDb = dbs.Count > 0 ? dbs[0] : null,
+            RightDb = dbs.Count > 1 ? dbs[1] : null,
+            Json = json,
+            Detailed = detailed,
+            SummaryOnly = summaryOnly,
+            Limit = limit,
+            ParseError = parseError,
+        };
+    }
+}

--- a/src/CodeIndex/Cli/DiffCommandRunner.cs
+++ b/src/CodeIndex/Cli/DiffCommandRunner.cs
@@ -9,7 +9,7 @@ namespace CodeIndex.Cli;
 
 public static class DiffCommandRunner
 {
-    private const int DefaultDiffLimit = 20;
+    internal const int DefaultDiffLimit = DiffCommandOptionsParser.DefaultLimit;
     internal const int MaxDiffEncodedFieldSampleLength = 1024;
     internal const int MaxDiffComparedRowsPerSide = 1_000_000;
     internal const int MaxDiffComparedRowBytes = 4 * 1024 * 1024;
@@ -33,7 +33,7 @@ public static class DiffCommandRunner
         }
 
         if (options.ParseError is not null)
-            return WriteCommandError(
+            return DiffResultWriter.WriteCommandError(
                 options.Json || options.SummaryOnly,
                 jsonOptions,
                 options.ParseError,
@@ -59,19 +59,19 @@ public static class DiffCommandRunner
             if (leftHeader.SchemaVersion != rightHeader.SchemaVersion)
             {
                 var schemaMismatch = BuildSchemaMismatchDiff(leftHeader, rightHeader, options);
-                WriteResult(schemaMismatch, options, jsonOptions);
+                DiffResultWriter.WriteResult(schemaMismatch, options, jsonOptions);
                 return SchemaMismatchExitCode;
             }
 
             var result = BuildDiff(leftHeader, rightHeader, options, cancellationToken);
 
-            WriteResult(result, options, jsonOptions);
+            DiffResultWriter.WriteResult(result, options, jsonOptions);
 
             return result.Identical ? CommandExitCodes.Success : DriftExitCode;
         }
         catch (OperationCanceledException)
         {
-            return WriteCommandError(
+            return DiffResultWriter.WriteCommandError(
                 options.Json || options.SummaryOnly,
                 jsonOptions,
                 "diff comparison cancelled before it could complete",
@@ -81,7 +81,7 @@ public static class DiffCommandRunner
         }
         catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or SqliteException or InvalidOperationException)
         {
-            return WriteCommandError(
+            return DiffResultWriter.WriteCommandError(
                 options.Json || options.SummaryOnly,
                 jsonOptions,
                 $"failed to compare databases: {CommandErrorWriter.FormatSanitizedExceptionMessage(ex)}",
@@ -96,7 +96,7 @@ public static class DiffCommandRunner
         if (SqliteFileUri.TryValidateBounds(dbPath, out var parseError))
             return null;
 
-        return WriteCommandError(
+        return DiffResultWriter.WriteCommandError(
             json,
             jsonOptions,
             $"invalid database file URI: {SqliteFileUri.FormatParseError(parseError)}",
@@ -106,70 +106,7 @@ public static class DiffCommandRunner
     }
 
     internal static DiffCommandOptions ParseArgs(string[] args)
-    {
-        var dbs = new List<string>(2);
-        var json = false;
-        var detailed = false;
-        var summaryOnly = false;
-        var limit = DefaultDiffLimit;
-        string? parseError = null;
-
-        for (var i = 0; i < args.Length; i++)
-        {
-            var arg = args[i];
-            switch (arg)
-            {
-                case "--help" or "-h":
-                    return new DiffCommandOptions { ShowHelp = true };
-                case "--json":
-                    json = true;
-                    break;
-                case "--detailed":
-                    detailed = true;
-                    break;
-                case "--summary-only":
-                    summaryOnly = true;
-                    break;
-                case "--limit" when i + 1 < args.Length:
-                    if (!int.TryParse(args[++i], out limit) || limit < 0)
-                        parseError = "--limit requires a non-negative integer";
-                    else if (limit > MaxDiffLimit)
-                    {
-                        parseError = $"--limit must be less than or equal to {MaxDiffLimit}";
-                        limit = DefaultDiffLimit;
-                    }
-                    break;
-                case "--limit":
-                    parseError = "--limit requires a value";
-                    break;
-                default:
-                    if (arg.StartsWith('-'))
-                        parseError = $"diff does not support option: '{arg}'";
-                    else if (dbs.Count >= 2)
-                        parseError = $"diff accepts exactly two database paths; unexpected argument: '{arg}'";
-                    else
-                        dbs.Add(arg);
-                    break;
-            }
-
-            if (parseError is not null)
-                break;
-        }
-
-        if (parseError is null && dbs.Count != 2)
-            parseError = "diff requires exactly two database paths";
-
-        return new DiffCommandOptions
-        {
-            LeftDb = dbs.Count > 0 ? dbs[0] : null,
-            RightDb = dbs.Count > 1 ? dbs[1] : null,
-            Json = json,
-            Detailed = detailed,
-            SummaryOnly = summaryOnly,
-            Limit = limit,
-            ParseError = parseError,
-        };
-    }
+        => DiffCommandOptionsParser.Parse(args, MaxDiffLimit);
 
     private const string FilePathRowsSql = "SELECT path FROM files ORDER BY path";
 
@@ -878,76 +815,6 @@ public static class DiffCommandRunner
             + " sha256="
             + hash
             + "]";
-    }
-
-    private static void WriteJson(DiffJsonResult result, JsonSerializerOptions jsonOptions)
-    {
-        Console.WriteLine(JsonSerializer.Serialize(
-            result,
-            CliJsonSerializerContextFactory.Create(jsonOptions).DiffJsonResult));
-    }
-
-    private static void WriteSummaryJson(DiffJsonResult result, JsonSerializerOptions jsonOptions)
-    {
-        Console.WriteLine(JsonSerializer.Serialize(
-            new DiffSummaryOnlyJsonResult(result.Status, result.Identical, result.LeftDb, result.RightDb, result.Summary),
-            CliJsonSerializerContextFactory.Create(jsonOptions).DiffSummaryOnlyJsonResult));
-    }
-
-    private static void WriteResult(DiffJsonResult result, DiffCommandOptions options, JsonSerializerOptions jsonOptions)
-    {
-        if (options.SummaryOnly)
-            WriteSummaryJson(result, jsonOptions);
-        else if (options.Json)
-            WriteJson(result, jsonOptions);
-        else
-            WriteText(result, options);
-    }
-
-    private static void WriteText(DiffJsonResult result, DiffCommandOptions options)
-    {
-        Console.WriteLine("Index database diff");
-        Console.WriteLine($"  left   : {result.LeftDb}");
-        Console.WriteLine($"  right  : {result.RightDb}");
-        Console.WriteLine($"  status : {result.Status}");
-        Console.WriteLine($"  schema : {result.Summary.LeftSchemaVersion} -> {result.Summary.RightSchemaVersion}");
-        Console.WriteLine($"  files  : {result.Summary.LeftFileCount} -> {result.Summary.RightFileCount} ({FormatDelta(result.Summary.FileCountDelta)})");
-        Console.WriteLine($"  symbols: {result.Summary.LeftSymbolCount} -> {result.Summary.RightSymbolCount} ({FormatDelta(result.Summary.SymbolCountDelta)})");
-        Console.WriteLine($"  refs   : {result.Summary.LeftReferenceCount} -> {result.Summary.RightReferenceCount} ({FormatDelta(result.Summary.ReferenceCountDelta)})");
-
-        WriteList("files only in left", result.FilesOnlyInLeft);
-        WriteList("files only in right", result.FilesOnlyInRight);
-        if (options.Detailed)
-        {
-            WriteList("symbols only in left", result.SymbolsOnlyInLeft ?? []);
-            WriteList("symbols only in right", result.SymbolsOnlyInRight ?? []);
-        }
-    }
-
-    private static void WriteList(string label, List<string> values)
-    {
-        if (values.Count == 0)
-            return;
-        Console.WriteLine($"  {label}:");
-        foreach (var value in values)
-            Console.WriteLine($"    - {value}");
-    }
-
-    private static string FormatDelta(long delta) => delta >= 0 ? $"+{delta}" : delta.ToString(System.Globalization.CultureInfo.InvariantCulture);
-
-    private static int WriteCommandError(bool json, JsonSerializerOptions jsonOptions, string message, int exitCode, string? hint = null, string? errorCode = null)
-    {
-        if (json)
-            Console.WriteLine(JsonSerializer.Serialize(
-                new CommandErrorJsonResult("error", message, hint, errorCode),
-                CliJsonSerializerContextFactory.Create(jsonOptions).CommandErrorJsonResult));
-        else
-        {
-            CommandErrorWriter.WriteStderr($"Error [{errorCode ?? CommandErrorCodes.UsageError}]: {message}");
-            if (!string.IsNullOrWhiteSpace(hint))
-                CommandErrorWriter.WriteStderr($"Hint: {hint}");
-        }
-        return exitCode;
     }
 
     private sealed record OrderedRowsDiff(

--- a/src/CodeIndex/Cli/DiffResultWriter.cs
+++ b/src/CodeIndex/Cli/DiffResultWriter.cs
@@ -1,0 +1,78 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace CodeIndex.Cli;
+
+internal static class DiffResultWriter
+{
+    internal static void WriteResult(DiffJsonResult result, DiffCommandOptions options, JsonSerializerOptions jsonOptions)
+    {
+        if (options.SummaryOnly)
+            WriteSummaryJson(result, jsonOptions);
+        else if (options.Json)
+            WriteJson(result, jsonOptions);
+        else
+            WriteText(result, options);
+    }
+
+    internal static int WriteCommandError(bool json, JsonSerializerOptions jsonOptions, string message, int exitCode, string? hint = null, string? errorCode = null)
+    {
+        if (json)
+            Console.WriteLine(JsonSerializer.Serialize(
+                new CommandErrorJsonResult("error", message, hint, errorCode),
+                CliJsonSerializerContextFactory.Create(jsonOptions).CommandErrorJsonResult));
+        else
+        {
+            CommandErrorWriter.WriteStderr($"Error [{errorCode ?? CommandErrorCodes.UsageError}]: {message}");
+            if (!string.IsNullOrWhiteSpace(hint))
+                CommandErrorWriter.WriteStderr($"Hint: {hint}");
+        }
+        return exitCode;
+    }
+
+    internal static string FormatDelta(long delta)
+        => delta >= 0 ? $"+{delta}" : delta.ToString(CultureInfo.InvariantCulture);
+
+    private static void WriteJson(DiffJsonResult result, JsonSerializerOptions jsonOptions)
+    {
+        Console.WriteLine(JsonSerializer.Serialize(
+            result,
+            CliJsonSerializerContextFactory.Create(jsonOptions).DiffJsonResult));
+    }
+
+    private static void WriteSummaryJson(DiffJsonResult result, JsonSerializerOptions jsonOptions)
+    {
+        Console.WriteLine(JsonSerializer.Serialize(
+            new DiffSummaryOnlyJsonResult(result.Status, result.Identical, result.LeftDb, result.RightDb, result.Summary),
+            CliJsonSerializerContextFactory.Create(jsonOptions).DiffSummaryOnlyJsonResult));
+    }
+
+    private static void WriteText(DiffJsonResult result, DiffCommandOptions options)
+    {
+        Console.WriteLine("Index database diff");
+        Console.WriteLine($"  left   : {result.LeftDb}");
+        Console.WriteLine($"  right  : {result.RightDb}");
+        Console.WriteLine($"  status : {result.Status}");
+        Console.WriteLine($"  schema : {result.Summary.LeftSchemaVersion} -> {result.Summary.RightSchemaVersion}");
+        Console.WriteLine($"  files  : {result.Summary.LeftFileCount} -> {result.Summary.RightFileCount} ({FormatDelta(result.Summary.FileCountDelta)})");
+        Console.WriteLine($"  symbols: {result.Summary.LeftSymbolCount} -> {result.Summary.RightSymbolCount} ({FormatDelta(result.Summary.SymbolCountDelta)})");
+        Console.WriteLine($"  refs   : {result.Summary.LeftReferenceCount} -> {result.Summary.RightReferenceCount} ({FormatDelta(result.Summary.ReferenceCountDelta)})");
+
+        WriteList("files only in left", result.FilesOnlyInLeft);
+        WriteList("files only in right", result.FilesOnlyInRight);
+        if (options.Detailed)
+        {
+            WriteList("symbols only in left", result.SymbolsOnlyInLeft ?? []);
+            WriteList("symbols only in right", result.SymbolsOnlyInRight ?? []);
+        }
+    }
+
+    private static void WriteList(string label, List<string> values)
+    {
+        if (values.Count == 0)
+            return;
+        Console.WriteLine($"  {label}:");
+        foreach (var value in values)
+            Console.WriteLine($"    - {value}");
+    }
+}

--- a/src/CodeIndex/Cli/ExportImportCommandRunner.cs
+++ b/src/CodeIndex/Cli/ExportImportCommandRunner.cs
@@ -21,11 +21,11 @@ internal static class ExportImportCommandRunner
     internal const long MaxImportDatabaseBytes = 8L * 1024 * 1024 * 1024;
     internal const long MaxImportDatabaseCompressionRatio = 1000;
     private const int ImportCopyBufferSize = 81920;
-    private const int ManifestUnknownExtensionFileLimit = DbContext.UnknownExtensionFilePathSampleLimit;
+    internal const int ManifestUnknownExtensionFileLimit = DbContext.UnknownExtensionFilePathSampleLimit;
     private const int ManifestUnknownExtensionJsonDepth = 4;
     internal const int ManifestUnknownExtensionDecodedItemLimit = ManifestUnknownExtensionFileLimit;
     internal const int ManifestUnknownExtensionPathCharLimit = 4096;
-    private const int ManifestUnknownExtensionFilesTotalCharLimit = 32 * 1024;
+    internal const int ManifestUnknownExtensionFilesTotalCharLimit = 32 * 1024;
     private static readonly DateTimeOffset DeterministicZipTimestamp = new(1980, 1, 1, 0, 0, 0, TimeSpan.Zero);
     private const string ExportCommandName = "export";
     private const string ImportCommandName = "import";
@@ -151,7 +151,7 @@ internal static class ExportImportCommandRunner
                 phase = PhaseManifest;
                 if (!TryReadManifest(manifestEntry, jsonOptions, out var manifest, out var manifestError, cancellationToken))
                     return WriteImportError(wantsJson, jsonOptions, PhaseManifest, "import_manifest_invalid", $"archive manifest is invalid: {manifestError}.", "use an archive produced by `cdidx export <archive>`.", ImportUsage);
-                if (!TryValidateManifestHeader(manifest, out var manifestHeaderError))
+                if (!ExportImportManifestCodec.TryValidateHeader(manifest, out var manifestHeaderError))
                     return WriteImportError(wantsJson, jsonOptions, PhaseManifest, "import_manifest_incompatible", $"archive manifest is invalid: {manifestHeaderError}.", "re-export from a compatible CodeIndex database.", ImportUsage);
                 importedManifest = manifest;
                 AddImportValidationPhase(validationPhases, PhaseManifest);
@@ -512,10 +512,10 @@ internal static class ExportImportCommandRunner
                         .Append(kind)
                         .Append("\tline:")
                         .Append(line.ToString(CultureInfo.InvariantCulture));
-                    AppendCtagsExtensionField(tagLine, "language", GetNullableString(reader, 4));
-                    AppendCtagsExtensionField(tagLine, "container_kind", GetNullableString(reader, 5));
-                    AppendCtagsExtensionField(tagLine, "container", GetNullableString(reader, 6));
-                    AppendCtagsExtensionField(tagLine, "visibility", GetNullableString(reader, 7));
+                    AppendCtagsExtensionField(tagLine, "language", ExportImportSqliteRow.ReadNullableString(reader, 4));
+                    AppendCtagsExtensionField(tagLine, "container_kind", ExportImportSqliteRow.ReadNullableString(reader, 5));
+                    AppendCtagsExtensionField(tagLine, "container", ExportImportSqliteRow.ReadNullableString(reader, 6));
+                    AppendCtagsExtensionField(tagLine, "visibility", ExportImportSqliteRow.ReadNullableString(reader, 7));
                     writer.WriteLine(tagLine.ToString());
                     emittedCount++;
                 }
@@ -614,9 +614,6 @@ internal static class ExportImportCommandRunner
         DbReader.AddPathFilterParameterSet(cmd, "pathPattern", filters.PathPatterns);
         DbReader.AddPathFilterParameterSet(cmd, "excludePathPattern", filters.ExcludePathPatterns);
     }
-
-    private static string? GetNullableString(SqliteDataReader reader, int ordinal)
-        => reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
 
     private static void AppendCtagsExtensionField(StringBuilder builder, string name, string? value)
     {
@@ -797,7 +794,7 @@ internal static class ExportImportCommandRunner
 
     private static bool TryReadManifest(ZipArchiveEntry manifestEntry, JsonSerializerOptions jsonOptions, out ExportManifest manifest, out string message, CancellationToken cancellationToken)
     {
-        if (!TryValidateManifestEntrySize(manifestEntry, out message))
+        if (!ExportImportManifestCodec.TryValidateEntrySize(manifestEntry, out message))
         {
             manifest = null!;
             return false;
@@ -811,27 +808,11 @@ internal static class ExportImportCommandRunner
             CopyToWithLimit(stream, manifestBytes, MaxImportManifestBytes, ManifestEntryName, cancellationToken);
             manifestBytes.Position = 0;
             cancellationToken.ThrowIfCancellationRequested();
-            if (JsonExceedsDepthLimit(manifestBytes.GetBuffer().AsSpan(0, (int)manifestBytes.Length), MaxImportManifestJsonDepth))
-            {
-                manifest = null!;
-                message = $"manifest.json exceeds the JSON depth limit of {MaxImportManifestJsonDepth}";
-                return false;
-            }
-
-            var parsedManifest = BoundedJson.Deserialize<ExportManifest>(
+            return ExportImportManifestCodec.TryDeserialize(
                 manifestBytes.GetBuffer().AsSpan(0, (int)manifestBytes.Length),
-                MaxImportManifestBytes,
-                CreateImportManifestJsonOptions(jsonOptions));
-            if (parsedManifest == null)
-            {
-                manifest = null!;
-                message = "manifest.json did not contain an object";
-                return false;
-            }
-
-            manifest = parsedManifest;
-            message = string.Empty;
-            return true;
+                jsonOptions,
+                out manifest,
+                out message);
         }
         catch (InvalidDataException ex)
         {
@@ -839,181 +820,6 @@ internal static class ExportImportCommandRunner
             message = FormatImportManifestReadException(ex);
             return false;
         }
-        catch (JsonException)
-        {
-            manifest = null!;
-            message = "manifest.json is not valid export manifest JSON";
-            return false;
-        }
-        catch (NotSupportedException)
-        {
-            manifest = null!;
-            message = "manifest.json contains unsupported export manifest JSON";
-            return false;
-        }
-    }
-
-    private static bool TryValidateManifestEntrySize(ZipArchiveEntry manifestEntry, out string message)
-    {
-        if (manifestEntry.Length < 0 || manifestEntry.CompressedLength < 0)
-        {
-            message = "archive manifest.json size metadata is invalid";
-            return false;
-        }
-
-        if (manifestEntry.Length > MaxImportManifestBytes)
-        {
-            message = $"archive manifest.json is too large: {ConsoleUi.FormatBytes(manifestEntry.Length)} uncompressed exceeds the import limit of {ConsoleUi.FormatBytes(MaxImportManifestBytes)}";
-            return false;
-        }
-
-        if (manifestEntry.CompressedLength > MaxImportManifestBytes)
-        {
-            message = $"archive manifest.json is too large: {ConsoleUi.FormatBytes(manifestEntry.CompressedLength)} compressed exceeds the import limit of {ConsoleUi.FormatBytes(MaxImportManifestBytes)}";
-            return false;
-        }
-
-        message = string.Empty;
-        return true;
-    }
-
-    private static JsonSerializerOptions CreateImportManifestJsonOptions(JsonSerializerOptions jsonOptions)
-        => new(jsonOptions) { MaxDepth = MaxImportManifestJsonDepth };
-
-    private static bool JsonExceedsDepthLimit(ReadOnlySpan<byte> json, int maxDepth)
-    {
-        var depth = 0;
-        var inString = false;
-
-        for (var i = 0; i < json.Length; i++)
-        {
-            var value = json[i];
-            if (inString)
-            {
-                if (value == (byte)'\\')
-                {
-                    i++;
-                    continue;
-                }
-
-                if (value == (byte)'"')
-                    inString = false;
-                continue;
-            }
-
-            if (value == (byte)'"')
-            {
-                inString = true;
-                continue;
-            }
-
-            if (value is (byte)'{' or (byte)'[')
-            {
-                depth++;
-                if (depth > maxDepth)
-                    return true;
-                continue;
-            }
-
-            if (value is (byte)'}' or (byte)']')
-                depth = Math.Max(0, depth - 1);
-        }
-
-        return false;
-    }
-
-    private static bool TryValidateManifestHeader(ExportManifest manifest, out string message)
-    {
-        if (!string.Equals(manifest.FormatVersion, "1", StringComparison.Ordinal))
-        {
-            message = $"unsupported format_version `{manifest.FormatVersion}`";
-            return false;
-        }
-
-        if (manifest.UserVersion < 0 || (manifest.UserVersion & ~DbContext.CurrentSchemaVersion) != 0)
-        {
-            message = $"unsupported user_version `{manifest.UserVersion}`";
-            return false;
-        }
-
-        if (!IsSha256Hex(manifest.DatabaseSha256))
-        {
-            message = "database_sha256 is missing or invalid";
-            return false;
-        }
-
-        if (!ValidateNonNegativeManifestLong(manifest.FileCount, "file_count", out message)
-            || !ValidateNonNegativeManifestLong(manifest.ChunkCount, "chunk_count", out message)
-            || !ValidateNonNegativeManifestLong(manifest.SymbolCount, "symbol_count", out message)
-            || !ValidateNonNegativeManifestLong(manifest.ReferenceCount, "reference_count", out message)
-            || !ValidateNonNegativeManifestLong(manifest.UnknownExtensionFileCount, "unknown_extension_file_count", out message))
-        {
-            return false;
-        }
-
-        if (!ValidateNonNegativeManifestInt(manifest.CodeIndexMetaSchemaVersion, "codeindex_meta_schema_version", out message)
-            || !ValidateNonNegativeManifestInt(manifest.CSharpSymbolNameContractVersion, "csharp_symbol_name_contract_version", out message)
-            || !ValidateNonNegativeManifestInt(manifest.SqlGraphContractVersion, "sql_graph_contract_version", out message)
-            || !ValidateNonNegativeManifestInt(manifest.HotspotFamilyVersion, "hotspot_family_version", out message)
-            || !ValidateNonNegativeManifestInt(manifest.UnknownExtensionFilePathLimit, "unknown_extension_file_path_limit", out message)
-            || !ValidateNonNegativeManifestInt(manifest.UnknownExtensionFileSampleCount, "unknown_extension_file_sample_count", out message)
-            || !ValidateNonNegativeManifestInt(manifest.UnknownExtensionFileSampleLimit, "unknown_extension_file_sample_limit", out message))
-        {
-            return false;
-        }
-
-        if (manifest.UnknownExtensionFileSampleCount.HasValue)
-        {
-            var sampleLength = manifest.UnknownExtensionFiles?.Length ?? 0;
-            if (manifest.UnknownExtensionFileSampleCount.Value != sampleLength)
-            {
-                message = "unknown_extension_file_sample_count must match unknown_extension_files length";
-                return false;
-            }
-        }
-
-        if (manifest.UnknownExtensionFileSampleCount.HasValue
-            && manifest.UnknownExtensionFileSampleLimit.HasValue
-            && manifest.UnknownExtensionFileSampleCount.Value > manifest.UnknownExtensionFileSampleLimit.Value)
-        {
-            message = "unknown_extension_file_sample_count exceeds unknown_extension_file_sample_limit";
-            return false;
-        }
-
-        if (manifest.UnknownExtensionFiles is { Length: > ManifestUnknownExtensionFileLimit })
-        {
-            message = $"unknown_extension_files exceeds the manifest limit of {ManifestUnknownExtensionFileLimit}";
-            return false;
-        }
-
-        if (manifest.UnknownExtensionFiles != null)
-        {
-            var totalPathChars = 0;
-            foreach (var path in manifest.UnknownExtensionFiles)
-            {
-                if (string.IsNullOrWhiteSpace(path))
-                {
-                    message = "unknown_extension_files contains an empty path";
-                    return false;
-                }
-
-                if (path.Length > ManifestUnknownExtensionPathCharLimit)
-                {
-                    message = $"unknown_extension_files contains a path longer than {ManifestUnknownExtensionPathCharLimit} characters";
-                    return false;
-                }
-
-                totalPathChars += path.Length;
-                if (totalPathChars > ManifestUnknownExtensionFilesTotalCharLimit)
-                {
-                    message = $"unknown_extension_files total path text exceeds the manifest limit of {ManifestUnknownExtensionFilesTotalCharLimit} characters";
-                    return false;
-                }
-            }
-        }
-
-        message = string.Empty;
-        return true;
     }
 
     private static bool TryValidateImportedManifest(
@@ -1083,30 +889,6 @@ internal static class ExportImportCommandRunner
         if (actual != expected.Value)
         {
             message = $"manifest {fieldName} `{expected.Value}` does not match codeindex.db {tableName} count `{actual}`";
-            return false;
-        }
-
-        message = string.Empty;
-        return true;
-    }
-
-    private static bool ValidateNonNegativeManifestLong(long? value, string fieldName, out string message)
-    {
-        if (value is < 0)
-        {
-            message = $"{fieldName} must be non-negative";
-            return false;
-        }
-
-        message = string.Empty;
-        return true;
-    }
-
-    private static bool ValidateNonNegativeManifestInt(int? value, string fieldName, out string message)
-    {
-        if (value is < 0)
-        {
-            message = $"{fieldName} must be non-negative";
             return false;
         }
 
@@ -1236,20 +1018,6 @@ internal static class ExportImportCommandRunner
         {
             return new(null, null, null, null);
         }
-    }
-
-    private static bool IsSha256Hex(string? value)
-    {
-        if (value == null || value.Length != 64)
-            return false;
-
-        foreach (var ch in value)
-        {
-            if (!char.IsAsciiHexDigit(ch))
-                return false;
-        }
-
-        return true;
     }
 
     internal static bool TryValidateDatabaseEntrySize(long uncompressedLength, long compressedLength, out string message)

--- a/src/CodeIndex/Cli/ExportImportManifestCodec.cs
+++ b/src/CodeIndex/Cli/ExportImportManifestCodec.cs
@@ -1,0 +1,260 @@
+using System.IO.Compression;
+using System.Text.Json;
+using CodeIndex.Database;
+using CodeIndex.Diagnostics;
+
+namespace CodeIndex.Cli;
+
+internal static class ExportImportManifestCodec
+{
+    internal static bool TryDeserialize(
+        ReadOnlySpan<byte> utf8Json,
+        JsonSerializerOptions jsonOptions,
+        out ExportImportCommandRunner.ExportManifest manifest,
+        out string message)
+    {
+        if (JsonExceedsDepthLimit(utf8Json, ExportImportCommandRunner.MaxImportManifestJsonDepth))
+        {
+            manifest = null!;
+            message = $"manifest.json exceeds the JSON depth limit of {ExportImportCommandRunner.MaxImportManifestJsonDepth}";
+            return false;
+        }
+
+        try
+        {
+            var parsedManifest = BoundedJson.Deserialize<ExportImportCommandRunner.ExportManifest>(
+                utf8Json,
+                ExportImportCommandRunner.MaxImportManifestBytes,
+                CreateImportManifestJsonOptions(jsonOptions));
+            if (parsedManifest == null)
+            {
+                manifest = null!;
+                message = "manifest.json did not contain an object";
+                return false;
+            }
+
+            manifest = parsedManifest;
+            message = string.Empty;
+            return true;
+        }
+        catch (JsonException)
+        {
+            manifest = null!;
+            message = "manifest.json is not valid export manifest JSON";
+            return false;
+        }
+        catch (NotSupportedException)
+        {
+            manifest = null!;
+            message = "manifest.json contains unsupported export manifest JSON";
+            return false;
+        }
+        catch (InvalidDataException ex)
+        {
+            manifest = null!;
+            message = ExportImportCommandRunner.FormatImportManifestReadException(ex);
+            return false;
+        }
+    }
+
+    internal static bool TryValidateEntrySize(ZipArchiveEntry manifestEntry, out string message)
+    {
+        if (manifestEntry.Length < 0 || manifestEntry.CompressedLength < 0)
+        {
+            message = "archive manifest.json size metadata is invalid";
+            return false;
+        }
+
+        if (manifestEntry.Length > ExportImportCommandRunner.MaxImportManifestBytes)
+        {
+            message = $"archive manifest.json is too large: {ConsoleUi.FormatBytes(manifestEntry.Length)} uncompressed exceeds the import limit of {ConsoleUi.FormatBytes(ExportImportCommandRunner.MaxImportManifestBytes)}";
+            return false;
+        }
+
+        if (manifestEntry.CompressedLength > ExportImportCommandRunner.MaxImportManifestBytes)
+        {
+            message = $"archive manifest.json is too large: {ConsoleUi.FormatBytes(manifestEntry.CompressedLength)} compressed exceeds the import limit of {ConsoleUi.FormatBytes(ExportImportCommandRunner.MaxImportManifestBytes)}";
+            return false;
+        }
+
+        message = string.Empty;
+        return true;
+    }
+
+    internal static bool TryValidateHeader(ExportImportCommandRunner.ExportManifest manifest, out string message)
+    {
+        if (!string.Equals(manifest.FormatVersion, "1", StringComparison.Ordinal))
+        {
+            message = $"unsupported format_version `{manifest.FormatVersion}`";
+            return false;
+        }
+
+        if (manifest.UserVersion < 0 || (manifest.UserVersion & ~DbContext.CurrentSchemaVersion) != 0)
+        {
+            message = $"unsupported user_version `{manifest.UserVersion}`";
+            return false;
+        }
+
+        if (!IsSha256Hex(manifest.DatabaseSha256))
+        {
+            message = "database_sha256 is missing or invalid";
+            return false;
+        }
+
+        if (!ValidateNonNegativeManifestLong(manifest.FileCount, "file_count", out message)
+            || !ValidateNonNegativeManifestLong(manifest.ChunkCount, "chunk_count", out message)
+            || !ValidateNonNegativeManifestLong(manifest.SymbolCount, "symbol_count", out message)
+            || !ValidateNonNegativeManifestLong(manifest.ReferenceCount, "reference_count", out message)
+            || !ValidateNonNegativeManifestLong(manifest.UnknownExtensionFileCount, "unknown_extension_file_count", out message))
+        {
+            return false;
+        }
+
+        if (!ValidateNonNegativeManifestInt(manifest.CodeIndexMetaSchemaVersion, "codeindex_meta_schema_version", out message)
+            || !ValidateNonNegativeManifestInt(manifest.CSharpSymbolNameContractVersion, "csharp_symbol_name_contract_version", out message)
+            || !ValidateNonNegativeManifestInt(manifest.SqlGraphContractVersion, "sql_graph_contract_version", out message)
+            || !ValidateNonNegativeManifestInt(manifest.HotspotFamilyVersion, "hotspot_family_version", out message)
+            || !ValidateNonNegativeManifestInt(manifest.UnknownExtensionFilePathLimit, "unknown_extension_file_path_limit", out message)
+            || !ValidateNonNegativeManifestInt(manifest.UnknownExtensionFileSampleCount, "unknown_extension_file_sample_count", out message)
+            || !ValidateNonNegativeManifestInt(manifest.UnknownExtensionFileSampleLimit, "unknown_extension_file_sample_limit", out message))
+        {
+            return false;
+        }
+
+        if (manifest.UnknownExtensionFileSampleCount.HasValue)
+        {
+            var sampleLength = manifest.UnknownExtensionFiles?.Length ?? 0;
+            if (manifest.UnknownExtensionFileSampleCount.Value != sampleLength)
+            {
+                message = "unknown_extension_file_sample_count must match unknown_extension_files length";
+                return false;
+            }
+        }
+
+        if (manifest.UnknownExtensionFileSampleCount.HasValue
+            && manifest.UnknownExtensionFileSampleLimit.HasValue
+            && manifest.UnknownExtensionFileSampleCount.Value > manifest.UnknownExtensionFileSampleLimit.Value)
+        {
+            message = "unknown_extension_file_sample_count exceeds unknown_extension_file_sample_limit";
+            return false;
+        }
+
+        if (manifest.UnknownExtensionFiles is { Length: > ExportImportCommandRunner.ManifestUnknownExtensionFileLimit })
+        {
+            message = $"unknown_extension_files exceeds the manifest limit of {ExportImportCommandRunner.ManifestUnknownExtensionFileLimit}";
+            return false;
+        }
+
+        if (manifest.UnknownExtensionFiles != null)
+        {
+            var totalPathChars = 0;
+            foreach (var path in manifest.UnknownExtensionFiles)
+            {
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    message = "unknown_extension_files contains an empty path";
+                    return false;
+                }
+
+                if (path.Length > ExportImportCommandRunner.ManifestUnknownExtensionPathCharLimit)
+                {
+                    message = $"unknown_extension_files contains a path longer than {ExportImportCommandRunner.ManifestUnknownExtensionPathCharLimit} characters";
+                    return false;
+                }
+
+                totalPathChars += path.Length;
+                if (totalPathChars > ExportImportCommandRunner.ManifestUnknownExtensionFilesTotalCharLimit)
+                {
+                    message = $"unknown_extension_files total path text exceeds the manifest limit of {ExportImportCommandRunner.ManifestUnknownExtensionFilesTotalCharLimit} characters";
+                    return false;
+                }
+            }
+        }
+
+        message = string.Empty;
+        return true;
+    }
+
+    internal static JsonSerializerOptions CreateImportManifestJsonOptions(JsonSerializerOptions jsonOptions)
+        => new(jsonOptions) { MaxDepth = ExportImportCommandRunner.MaxImportManifestJsonDepth };
+
+    internal static bool JsonExceedsDepthLimit(ReadOnlySpan<byte> json, int maxDepth)
+    {
+        var depth = 0;
+        var inString = false;
+
+        for (var i = 0; i < json.Length; i++)
+        {
+            var value = json[i];
+            if (inString)
+            {
+                if (value == (byte)'\\')
+                {
+                    i++;
+                    continue;
+                }
+
+                if (value == (byte)'"')
+                    inString = false;
+                continue;
+            }
+
+            if (value == (byte)'"')
+            {
+                inString = true;
+                continue;
+            }
+
+            if (value is (byte)'{' or (byte)'[')
+            {
+                depth++;
+                if (depth > maxDepth)
+                    return true;
+                continue;
+            }
+
+            if (value is (byte)'}' or (byte)']')
+                depth = Math.Max(0, depth - 1);
+        }
+
+        return false;
+    }
+
+    private static bool ValidateNonNegativeManifestLong(long? value, string fieldName, out string message)
+    {
+        if (value is < 0)
+        {
+            message = $"{fieldName} must be non-negative";
+            return false;
+        }
+
+        message = string.Empty;
+        return true;
+    }
+
+    private static bool ValidateNonNegativeManifestInt(int? value, string fieldName, out string message)
+    {
+        if (value is < 0)
+        {
+            message = $"{fieldName} must be non-negative";
+            return false;
+        }
+
+        message = string.Empty;
+        return true;
+    }
+
+    private static bool IsSha256Hex(string? value)
+    {
+        if (value == null || value.Length != 64)
+            return false;
+
+        foreach (var ch in value)
+        {
+            if (!char.IsAsciiHexDigit(ch))
+                return false;
+        }
+
+        return true;
+    }
+}

--- a/src/CodeIndex/Cli/ExportImportSqliteRow.cs
+++ b/src/CodeIndex/Cli/ExportImportSqliteRow.cs
@@ -1,0 +1,9 @@
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Cli;
+
+internal static class ExportImportSqliteRow
+{
+    internal static string? ReadNullableString(SqliteDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal) ? null : reader.GetString(ordinal);
+}

--- a/tests/CodeIndex.Tests/DiffCommandHelpersTests.cs
+++ b/tests/CodeIndex.Tests/DiffCommandHelpersTests.cs
@@ -1,0 +1,96 @@
+using System.Text.Json;
+using CodeIndex.Cli;
+
+namespace CodeIndex.Tests;
+
+public sealed class DiffCommandHelpersTests
+{
+    [Fact]
+    public void Parse_RejectsUnsupportedOption_Issue4181()
+    {
+        var options = DiffCommandOptionsParser.Parse(["left.db", "right.db", "--bogus"], maxLimit: 25);
+
+        Assert.Equal("left.db", options.LeftDb);
+        Assert.Equal("right.db", options.RightDb);
+        Assert.Equal("diff does not support option: '--bogus'", options.ParseError);
+    }
+
+    [Fact]
+    public void Parse_LimitAboveBoundResetsToDefault_Issue4181()
+    {
+        var options = DiffCommandOptionsParser.Parse(["left.db", "right.db", "--limit", "26"], maxLimit: 25);
+
+        Assert.Equal(DiffCommandOptionsParser.DefaultLimit, options.Limit);
+        Assert.Equal("--limit must be less than or equal to 25", options.ParseError);
+    }
+
+    [Fact]
+    public void WriteResult_SummaryOnlyOmitsDiffSamples_Issue4181()
+    {
+        var jsonOptions = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+        var diffOptions = new DiffCommandOptions { SummaryOnly = true, Limit = 5 };
+        var result = CreateDiffResult();
+
+        var output = CaptureStdout(() => DiffResultWriter.WriteResult(result, diffOptions, jsonOptions));
+
+        using var document = JsonDocument.Parse(output);
+        var root = document.RootElement;
+        Assert.Equal("different", root.GetProperty("status").GetString());
+        Assert.Equal("left.db", root.GetProperty("left_db").GetString());
+        Assert.Equal("right.db", root.GetProperty("right_db").GetString());
+        Assert.False(root.TryGetProperty("files_only_in_left", out _));
+        Assert.False(root.TryGetProperty("files_only_in_right", out _));
+    }
+
+    [Theory]
+    [InlineData(0, "+0")]
+    [InlineData(3, "+3")]
+    [InlineData(-2, "-2")]
+    public void FormatDelta_UsesDiffTextContract_Issue4181(long delta, string expected)
+        => Assert.Equal(expected, DiffResultWriter.FormatDelta(delta));
+
+    private static DiffJsonResult CreateDiffResult()
+        => new(
+            "different",
+            false,
+            "left.db",
+            "right.db",
+            new DiffSummaryJsonResult(
+                1,
+                2,
+                1,
+                3,
+                3,
+                0,
+                5,
+                4,
+                -1,
+                8,
+                8,
+                true),
+            ["src/Left.cs"],
+            ["src/Right.cs"],
+            null,
+            null,
+            5,
+            false);
+
+    private static string CaptureStdout(Action action)
+    {
+        var originalOut = Console.Out;
+        using var writer = new StringWriter();
+        lock (TestConsoleLock.Gate)
+        {
+            try
+            {
+                Console.SetOut(writer);
+                action();
+                return writer.ToString();
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+            }
+        }
+    }
+}

--- a/tests/CodeIndex.Tests/ExportImportManifestCodecTests.cs
+++ b/tests/CodeIndex.Tests/ExportImportManifestCodecTests.cs
@@ -1,0 +1,98 @@
+using System.Text;
+using System.Text.Json;
+using CodeIndex.Cli;
+using Microsoft.Data.Sqlite;
+
+namespace CodeIndex.Tests;
+
+public sealed class ExportImportManifestCodecTests
+{
+    [Fact]
+    public void TryDeserialize_RejectsNullManifest_Issue4181()
+    {
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+        Assert.False(ExportImportManifestCodec.TryDeserialize("null"u8, options, out _, out var message));
+        Assert.Equal("manifest.json did not contain an object", message);
+    }
+
+    [Fact]
+    public void TryDeserialize_RejectsMalformedManifest_Issue4181()
+    {
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+
+        Assert.False(ExportImportManifestCodec.TryDeserialize("{"u8, options, out _, out var message));
+        Assert.Equal("manifest.json is not valid export manifest JSON", message);
+    }
+
+    [Fact]
+    public void TryDeserialize_RejectsOverDepthManifest_Issue4181()
+    {
+        var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower };
+        var json =
+            "{\"format_version\":\"1\",\"cdidx_version\":\"test\",\"user_version\":0,\"database_sha256\":\"" +
+            new string('0', 64) +
+            "\",\"nested\":" +
+            string.Concat(Enumerable.Repeat("{\"x\":", ExportImportCommandRunner.MaxImportManifestJsonDepth + 1)) +
+            "0" +
+            new string('}', ExportImportCommandRunner.MaxImportManifestJsonDepth + 1) +
+            "}";
+
+        Assert.False(ExportImportManifestCodec.TryDeserialize(Encoding.UTF8.GetBytes(json), options, out _, out var message));
+        Assert.Equal(
+            $"manifest.json exceeds the JSON depth limit of {ExportImportCommandRunner.MaxImportManifestJsonDepth}",
+            message);
+    }
+
+    [Fact]
+    public void TryValidateHeader_RejectsNegativeMetadata_Issue4181()
+    {
+        var manifest = CreateValidManifest(FileCount: -1);
+
+        Assert.False(ExportImportManifestCodec.TryValidateHeader(manifest, out var message));
+        Assert.Equal("file_count must be non-negative", message);
+    }
+
+    [Fact]
+    public void TryValidateHeader_RejectsUnknownExtensionSampleMismatch_Issue4181()
+    {
+        var manifest = CreateValidManifest(
+            UnknownExtensionFiles: ["docs/notes.txt"],
+            UnknownExtensionFileSampleCount: 2,
+            UnknownExtensionFileSampleLimit: 10);
+
+        Assert.False(ExportImportManifestCodec.TryValidateHeader(manifest, out var message));
+        Assert.Equal("unknown_extension_file_sample_count must match unknown_extension_files length", message);
+    }
+
+    [Fact]
+    public void ReadNullableString_ReturnsNullForDbNull_Issue4181()
+    {
+        using var connection = new SqliteConnection("Data Source=:memory:");
+        connection.Open();
+        using var command = connection.CreateCommand();
+        command.CommandText = "SELECT NULL AS optional, 'value' AS required";
+        using var reader = command.ExecuteReader();
+
+        Assert.True(reader.Read());
+        Assert.Null(ExportImportSqliteRow.ReadNullableString(reader, 0));
+        Assert.Equal("value", ExportImportSqliteRow.ReadNullableString(reader, 1));
+    }
+
+    private static ExportImportCommandRunner.ExportManifest CreateValidManifest(
+        long? FileCount = null,
+        string[]? UnknownExtensionFiles = null,
+        int? UnknownExtensionFileSampleCount = null,
+        int? UnknownExtensionFileSampleLimit = null)
+        => new(
+            "1",
+            "test",
+            0,
+            ProjectRoot: null,
+            IndexedHeadSha: null,
+            DatabaseSha256: new string('0', 64),
+            FileCount: FileCount,
+            UnknownExtensionFiles: UnknownExtensionFiles,
+            UnknownExtensionFileSampleCount: UnknownExtensionFileSampleCount,
+            UnknownExtensionFileSampleLimit: UnknownExtensionFileSampleLimit);
+}


### PR DESCRIPTION
## Summary

- Split diff option parsing and result rendering out of `DiffCommandRunner`.
- Split export/import manifest decoding/header validation and nullable SQLite row reads out of `ExportImportCommandRunner`.
- Added focused helper tests for parser errors, diff summary JSON, manifest malformed/over-depth metadata validation, and nullable row reads.

## Validation

- `dotnet build tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-restore -p:RunAnalyzers=false -p:UseSharedCompilation=false -p:BuildInParallel=false -m:1 -nodeReuse:false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-build --no-restore --filter "FullyQualifiedName~DiffCommandHelpersTests|FullyQualifiedName~ExportImportManifestCodecTests" -p:UseSharedCompilation=false -nodeReuse:false`
- `dotnet test tests/CodeIndex.Tests/CodeIndex.Tests.csproj --framework net8.0 --no-build --no-restore -p:UseSharedCompilation=false -nodeReuse:false`
- `dotnet run --project tools/CodeIndex.Changelog/CodeIndex.Changelog.csproj --framework net8.0 --no-build -- check`
- `git diff --check`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll index /Users/widthdom/Projects/mine/cdidx/CodeIndex18th`
- `dotnet ./src/CodeIndex/bin/Debug/net8.0/cdidx.dll status --check --json`
- Codex adversarial review: no actionable regressions found in the staged/untracked changes.

## Documentation / Changelog

- Added `changelog.d/unreleased/4181.internal.md`.
- No user-facing CLI contract changed, so no README/User Guide update was needed.
- `AGENTS.md`, `CLAUDE.md`, and `AGENT_GUIDE.md` were not modified.

## Follow-up Candidates

- Broader export/import orchestration splits can continue in later issues if needed.

Fixes #4181
